### PR TITLE
Workaround for badly loading sidebar

### DIFF
--- a/Website/plugins/ogdenwebb/js/core.js
+++ b/Website/plugins/ogdenwebb/js/core.js
@@ -58,32 +58,18 @@ $(document).ready( function() {
     });
     function move_sidebar( show ) {
         var el = $('#raku-sidebar');
-        var svg = $(el).find('svg')[0];
+        var icon_container = $(el).find('.icon')[0];
         if ( show === 'open' ) {
             $("#mainSidebar").css('width', '');
             $("#mainSidebar").css('display', 'block');
             $(el).css('left', '');
-//            if (svg !== undefined) {
-                svg.setAttribute('data-icon', 'chevron-left');
-//            }
-//            else {
-//                var i_icon = $(el).find('i')[0];
-//                $(i).removeClass('fa-chevron-right');
-//                $(i).addClass('fa-chevron-left');
-//            }
+            $(icon_container).html(FontAwesome.icon({prefix: 'fas', iconName: 'chevron-left'}).html[0]);
         }
         else {
             $("#mainSidebar").css('width', '0');
             $("#mainSidebar").css('display', 'none');
             $(el).css('left', '-5px');
-//            if (svg !== undefined) {
-                svg.setAttribute('data-icon', 'chevron-right');
-//            }
-//            else {
-//                var i_icon = $(el).find('i')[0];
-//                $(i).removeClass('fa-chevron-left');
-//                $(i).addClass('fa-chevron-right');
-//            }
+            $(icon_container).html(FontAwesome.icon({prefix: 'fas', iconName: 'chevron-right'}).html[0]);
         }
     };
 

--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -102,7 +102,7 @@ use v6.d;
         <div id="raku-sidebar" class="raku-sidebar-toggle" style="">
           <a class="button is-primary">
             <span class="icon">
-              <i class="fas fa-chevron-left is-medium"></i>
+            <!-- This is where the chevron arrow will be loaded in the right direction -->
             </span>
           </a>
         </div>


### PR DESCRIPTION
Proposed solution to https://github.com/Raku/doc-website/issues/52 .

Rather than relying on the asyncronous "i to svg" transformation, let's use the Javascript API of FontAwesome to generate the right tags at the right place directly.

For me, it seems to work so far.