### PR TITLE
Add cro as dep

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -14,7 +14,8 @@
     "Collection:ver<0.14.2+>",
     "Terminal::ANSIColor:ver<0.9+>:auth<zef:lizmat>",
     "Doc::TypeGraph:ver<2.2.1.1+>",
-    "Doc::TypeGraph::Viz:ver<2.2.1.1+>"
+    "Doc::TypeGraph::Viz:ver<2.2.1.1+>",
+    "Cro::HTTP:ver<0.8.9>:auth<zef:cro>"
   ],
   "build-depends": [],
   "test-depends": [],

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ zef install . --deps-only
 ```
 in the cloned directory. There are a couple of C libraries that may need to be installed as well, such as OpenSSL and LibArchive (make sure to install the ``-dev`` versions).
 
-Cro is not in the META6.json file because it can fail in the testing stages in an automatic testing environment. However, Cro and Cro::HTTP is needed for serving the rendered files locally.
+Cro is needed for serving the rendered files locally. You may wish to install it separately. 
 
 Syntax highlighting of Raku code in the documentation still requires a ``node.js`` stack. See the documentation for ``Raku::Pod::Render`` for more information.
 


### PR DESCRIPTION
Part of #15; Remove warning. I haven't seen this failure mode; if needed we can add a note that cro themselves recommend installing without running the tests.