### PR TITLE
temporarily disable extended search page for first launch

### DIFF
--- a/Website/configs/01-config.raku
+++ b/Website/configs/01-config.raku
@@ -1,7 +1,7 @@
 %(
     :mode-sources<structure-sources>, # content for the website structure
     :mode-cache<structure-cache>, # cache for the above
-    :mode-ignore(), # files to ignore
+    :mode-ignore('search.rakudoc',), # files to ignore
     :mode-obtain(), # not a remote repository
     :mode-refresh(), # ditto
     :mode-extensions<rakudoc pod6>, # only use these for content

--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -74,10 +74,6 @@ use v6.d;
                 More
               </a>
               <div class="navbar-dropdown">
-                <a class="navbar-item" href="/search.html">
-                  Extended Search
-                </a>
-                <hr class="navbar-divider">
                 <a class="navbar-item" href="/about.html">
                   About
                 </a>


### PR DESCRIPTION
As suggested in discussion in #68.
You will note that a) a change is made in the template for the Navigation bar, and b) the structure-source file that accesses the data is 'ignored' in the configuration data. Reversing the change is similarly a minimal change.