### PR TITLE
Add generated content to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /.idea/
 /.precomp/
 /OgdenWebb/plugins/typegraph/typegraphs/*.svg
+/doc_cache/
+/rendered_html/
+/local_raku_docs/
+/Website/structure-cache/
+/Website/reports/


### PR DESCRIPTION
Makes working on a cloned instance used for hosting the site easier. I simply added the folders that appeared without making any modifications.