### PR TITLE
Change URL of the blog aggregator

### DIFF
--- a/Website/structure-sources/index.rakudoc
+++ b/Website/structure-sources/index.rakudoc
@@ -201,7 +201,7 @@
               <div class="column">
                 <p class="head">Explore</p>
                 <ul>
-                  <li><a href="https://pl6anet.org/">Raku Blog Aggregator</a></li>
+                  <li><a href="https://planet.raku.org/">Raku Blog Aggregator</a></li>
                   <li><a href="https://rakudoweekly.blog/">Rakudo Weekly</a></li>
                   <li><a href="https://perlweeklychallenge.org/">The Weekly Challenge</a></li>
                   <li><a href="https://raku-advent.blog/">Raku Advent Calendar</a></li>


### PR DESCRIPTION
It has been renamed to planet.raku.org, even though pl6anet is still hosted.