### PR TITLE
add cleanup to reflog

### DIFF
--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -10,7 +10,7 @@
             gather-js-jq gather-css
         >,
         :report<link-plugin-assets-report>,
-        :transfer<secondaries gather-js-jq gather-css images search-bar>,
+        :transfer<secondaries gather-js-jq gather-css images search-bar git-reflog>,
         :compilation<secondaries listfiles search-bar link-error-test>,
         :completion<cro-app>,
     ),

--- a/Website/plugins/git-reflog/cleanup.raku
+++ b/Website/plugins/git-reflog/cleanup.raku
@@ -1,0 +1,6 @@
+#!/usr/bin/env raku
+use v6.d;
+# cleanup the directory
+sub ($pr, %processed, %options ) {
+    'reflog.raku'.IO.unlink
+}

--- a/Website/plugins/git-reflog/config.raku
+++ b/Website/plugins/git-reflog/config.raku
@@ -10,5 +10,6 @@
 	:setup<add-ref-hash.raku>,
 	:template-raku<reflog.raku>,
 	:information<template-raku>,
-	:version<0.1.0>,
+	:version<0.1.3>,
+	:transfer<cleanup.raku>,
 )

--- a/Website/plugins/git-reflog/reflog.raku
+++ b/Website/plugins/git-reflog/reflog.raku
@@ -1,5 +1,0 @@
-%(
-    git-reflog => sub (%prm, %tml) {
-        '<p>Raku source files upto commit ｢328aa7c｣, see <a href="https://github.com/Raku/doc/tree/328aa7c">github.com/Raku/doc/tree/328aa7c</a></p>'
-    },
-);


### PR DESCRIPTION
git-reflog generates a template file that changes each time a source is changed. This removes the old template file.