### PR TITLE
Remove myself from the about page

### DIFF
--- a/Website/structure-sources/about.rakudoc
+++ b/Website/structure-sources/about.rakudoc
@@ -11,7 +11,6 @@ This particular website is a fraction of effort standing on the shoulders of the
 
 Some of the people who helped create this I< website > are:
 =item L<Ogden Webb | https://github.com/ogdenwebb > - the author of the website design.
-=item L<Aleks-Daniel Jakimenko-Aleksejev | https://github.com/AlexDaniel> - provided invaluable feedback.
 
 =item L<Juan Julián Merelo Guervós | https://github.com/JJ> - led work on Raku documentation and refactored
 resulting in L<Documentable| https://github.com/Raku/Documentable> creation.


### PR DESCRIPTION
It seems that there was some confusion and I was added by mistake. That list seems to be of important contributors to the website itself, which I am not.

Related to #129.