### PR TITLE
Stub out Buildkite pipeline

### DIFF
--- a/.buildkite/archive.sh
+++ b/.buildkite/archive.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+(
+  cd rendered_html
+  sh -c 'tar zcf ../raku-doc-website.tar.gz *'
+)

--- a/.buildkite/container.sh
+++ b/.buildkite/container.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+c=$(buildah from docker.io/nginx:1.23.3-alpine)
+buildah add $c raku-doc-website.tar.gz /usr/share/nginx/html
+buildah commit --rm $c quay.io/colemanx/raku-doc-website:latest
+buildah push quay.io/colemanx/raku-doc-website:latest
+

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,21 @@
+agents:
+  queue: raku-doc
+steps:
+  - label: "Build site"
+    key: build
+    commands:
+      - "zef install . --deps-only"
+      - "./bin_files/build-site --without-completion"
+      - "./.buildkite/archive.sh"
+      - "buildkite-agent artifact upload ./raku-doc-website.tar.gz"
+      - rm ./raku-doc-website.tar.gz
+
+  - label: "Containerize static assets"
+    key: container
+    if: build.source != 'schedule' && build.branch == 'main'
+    depends_on:
+      - build
+    commands:
+      - buildkite-agent artifact download --step build raku-doc-website.tar.gz .
+      - ./.buildkite/container.sh
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Raku Documentation
+
 >The Collection files for the Raku Documentation site.
 
 


### PR DESCRIPTION
Consider this provisional.

It uses a Buildkite account as well as a Quay.io account that no one
else has access to. However, if merged, the following image will be
publicly-accessible and should be kept up to date on merges to main.

    quay.io/colemanx/raku-doc-website:latest

I'd like to ask around the other community projects and see if there's
anything else to integrate with. In the meantime, this moves the ball
forward.
