### PR TITLE
Support old-style Proc::Async URLs

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -10,6 +10,7 @@
 
 	root * /usr/share/caddy
     try_files {path}.html {path} 
+    uri /type/* replace :: /
 
 
 	# Enable the static file server.


### PR DESCRIPTION
go live only supported /Proc/Async, this restores the old functionality - many links to the docs depend on this style.

Part of #149