### PR TITLE
Include a scheme in the cro-run status message

### DIFF
--- a/Website/plugins/cro-app/cro-run.raku
+++ b/Website/plugins/cro-app/cro-run.raku
@@ -23,7 +23,7 @@ sub ( $destination, $landing, $ext, %p-config, %options ) {
         Cro::HTTP::Log::File.new(logs => $*OUT, errors => $*ERR)
     ]
     );
-    say "Serving $landing on $host\:$port" unless %options<no-status>;
+    say "Serving $landing on http://$host\:$port" unless %options<no-status>;
     $http.start;
     react {
         whenever signal(SIGINT) {


### PR DESCRIPTION
Since most terminals recognise URLs and offer to open them on click, include an `http` scheme in the initial status message.