### PR TITLE
first attempt to incorporate the CREDITS file and About

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,19 +1,15 @@
-=pod
+Following in the steps of other open source projects that
+eventually take over the world, here is a partial list
+of people who have contributed to this documentation tooling repo.
+It is sorted by name and formatted to allow easy
+grepping and beautification by scripts.
+The fields are: name (N), email (E), web-address (W),
+description (D), GitHub username (U) and snail-mail
+address (S).
 
-    Following in the steps of other open source projects that
-    eventually take over the world, here is the partial list
-    of people who have contributed to this documentation.
-    It is sorted by name and formatted to allow easy
-    grepping and beautification by scripts.
-    The fields are: name (N), email (E), web-address (W),
-    description (D), GitHub username (U) and snail-mail
-    address (S).
+Thanks,
 
-        Thanks,
-
-        The Raku/doc Team
-        PS: Yes, this looks remarkably like the Linux CREDITS format
-        PPS: This file is encoded in UTF-8
+The Raku/doc Team
 
 ----------
 
@@ -21,8 +17,10 @@ U: 2colours
 
 U: Altai-man
 
-U: finanlyst
+N: Richard Hainsworth
+U: finanalyst
 E: rnhainsworth@gmail.com
+D: Raku::Pod::Render & Collection,
 
 N: JJ Merelo
 N: Juan Julián Merelo Guervós
@@ -35,6 +33,7 @@ U: moritz
 D: Initial p6doc development, documentation
 
 U: rawleyfowler
+E: rawleyfowler@proton.me
 
 U: WhistlingZephyr
 
@@ -42,4 +41,3 @@ N: Will Coleda
 U: coke
 E: will@coleda.com
 
-=cut

--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -2,7 +2,7 @@
     :plugins<plugins>,
     :plugin-format<html>,
     plugins-required => %(
-        :setup<raku-doc-setup>,
+        :setup<raku-doc-setup credits-page>,
         :render<
             font-awesome ogdenwebb camelia simple-extras listfiles images deprecate-span filterlines
             tablemanager secondaries typegraph

--- a/Website/plugins/credits-page/README.rakudoc
+++ b/Website/plugins/credits-page/README.rakudoc
@@ -1,0 +1,25 @@
+=begin pod
+=TITLE credits-page is a plugin for Collection
+
+The plugin is for the 'render' and 'setup' milestone
+
+A new document is added to the collection from the text CREDITS file in the main directory
+
+=head1 Custom blocks
+No custom block is needed because it plugin provides a template for the whole Rakudoc block
+
+=head1 Templates
+
+Standard pod templates
+
+=head1 Expect format
+
+Some preliminary text
+C<--------------------------------->
+    then contributors with fields as follows:
+    name (N), email (E), web-address (W),
+    description (D), GitHub username (U),
+    and snail-mail address (S).
+    Each contributor is separated by a single empty line
+
+=end pod

--- a/Website/plugins/credits-page/config.raku
+++ b/Website/plugins/credits-page/config.raku
@@ -8,6 +8,6 @@
 	:name<credits-page>,
 	:render,
 	:setup<setup-callable.raku>,
-	:template-raku<credits-template.raku>,
+	:template-raku(),
 	:version<0.1.0>,
 )

--- a/Website/plugins/credits-page/config.raku
+++ b/Website/plugins/credits-page/config.raku
@@ -1,0 +1,13 @@
+%(
+	:auth<collection>,
+	:authors(
+		"finanalyst",
+	),
+	:custom-raku(), # only a template needed not a block
+	:license<Artistic-2.0>,
+	:name<credits-page>,
+	:render,
+	:setup<setup-callable.raku>,
+	:template-raku<credits-template.raku>,
+	:version<0.1.0>,
+)

--- a/Website/plugins/credits-page/setup-callable.raku
+++ b/Website/plugins/credits-page/setup-callable.raku
@@ -1,0 +1,74 @@
+use v6.d;
+use Pod::Load;
+my regex preface {
+    ^ (.+) \n \-+ $$
+}
+my regex value { .+? }
+my regex name {
+    ^^ 'N:' \s* <value> \v
+}
+my regex email {
+    ^^ 'E:' \s* <value> \v
+}
+my regex desc {
+    ^^ 'D:' \s* <value> \v
+}
+my regex github {
+    ^^ 'U:' \s* <value> \v
+}
+my regex website {
+    ^^ 'W:' \s* <value> \v
+}
+my regex smail {
+    ^^ 'S:' \s* <value> \v
+}
+my regex detail {
+    <name> | <email> | <website> | <desc> | <github> | <smail>
+}
+my regex contributor {
+    <detail>+ \v
+}
+
+sub ($source-cache, $mode-cache, Bool $full-render,  $source-root, $mode-root, %p-options, %options) {
+    my $fn = "{ $*CWD.parent.parent.parent }/CREDITS";
+#    my $fn = "trial/CREDITS";
+    return unless $fn.IO ~~ :e & :f;
+    my $contents = $fn.IO.slurp ~ "\n\n";
+    $contents ~~ / ^ <preface> \s* <contributor>+ \s* $ /;
+    my $preface = $/<preface>[0].Str;
+    my @contributors = [
+        %(  :name<Name>, :github('Github user-name'), :email<Email>,
+            :desc<Description>, :website<Website>, :smail('Snail mail') ),
+    ];
+    for $/<contributor> {
+        my %info;
+        for $_.<detail> {
+            for .kv -> $k, $v {
+                %info{ $k.Str } = $v.<value>.Str;
+            }
+        }
+        @contributors.push: %info;
+    }
+    my %widths = %( gather for @contributors[0].keys -> $k {
+        take $k => max( @contributors.map({ with .{ $k } { .chars } }))
+    } );
+    my $table = "=begin table\n";
+    my $first = 0;
+    my @order = <github name desc email website>;
+    my $format = @order.map({ '%' ~ %widths{$_} ~ 's ' }).join('| ') ~ "\n";
+    my $full-wid = '=' x (( [+] %widths.values) + 3 * %widths.elems) ~ "\n";
+    for @contributors -> %inf {
+        my @row = @order.map({ %inf{$_} // '' });
+        $table ~= sprintf( $format, @row );
+        $table ~= $full-wid unless $first++ ;
+    }
+    $table ~= "\n=end table";
+    $mode-cache.add('Website/structure-sources/credits.rakudoc', load(qq:to/RAKUDOC/));
+    =begin pod :no-toc :no-glossary
+    =TITLE Contributors
+    =SUBTITLE File generated from CREDITS text
+
+    $table
+    =end pod
+    RAKUDOC
+}

--- a/Website/plugins/credits-page/t/05-basic.rakutest
+++ b/Website/plugins/credits-page/t/05-basic.rakutest
@@ -1,0 +1,5 @@
+use v6.d;
+use Test;
+use Test::CollectionPlugin;
+test-plugin();
+done-testing

--- a/Website/structure-sources/about.rakudoc
+++ b/Website/structure-sources/about.rakudoc
@@ -4,21 +4,21 @@
 The B<Raku programming language> is a very flexible, modern programming language.
 
 This website is dedicated to be a good I<viewer> for its documentation.
+
 Many people have contributed to writing the documentation and tooling, and a separate credits page
 can be found L<here|https://raw.githubusercontent.com/Raku/doc/master/CREDITS>.
 
+This particular website is a fraction of effort standing on the shoulders of the giants.
+
 Some of the people who helped create this I< website > are:
-=item L<Ogden Webb | https://github.com/ogdenwebb > - the author of the website design.
+=item L<Ogden Webb | https://github.com/ogdenwebb> - the author of the website design.
 =item L<Aleks-Daniel Jakimenko-Aleksejev | https://github.com/AlexDaniel> - provided invaluable feedback.
 
 =item L<Juan Julián Merelo Guervós | https://github.com/JJ> - led work on Raku documentation and refactored
-resulting in L<Documentable| https://github.com/Raku/Documentable> creation.
+resulting in L<Documentable|https://github.com/Raku/Documentable> creation.
 
-=item L<Richard Nabil Hainsworth, aka finanalyst | https://github.com/finanalyst> - adapted website to Collection toolchain.
+=item L<Richard Nabil Hainsworth, aka finanalyst | http://github.com/finanalyst> - adapted website to Collection toolchain.
 
-Many other people have contributed, and often the smallest contribution can have a significant
-effect. The Raku community is grateful to them all.
-
-L<Every contributor can add their name and some details to the CREDITS file| /credits>.
+The website is continuously being improved by community members, L<who are listed here|/credits>.
 
 =end pod

--- a/Website/structure-sources/about.rakudoc
+++ b/Website/structure-sources/about.rakudoc
@@ -3,11 +3,10 @@
 
 The B<Raku programming language> is a very flexible, modern programming language.
 
-This website is dedicated to be a good I<viewer> for its documentation.
+This website is a newer, more modern I<viewer> for the Raku documentation.
+
 Many people have contributed to writing the documentation and tooling, and a separate credits page is
 can be found L<here|https://raw.githubusercontent.com/Raku/doc/master/CREDITS>.
-
-This particular website is a fraction of effort standing on the shoulders of the giants.
 
 Some of the people who helped create this I< website > are:
 =item L<Ogden Webb | https://github.com/ogdenwebb > - the author of the website design.
@@ -17,4 +16,10 @@ Some of the people who helped create this I< website > are:
 resulting in L<Documentable| https://github.com/Raku/Documentable> creation.
 
 =item L<Richard Nabil Hainsworth, aka finanalyst | https://github.com/finanalyst> - adapted website to Collection toolchain.
+
+Many other people have contributed, and often the smallest contribution can have a significant
+effect. The Raku community is grateful to them all.
+
+L<Every contributor can add their name and some details to the CREDITS file| /credits>.
+
 =end pod


### PR DESCRIPTION
This is mentioned in Discussion #51

A setup plugin takes the contributor information in CREDITS, and creates a virtual file in Cache, which is then rendered as credits.rakudoc. This is referenced in about.rakudoc