### PR TITLE
remove extended search and error-report, add website issue reporting

### DIFF
--- a/Website/configs/01-config.raku
+++ b/Website/configs/01-config.raku
@@ -1,7 +1,7 @@
 %(
     :mode-sources<structure-sources>, # content for the website structure
     :mode-cache<structure-cache>, # cache for the above
-    :mode-ignore('search.rakudoc',), # files to ignore
+    :mode-ignore<search.rakudoc error-report.rakudoc>, # files to ignore
     :mode-obtain(), # not a remote repository
     :mode-refresh(), # ditto
     :mode-extensions<rakudoc pod6>, # only use these for content

--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -74,16 +74,13 @@ use v6.d;
                 More
               </a>
               <div class="navbar-dropdown">
-                <a class="navbar-item" href="/search.html">
-                  Extended Search
-                </a>
                 <hr class="navbar-divider">
                 <a class="navbar-item" href="/about.html">
                   About
                 </a>
                 <hr class="navbar-divider">
-                <a class="navbar-item" href="/error-report.html">
-                  Anomalous links
+                <a class="navbar-item has-text-red" href="https://github.com/raku/doc-website/issues">
+                  Report an issue with this site
                 </a>
               </div>
             </div>


### PR DESCRIPTION
Extended-search was in drop-down and would 404, Following @Altai-man , adding a link to this repo under More so that an issue with the site can be reported. Removing error-fixing page from the production site.