### PR TITLE
Add rewrites for .html; switch to caddy

### DIFF
--- a/.buildkite/container.sh
+++ b/.buildkite/container.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-c=$(buildah from docker.io/nginx:1.23.3-alpine)
-buildah add $c raku-doc-website.tar.gz /usr/share/nginx/html
+c=$(buildah from docker.io/caddy:latest)
+buildah add $c raku-doc-website.tar.gz /usr/share/caddy
+buildah add $c Caddyfile /etc/caddy/Caddyfile
 buildah commit --rm $c quay.io/colemanx/raku-doc-website:latest
 buildah push quay.io/colemanx/raku-doc-website:latest
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,21 @@
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+
+
+:80 {
+	# Set this path to your site's directory.
+    @htmlext {
+        path_regexp static (/.*)\.(html?)$
+    }
+
+	root * /usr/share/caddy
+    try_files {path}.html {path} 
+
+
+	# Enable the static file server.
+	file_server
+}
+
+# Refer to the Caddy docs for more information:
+# https://caddyserver.com/docs/caddyfile
+


### PR DESCRIPTION
This might seem like a drastic change, but it's really not a big
deal, since we aren't using advanced configs anyways.

Caddy's configuration language is much saner for our use-case, and
it even opens the door to api-based config.
