### PR TITLE
Build container if it's a scheduled build

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,7 +12,7 @@ steps:
 
   - label: "Containerize static assets"
     key: container
-    if: build.source != 'schedule' && build.branch == 'main'
+    if: build.branch == 'main'
     depends_on:
       - build
     commands:


### PR DESCRIPTION
The `if` conditional was preventing a container build if the pipeline was triggered by a cron job. Remove that conditional so we publish a new container hourly.