### PR TITLE
Override CSS padding in `.raku-code` divs

### DIFF
--- a/Website/plugins/ogdenwebb/css/code/dark.css
+++ b/Website/plugins/ogdenwebb/css/code/dark.css
@@ -46,5 +46,3 @@ textarea::-moz-selection {
 
 textarea::selection {
   background: #212426; }
-
-/*# sourceMappingURL=dark.css.map */

--- a/Website/plugins/ogdenwebb/css/code/dark.css
+++ b/Website/plugins/ogdenwebb/css/code/dark.css
@@ -2,65 +2,49 @@
 /* Dark color theme */
 .cm-s-ayaya.CodeMirror {
   background: #212426;
-  color: #f2f2f2;
-}
+  color: #f2f2f2; }
 
 .CodeMirror-gutters {
   background-color: #212426;
   color: #6C7292;
-  border-right: 0;
-}
+  border-right: 0; }
 
 .CodeMirror-linenumber {
-  color: #f2f2f2;
-}
+  color: #f2f2f2; }
 
 .CodeMirror-selected,
 .CodeMirror-focused .CodeMirror-selected {
-  background: #393e41;
-}
+  background: #393e41; }
 
 .cm-s-ayaya span.cm-atom, .cm-s-ayaya span.function, .cm-s-ayaya span.routine {
-  color: #978DEB;
-}
+  color: #978DEB; }
 .cm-s-ayaya span.cm-comment, .cm-s-ayaya span.comment {
-  color: #6C7292;
-}
+  color: #6C7292; }
 .cm-s-ayaya span.cm-number, .cm-s-ayaya span.numeric {
-  color: #6295E3;
-}
+  color: #6295E3; }
 .cm-s-ayaya span.cm-comment.cm-type {
-  color: #5998a6;
-}
+  color: #5998a6; }
 .cm-s-ayaya span.cm-keyword, .cm-s-ayaya span.keyword, .cm-s-ayaya span.declarator {
-  color: #8DE1EB;
-}
+  color: #8DE1EB; }
 .cm-s-ayaya span.cm-string, .cm-s-ayaya span.string {
-  color: #68F3CA;
-}
+  color: #68F3CA; }
 .cm-s-ayaya span.cm-variable, .cm-s-ayaya span.variable {
-  color: #EED891;
-}
+  color: #EED891; }
 .cm-s-ayaya span.cm-variable-2 {
-  color: #EED891;
-}
+  color: #EED891; }
 .cm-s-ayaya span.cm-variable-3 {
-  color: #EED891;
-}
+  color: #EED891; }
 .cm-s-ayaya span.cm-type, .cm-s-ayaya span.type {
-  color: #E04C86;
-}
+  color: #E04C86; }
 .cm-s-ayaya span.cm-def {
-  color: #8DE1EB;
-}
+  color: #8DE1EB; }
 .cm-s-ayaya span.cm-operator, .cm-s-ayaya span.assignment, .cm-s-ayaya span.operator {
-  color: #E05C4C;
-}
+  color: #E05C4C; }
 
 textarea::-moz-selection {
-  background: #212426;
-}
+  background: #212426; }
 
 textarea::selection {
-  background: #212426;
-}
+  background: #212426; }
+
+/*# sourceMappingURL=dark.css.map */

--- a/Website/plugins/ogdenwebb/css/code/light.css
+++ b/Website/plugins/ogdenwebb/css/code/light.css
@@ -28,5 +28,3 @@
   color: #223B9E; }
 .cm-s-ayaya span.cm-operator, .cm-s-ayaya span.assignment {
   color: #C01823; }
-
-/*# sourceMappingURL=light.css.map */

--- a/Website/plugins/ogdenwebb/css/code/light.css
+++ b/Website/plugins/ogdenwebb/css/code/light.css
@@ -2,42 +2,31 @@
 /* Light color theme */
 .cm-s-ayaya.CodeMirror {
   background: #fafafa;
-  color: #030303;
-}
+  color: #030303; }
 
 .cm-s-ayaya span.cm-atom, .cm-s-ayaya span.function, .cm-s-ayaya span.routine {
-  color: #005C43;
-}
+  color: #005C43; }
 .cm-s-ayaya span.cm-comment, .cm-s-ayaya span.comment {
-  color: #6D4F4B;
-}
+  color: #6D4F4B; }
 .cm-s-ayaya span.cm-number, .cm-s-ayaya span.numeric {
-  color: #1C6301;
-}
+  color: #1C6301; }
 .cm-s-ayaya span.cm-comment.cm-type {
-  color: #5998a6;
-}
+  color: #5998a6; }
 .cm-s-ayaya span.cm-keyword, .cm-s-ayaya span.keyword, .cm-s-ayaya span.declarator {
-  color: #223B9E;
-}
+  color: #223B9E; }
 .cm-s-ayaya span.cm-string, .cm-s-ayaya span.string {
-  color: #004FB3;
-}
+  color: #004FB3; }
 .cm-s-ayaya span.cm-variable, .cm-s-ayaya span.variable {
-  color: #5503B3;
-}
+  color: #5503B3; }
 .cm-s-ayaya span.cm-variable-2 {
-  color: #5503B3;
-}
+  color: #5503B3; }
 .cm-s-ayaya span.cm-variable-3 {
-  color: #5503B3;
-}
+  color: #5503B3; }
 .cm-s-ayaya span.cm-type, .cm-s-ayaya span.type {
-  color: #A3004F;
-}
+  color: #A3004F; }
 .cm-s-ayaya span.cm-def {
-  color: #223B9E;
-}
+  color: #223B9E; }
 .cm-s-ayaya span.cm-operator, .cm-s-ayaya span.assignment {
-  color: #C01823;
-}
+  color: #C01823; }
+
+/*# sourceMappingURL=light.css.map */

--- a/Website/plugins/ogdenwebb/css/main.css
+++ b/Website/plugins/ogdenwebb/css/main.css
@@ -2,189 +2,148 @@
 @import url("https://fonts.googleapis.com/css?family=Lato:400,700");
 /* Camelia Spinner Container */
 #code-run-spinner-container {
-  visibility: hidden;
-}
+  visibility: hidden; }
 
 /* Display as flex and center */
 #code-run-spinner {
   display: flex;
-  justify-content: center;
-}
+  justify-content: center; }
 
 /* Camelia img */
 #camelia-spinner {
   display: inline-block;
   animation: spinner 1.25s infinite;
   border: 5px black;
-  border-radius: 10px black;
-}
+  border-radius: 10px black; }
 
 /* Keyframes for camelia spinner */
 @keyframes spinner {
   0% {
-    transform: rotate(0deg);
-  }
+    transform: rotate(0deg); }
   100% {
-    transform: rotate(359deg);
-  }
-}
+    transform: rotate(359deg); } }
 h1, h2, h3, h4, h5, h6 {
-  font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-}
+  font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif; }
 
 .button, .title {
-  font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-}
+  font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif; }
 
 .card .button {
-  width: 200px;
-}
+  width: 200px; }
 
 .card-home {
-  box-shadow: unset !important;
-}
+  box-shadow: unset !important; }
 
 body {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - 1px);
-}
+  min-height: calc(100vh - 1px); }
 
 #wrapper {
-  flex: 1;
-}
+  flex: 1; }
 
 /* Site header */
 .navbar-brand .navbar-item img {
-  max-height: 100%;
-}
+  max-height: 100%; }
 
 .navbar-logo {
-  position: relative;
-}
+  position: relative; }
 
 .navbar-logo-tm {
   position: absolute;
   z-index: 35;
   top: 0.35rem;
   right: -0.35rem;
-  font-size: 0.75rem;
-}
+  font-size: 0.75rem; }
 
 .footer {
   height: 50px;
-  padding: 0;
-}
+  padding: 0; }
 
 .main-footer {
-  font-size: 0.875rem;
-}
+  font-size: 0.875rem; }
 
 .footer .level {
-  height: 50px;
-}
+  height: 50px; }
 
 .footer-content {
   max-width: 1000px;
-  margin: 0 auto;
-}
+  margin: 0 auto; }
 
 .footer a:hover {
-  text-decoration: underline;
-}
+  text-decoration: underline; }
 
 .icon-large {
-  font-size: 96px;
-}
+  font-size: 96px; }
 
 .dropdown-item.generated {
-  width: 30vw;
-}
-.dropdown-item.generated .file-path {
-  font-weight: 600;
-}
+  width: 30vw; }
+  .dropdown-item.generated .file-path {
+    font-weight: 600; }
 
 .has-background-image {
   background-position: center;
   background-repeat: no-repeat;
-  background-size: cover;
-}
+  background-size: cover; }
 
 .raku.links-block .head {
   font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   font-size: 1rem;
   font-weight: 600;
-  margin-bottom: 0.5rem;
-}
+  margin-bottom: 0.5rem; }
 .raku.links-block a {
   font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   font-size: 1rem;
-  font-weight: 700;
-}
+  font-weight: 700; }
 .raku.links-block li {
-  margin-bottom: 0.5rem;
-}
+  margin-bottom: 0.5rem; }
 .raku.links-block .level-item {
   padding-left: 4rem;
-  padding-right: 4rem;
-}
+  padding-right: 4rem; }
 .raku.links-block .card {
-  background-color: unset;
-}
+  background-color: unset; }
 
 .raku.page-title,
 .raku.page-subtitle {
-  font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-}
+  font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif; }
 
 .page-generated {
-  padding: 0.75rem;
-}
+  padding: 0.75rem; }
 
 .raku.page-title {
   font-size: 1.5rem;
-  font-weight: 600;
-}
+  font-weight: 600; }
 
 .raku.page-subtitle {
-  font-size: 1rem;
-}
+  font-size: 1rem; }
 
 .raku.page-header {
   margin-top: 1rem;
-  position: relative;
-}
+  position: relative; }
 
 .raku.page-header,
 .raku.page-content {
-  padding: 1rem 1.5rem;
-}
+  padding: 1rem 1.5rem; }
 
 .raku.page-header .page-edit {
   position: absolute;
   right: 1rem;
-  top: 0.75rem;
-}
-.raku.page-header .page-edit .page-edit-button {
-  height: 30px;
-}
+  top: 0.75rem; }
+  .raku.page-header .page-edit .page-edit-button {
+    height: 30px; }
 
 .page-footnotes {
-  margin-left: 2rem;
-}
+  margin-left: 2rem; }
 
 .raku-search .search-item {
   margin-top: 1.25rem;
-  margin-bottom: 1.25rem;
-}
+  margin-bottom: 1.25rem; }
 .raku-search .search-item-title {
   font-weight: 500;
-  margin-bottom: 0.25rem;
-}
+  margin-bottom: 0.25rem; }
 .raku-search .search-category-title {
   font-weight: 500;
-  padding-bottom: 0.75rem;
-}
+  padding-bottom: 0.75rem; }
 
 /* Categories */
 /* original
@@ -216,67 +175,55 @@ body {
 /* For Collection */
 .raku .container .columns.listing {
   column-count: 2;
-  display: block;
-}
-.raku .container .columns.listing > p {
-  column-span: all;
-  margin: 0 0 2em;
-  text-align: center;
-}
-.raku .container .columns.listing .listf-container {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 1.25rem;
-  font-size: 1rem;
-  font-weight: 500;
-  line-height: 1.5;
-}
-.raku .container .columns.listing .listf-container div:nth-of-type(4n-2) {
-  background-color: inherit;
-}
-.raku .container .columns.listing .listf-container div:nth-of-type(4n-1) {
-  background-color: inherit;
-}
-.raku .container .columns.listing .listf-container .listf-caption {
-  font-size: 1rem;
-  font-weight: 500;
-  line-height: 1.5;
-  display: flex;
-  justify-content: center;
-}
-.raku .container .columns.listing .listf-container .listf-file {
-  padding-top: 0.25rem;
-  font-size: 1rem;
-  font-weight: 500;
-  line-height: 1.5;
-  border-top: 1px;
-}
-.raku .container .columns.listing .listf-container .listf-desc {
-  font-size: 1rem;
-  font-weight: 500;
-  line-height: 1.5;
-  padding: 0 0.3rem 0 0.3rem;
-  margin-bottom: 0.25rem;
-  align-self: normal;
-}
-.raku .container .columns.listing .listf-container .listf-desc > p {
-  padding: inherit;
-  margin: inherit;
-}
+  display: block; }
+  .raku .container .columns.listing > p {
+    column-span: all;
+    margin: 0 0 2em;
+    text-align: center; }
+  .raku .container .columns.listing .listf-container {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1.25rem;
+    font-size: 1rem;
+    font-weight: 500;
+    line-height: 1.5; }
+    .raku .container .columns.listing .listf-container div:nth-of-type(4n-2) {
+      background-color: inherit; }
+    .raku .container .columns.listing .listf-container div:nth-of-type(4n-1) {
+      background-color: inherit; }
+    .raku .container .columns.listing .listf-container .listf-caption {
+      font-size: 1rem;
+      font-weight: 500;
+      line-height: 1.5;
+      display: flex;
+      justify-content: center; }
+    .raku .container .columns.listing .listf-container .listf-file {
+      padding-top: 0.25rem;
+      font-size: 1rem;
+      font-weight: 500;
+      line-height: 1.5;
+      border-top: 1px; }
+    .raku .container .columns.listing .listf-container .listf-desc {
+      font-size: 1rem;
+      font-weight: 500;
+      line-height: 1.5;
+      padding: 0 0.3rem 0 0.3rem;
+      margin-bottom: 0.25rem;
+      align-self: normal; }
+      .raku .container .columns.listing .listf-container .listf-desc > p {
+        padding: inherit;
+        margin: inherit; }
 
 /* Programs page template */
 .raku-programs .programs-items {
   padding-top: 0.25rem;
-  padding-bottom: 0.75rem;
-}
+  padding-bottom: 0.75rem; }
 .raku-programs .programs-item {
   font-weight: 500;
-  padding: 1rem 1.5rem;
-}
+  padding: 1rem 1.5rem; }
 .raku-programs .programs-item-title {
   font-size: 1.25rem;
-  font-weight: 500;
-}
+  font-weight: 500; }
 
 .raku-h1 {
   font-size: 1.375rem;
@@ -285,8 +232,7 @@ body {
   text-align: center;
   margin-top: 0.75rem;
   margin-bottom: 1rem;
-  scroll-margin-top: 4.625rem;
-}
+  scroll-margin-top: 4.625rem; }
 
 .raku-h2 {
   font-size: 1.375rem;
@@ -294,58 +240,49 @@ body {
   padding: 0.25rem;
   margin-top: 0.75rem;
   margin-bottom: 1rem;
-  scroll-margin-top: 4rem;
-}
+  scroll-margin-top: 4rem; }
 
 .raku-h3 {
   font-size: 1.25rem;
   font-weight: 500;
   margin-top: 0.75rem;
   margin-bottom: 1rem;
-  scroll-margin-top: 4rem;
-}
+  scroll-margin-top: 4rem; }
 
 .raku-h4 {
   font-size: 1rem;
   font-weight: 500;
   margin-bottom: 1rem;
-  scroll-margin-top: 4rem;
-}
+  scroll-margin-top: 4rem; }
 
 .raku-h5 {
   font-size: 0.875rem;
   font-weight: 500;
   margin-bottom: 1rem;
-  scroll-margin-top: 3rem;
-}
+  scroll-margin-top: 3rem; }
 
 .raku-h6 {
   font-size: 0.75rem;
   font-weight: 600;
   margin-bottom: 1rem;
-  scroll-margin-top: 3rem;
-}
+  scroll-margin-top: 3rem; }
 
 .raku-anchor {
   font-size: 0.9em;
-  text-decoration: none;
-}
+  text-decoration: none; }
 
 a.raku-anchor,
 .raku-h1 a.raku-anchor, .raku-h2 a.raku-anchor, .raku-h3 a.raku-anchor, .raku-h4 a.raku-anchor, .raku-h5 a.raku-anchor, .raku-h6 a.raku-anchor {
   text-decoration: none;
-  visibility: hidden;
-}
+  visibility: hidden; }
 
 .raku-h1:hover a.raku-anchor, .raku-h2:hover a.raku-anchor, .raku-h3:hover a.raku-anchor, .raku-h4:hover a.raku-anchor, .raku-h5:hover a.raku-anchor, .raku-h6:hover a.raku-anchor {
-  visibility: visible;
-}
+  visibility: visible; }
 
 /* Version note */
 .raku.version-note {
   margin: 1rem 0;
-  padding: 1.25rem;
-}
+  padding: 1.25rem; }
 
 .version-note-header {
   align-items: center;
@@ -353,110 +290,86 @@ a.raku-anchor,
   justify-content: space-between;
   line-height: 1.25;
   padding-bottom: 0.5em;
-  position: relative;
-}
+  position: relative; }
 
 .version-related-to {
   position: absolute;
-  right: 1rem;
-}
+  right: 1rem; }
 
 .version-note-header {
-  font-weight: 500;
-}
+  font-weight: 500; }
 
 table.centered {
   margin-left: auto;
-  margin-right: auto;
-}
+  margin-right: auto; }
 
 .table {
-  margin: 0.75rem 0;
-}
-.table caption {
-  padding-bottom: 0.5rem;
-}
+  margin: 0.75rem 0; }
+  .table caption {
+    padding-bottom: 0.5rem; }
 
 .raku-about .card {
   margin: 1.25rem 0;
-  border-radius: 3px;
-}
+  border-radius: 3px; }
 
 .raku-about.minor-list li {
-  margin: 0.75rem 0;
-}
+  margin: 0.75rem 0; }
 
 .raku-about-major .user-info,
 .raku-about-minor .user-info {
-  margin-bottom: 0.25rem;
-}
+  margin-bottom: 0.25rem; }
 
 .raku.tabs.is-boxed a {
   border: unset;
   border-radius: unset;
-  padding: 0.5em 1.25em;
-}
+  padding: 0.5em 1.25em; }
 
 .raku.tabcontent {
-  display: none;
-}
+  display: none; }
 
 .content li:not(:only-child) {
-  padding: 0.25rem 0;
-}
+  padding: 0.25rem 0; }
 
 p {
   padding-top: 0.5rem !important;
-  padding-bottom: 0.5rem !important;
-}
+  padding-bottom: 0.5rem !important; }
 
 figure svg {
   max-width: 100%;
-  height: auto;
-}
+  height: auto; }
 
 h1.error-title {
-  font-size: 168px;
-}
+  font-size: 168px; }
 
 .error-content .subtitle {
-  max-width: 600px;
-}
+  max-width: 600px; }
 
 .error-icon {
   font-size: 240px;
   position: absolute;
-  right: 5%;
-}
+  right: 5%; }
 
 .error-icon img {
   margin-top: 25px;
-  width: 400px;
-}
+  width: 400px; }
 
 .error-content .level {
-  width: 400px;
-}
+  width: 400px; }
 .error-content .level-item {
-  justify-content: start;
-}
+  justify-content: start; }
 
 .ui-helper-hidden-accessible {
   position: absolute;
-  left: -999em;
-}
+  left: -999em; }
 
 .enter-prompt {
   padding-left: 10px;
-  color: grey;
-}
+  color: grey; }
 
 @media only screen and (min-width: 1210px) {
   .navbar-search-autocomplete {
     top: 35px;
-    left: 10px;
-  }
-}
+    left: 10px; } }
 .raku-sidebar {
   max-width: calc(100% - 50px);
   position: fixed;
@@ -469,132 +382,105 @@ h1.error-title {
   height: 100%;
   width: 300px;
   padding: 1.25rem;
-  padding-top: 5rem;
-}
-.raku-sidebar.is-marginless {
-  max-width: 100%;
-}
-.raku-sidebar + mobile {
-  width: 100%;
-  right: -100%;
-}
-.raku-sidebar + tablet {
-  width: 50%;
-  right: -50%;
-}
-.raku-sidebar + desktop {
-  width: 35%;
-  right: -35%;
-}
-.raku-sidebar + widescreen {
-  width: 30%;
-  right: -30%;
-}
-.raku-sidebar + fullhd {
-  width: 25%;
-  right: -25%;
-}
-.raku-sidebar.is-left + mobile {
-  left: -100%;
-}
-.raku-sidebar.is-left + tablet {
-  left: -50%;
-}
-.raku-sidebar.is-left + desktop {
-  left: -35%;
-}
-.raku-sidebar.is-left + widescreen {
-  left: -30%;
-}
-.raku-sidebar.is-left + fullhd {
-  left: -25%;
-}
-.raku-sidebar.is-left.is-active {
-  right: 0;
-  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.25);
-}
-.raku-sidebar.is-left.is-active.is-left {
-  left: 0;
-}
+  padding-top: 5rem; }
+  .raku-sidebar.is-marginless {
+    max-width: 100%; }
+  .raku-sidebar + mobile {
+    width: 100%;
+    right: -100%; }
+  .raku-sidebar + tablet {
+    width: 50%;
+    right: -50%; }
+  .raku-sidebar + desktop {
+    width: 35%;
+    right: -35%; }
+  .raku-sidebar + widescreen {
+    width: 30%;
+    right: -30%; }
+  .raku-sidebar + fullhd {
+    width: 25%;
+    right: -25%; }
+  .raku-sidebar.is-left + mobile {
+    left: -100%; }
+  .raku-sidebar.is-left + tablet {
+    left: -50%; }
+  .raku-sidebar.is-left + desktop {
+    left: -35%; }
+  .raku-sidebar.is-left + widescreen {
+    left: -30%; }
+  .raku-sidebar.is-left + fullhd {
+    left: -25%; }
+  .raku-sidebar.is-left.is-active {
+    right: 0;
+    box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.25); }
+    .raku-sidebar.is-left.is-active.is-left {
+      left: 0; }
 
 .raku-sidebar .menu-list {
   font-size: 0.875rem;
   list-style: disc outside;
-  padding-left: 10px;
-}
-.raku-sidebar .menu-list code {
-  background-color: unset;
-}
+  padding-left: 10px; }
+  .raku-sidebar .menu-list code {
+    background-color: unset; }
 
 .raku-sidebar .menu-list ::marker {
-  font-size: 0.75em;
-}
+  font-size: 0.75em; }
 
 .raku-sidebar .menu-label,
 .raku-sidebar .menu-label:not(:last-child) {
-  margin-bottom: 0.75em;
-}
+  margin-bottom: 0.75em; }
 
 .raku-sidebar-body .menu-label {
-  font-weight: 600;
-}
+  font-weight: 600; }
 
 .raku-sidebar-toggle {
   z-index: 20;
   position: fixed;
   top: 125px;
   left: 295px;
-  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.25);
-}
+  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.25); }
 
 .raku-sidebar.category-sidebar {
   padding: 0.5rem;
-  padding-top: 5rem;
-}
-.raku-sidebar.category-sidebar .menu-list {
-  list-style: none;
-  padding-left: 0px;
-}
-.raku-sidebar.category-sidebar .menu-list a {
-  margin: 0.25rem 0;
-  padding: 1em 0.75em;
-  border-radius: 3px;
-}
-.raku-sidebar.category-sidebar .menu-list li a.is-active {
-  font-weight: 700;
-}
+  padding-top: 5rem; }
+  .raku-sidebar.category-sidebar .menu-list {
+    list-style: none;
+    padding-left: 0px; }
+    .raku-sidebar.category-sidebar .menu-list a {
+      margin: 0.25rem 0;
+      padding: 1em 0.75em;
+      border-radius: 3px; }
+    .raku-sidebar.category-sidebar .menu-list li a.is-active {
+      font-weight: 700; }
 
 .raku-sidebar.category-sidebar .menu-list ::marker {
-  font-size: 0;
-}
+  font-size: 0; }
 
 .raku-code {
   position: relative;
-  margin: 1rem 0;
-}
-.raku-code .code-name {
-  padding-top: 0.75rem;
-  padding-left: 1.25rem;
-  font-weight: 500;
-}
-.raku-code .code-button {
-  height: 2em;
-}
-.raku-code .code-output {
-  font-size: 0.75rem;
-  font-family: monospace;
-  padding: 0.75rem 1.25rem;
-}
-.raku-code .code-output-title {
-  font-size: 1rem;
-  font-weight: 500;
-  padding: 0.25rem 0;
-  margin-bottom: 0.5rem;
-}
+  margin: 1rem 0; }
+  .raku-code .code-name {
+    padding-top: 0.75rem;
+    padding-left: 1.25rem;
+    font-weight: 500; }
+  .raku-code .code-button {
+    height: 2em; }
+  .raku-code .code-output {
+    font-size: 0.75rem;
+    font-family: monospace;
+    padding: 0.75rem 1.25rem; }
+  .raku-code .code-output-title {
+    font-size: 1rem;
+    font-weight: 500;
+    padding: 0.25rem 0;
+    margin-bottom: 0.5rem; }
+  .raku-code .section {
+    /* https://github.com/Raku/doc-website/issues/144 */
+    padding: 0rem; }
 
 /* Bulma Utilities */
-.file-cta,
-.file-name, .select select, .textarea, .input, .button {
+.button, .input, .textarea, .select select, .file-cta,
+.file-name {
   -moz-appearance: none;
   -webkit-appearance: none;
   align-items: center;
@@ -611,30 +497,26 @@ h1.error-title {
   padding-right: calc(0.75em - 1px);
   padding-top: calc(0.5em - 1px);
   position: relative;
-  vertical-align: top;
-}
-.file-cta:focus,
-.file-name:focus, .select select:focus, .textarea:focus, .input:focus, .button:focus, .is-focused.file-cta,
-.is-focused.file-name, .select select.is-focused, .is-focused.textarea, .is-focused.input, .is-focused.button, .file-cta:active,
-.file-name:active, .select select:active, .textarea:active, .input:active, .button:active, .is-active.file-cta,
-.is-active.file-name, .select select.is-active, .is-active.textarea, .is-active.input, .is-active.button {
-  outline: none;
-}
-[disabled].file-cta,
-[disabled].file-name, .select select[disabled], [disabled].textarea, [disabled].input, [disabled].button, fieldset[disabled] .file-cta,
-fieldset[disabled] .file-name, fieldset[disabled] .select select, .select fieldset[disabled] select, fieldset[disabled] .textarea, fieldset[disabled] .input, fieldset[disabled] .button {
-  cursor: not-allowed;
-}
+  vertical-align: top; }
+  .button:focus, .input:focus, .textarea:focus, .select select:focus, .file-cta:focus,
+  .file-name:focus, .is-focused.button, .is-focused.input, .is-focused.textarea, .select select.is-focused, .is-focused.file-cta,
+  .is-focused.file-name, .button:active, .input:active, .textarea:active, .select select:active, .file-cta:active,
+  .file-name:active, .is-active.button, .is-active.input, .is-active.textarea, .select select.is-active, .is-active.file-cta,
+  .is-active.file-name {
+    outline: none; }
+  [disabled].button, [disabled].input, [disabled].textarea, .select select[disabled], [disabled].file-cta,
+  [disabled].file-name, fieldset[disabled] .button, fieldset[disabled] .input, fieldset[disabled] .textarea, fieldset[disabled] .select select, .select fieldset[disabled] select, fieldset[disabled] .file-cta,
+  fieldset[disabled] .file-name {
+    cursor: not-allowed; }
 
-.file, .button {
+.button, .file {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;
-}
+  user-select: none; }
 
-.select:not(.is-multiple):not(.is-loading)::after, .navbar-link:not(.is-arrowless)::after {
+.navbar-link:not(.is-arrowless)::after, .select:not(.is-multiple):not(.is-loading)::after {
   border: 3px solid transparent;
   border-radius: 2px;
   border-right: 0;
@@ -648,13 +530,11 @@ fieldset[disabled] .file-name, fieldset[disabled] .select select, .select fields
   top: 50%;
   transform: rotate(-45deg);
   transform-origin: center;
-  width: 0.625em;
-}
+  width: 0.625em; }
 
-.title:not(:last-child),
-.subtitle:not(:last-child), .table-container:not(:last-child), .table:not(:last-child), .block:not(:last-child), .content:not(:last-child), .box:not(:last-child), .message:not(:last-child), .level:not(:last-child) {
-  margin-bottom: 1.5rem;
-}
+.level:not(:last-child), .message:not(:last-child), .box:not(:last-child), .content:not(:last-child), .block:not(:last-child), .table:not(:last-child), .table-container:not(:last-child), .title:not(:last-child),
+.subtitle:not(:last-child) {
+  margin-bottom: 1.5rem; }
 
 .delete {
   -webkit-touch-callout: none;
@@ -681,58 +561,49 @@ fieldset[disabled] .file-name, fieldset[disabled] .select select, .select fields
   outline: none;
   position: relative;
   vertical-align: top;
-  width: 20px;
-}
-.delete::before, .delete::after {
-  background-color: #fafafa;
-  content: "";
-  display: block;
-  left: 50%;
-  position: absolute;
-  top: 50%;
-  transform: translateX(-50%) translateY(-50%) rotate(45deg);
-  transform-origin: center center;
-}
-.delete::before {
-  height: 2px;
-  width: 50%;
-}
-.delete::after {
-  height: 50%;
-  width: 2px;
-}
-.delete:hover, .delete:focus {
-  background-color: rgba(3, 3, 3, 0.3);
-}
-.delete:active {
-  background-color: rgba(3, 3, 3, 0.4);
-}
-.is-small.delete {
-  height: 16px;
-  max-height: 16px;
-  max-width: 16px;
-  min-height: 16px;
-  min-width: 16px;
-  width: 16px;
-}
-.is-medium.delete {
-  height: 24px;
-  max-height: 24px;
-  max-width: 24px;
-  min-height: 24px;
-  min-width: 24px;
-  width: 24px;
-}
-.is-large.delete {
-  height: 32px;
-  max-height: 32px;
-  max-width: 32px;
-  min-height: 32px;
-  min-width: 32px;
-  width: 32px;
-}
+  width: 20px; }
+  .delete::before, .delete::after {
+    background-color: #fafafa;
+    content: "";
+    display: block;
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%) rotate(45deg);
+    transform-origin: center center; }
+  .delete::before {
+    height: 2px;
+    width: 50%; }
+  .delete::after {
+    height: 50%;
+    width: 2px; }
+  .delete:hover, .delete:focus {
+    background-color: rgba(3, 3, 3, 0.3); }
+  .delete:active {
+    background-color: rgba(3, 3, 3, 0.4); }
+  .is-small.delete {
+    height: 16px;
+    max-height: 16px;
+    max-width: 16px;
+    min-height: 16px;
+    min-width: 16px;
+    width: 16px; }
+  .is-medium.delete {
+    height: 24px;
+    max-height: 24px;
+    max-width: 24px;
+    min-height: 24px;
+    min-width: 24px;
+    width: 24px; }
+  .is-large.delete {
+    height: 32px;
+    max-height: 32px;
+    max-width: 32px;
+    min-height: 32px;
+    min-width: 32px;
+    width: 32px; }
 
-.control.is-loading::after, .select.is-loading::after, .loader, .button.is-loading::after {
+.button.is-loading::after, .loader, .select.is-loading::after, .control.is-loading::after {
   animation: spinAround 500ms infinite linear;
   border: 2px solid #e5e5e5;
   border-radius: 9999px;
@@ -742,10 +613,9 @@ fieldset[disabled] .file-name, fieldset[disabled] .select select, .select fields
   display: block;
   height: 1em;
   position: relative;
-  width: 1em;
-}
+  width: 1em; }
 
-.hero-video, .image.is-square img,
+.image.is-square img,
 .image.is-square .has-ratio, .image.is-1by1 img,
 .image.is-1by1 .has-ratio, .image.is-5by4 img,
 .image.is-5by4 .has-ratio, .image.is-4by3 img,
@@ -761,13 +631,12 @@ fieldset[disabled] .file-name, fieldset[disabled] .select select, .select fields
 .image.is-3by5 .has-ratio, .image.is-9by16 img,
 .image.is-9by16 .has-ratio, .image.is-1by2 img,
 .image.is-1by2 .has-ratio, .image.is-1by3 img,
-.image.is-1by3 .has-ratio {
+.image.is-1by3 .has-ratio, .hero-video {
   bottom: 0;
   left: 0;
   position: absolute;
   right: 0;
-  top: 0;
-}
+  top: 0; }
 
 .navbar-burger {
   -moz-appearance: none;
@@ -779,10 +648,10 @@ fieldset[disabled] .file-name, fieldset[disabled] .select select, .select fields
   font-family: inherit;
   font-size: 1em;
   margin: 0;
-  padding: 0;
-}
+  padding: 0; }
 
-/* Bulma Base */ /*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */
+/* Bulma Base */
+/*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */
 html,
 body,
 p,
@@ -807,8 +676,7 @@ h4,
 h5,
 h6 {
   margin: 0;
-  padding: 0;
-}
+  padding: 0; }
 
 h1,
 h2,
@@ -817,51 +685,41 @@ h4,
 h5,
 h6 {
   font-size: 100%;
-  font-weight: normal;
-}
+  font-weight: normal; }
 
 ul {
-  list-style: none;
-}
+  list-style: none; }
 
 button,
 input,
 select,
 textarea {
-  margin: 0;
-}
+  margin: 0; }
 
 html {
-  box-sizing: border-box;
-}
+  box-sizing: border-box; }
 
 *, *::before, *::after {
-  box-sizing: inherit;
-}
+  box-sizing: inherit; }
 
 img,
 video {
   height: auto;
-  max-width: 100%;
-}
+  max-width: 100%; }
 
 iframe {
-  border: 0;
-}
+  border: 0; }
 
 table {
   border-collapse: collapse;
-  border-spacing: 0;
-}
+  border-spacing: 0; }
 
 td,
 th {
-  padding: 0;
-}
-td:not([align]),
-th:not([align]) {
-  text-align: inherit;
-}
+  padding: 0; }
+  td:not([align]),
+  th:not([align]) {
+    text-align: inherit; }
 
 html {
   background-color: #fafafa;
@@ -872,8 +730,7 @@ html {
   overflow-x: hidden;
   overflow-y: scroll;
   text-rendering: optimizeLegibility;
-  text-size-adjust: 100%;
-}
+  text-size-adjust: 100%; }
 
 article,
 aside,
@@ -882,8 +739,7 @@ footer,
 header,
 hgroup,
 section {
-  display: block;
-}
+  display: block; }
 
 body,
 button,
@@ -891,78 +747,64 @@ input,
 optgroup,
 select,
 textarea {
-  font-family: "Inter", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-}
+  font-family: "Inter", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif; }
 
 code,
 pre {
   -moz-osx-font-smoothing: auto;
   -webkit-font-smoothing: auto;
-  font-family: monospace;
-}
+  font-family: monospace; }
 
 body {
   color: #83858D;
   font-size: 1em;
   font-weight: 400;
-  line-height: 1.5;
-}
+  line-height: 1.5; }
 
 a {
   color: #004FB3;
   cursor: pointer;
-  text-decoration: none;
-}
-a strong {
-  color: currentColor;
-}
-a:hover {
-  color: #3A3D4E;
-}
+  text-decoration: none; }
+  a strong {
+    color: currentColor; }
+  a:hover {
+    color: #3A3D4E; }
 
 code {
   background-color: #f5f5f5;
   color: #57001a;
   font-size: 0.875em;
   font-weight: normal;
-  padding: 0.25em 0.25em 0.25em 0.25em;
-}
+  padding: 0.25em 0.25em 0.25em 0.25em; }
 
 hr {
   background-color: #f5f5f5;
   border: none;
   display: block;
   height: 2px;
-  margin: 1.5rem 0;
-}
+  margin: 1.5rem 0; }
 
 img {
   height: auto;
-  max-width: 100%;
-}
+  max-width: 100%; }
 
-input[type=checkbox],
-input[type=radio] {
-  vertical-align: baseline;
-}
+input[type="checkbox"],
+input[type="radio"] {
+  vertical-align: baseline; }
 
 small {
-  font-size: 0.875em;
-}
+  font-size: 0.875em; }
 
 span {
   font-style: inherit;
-  font-weight: inherit;
-}
+  font-weight: inherit; }
 
 strong {
   color: #3A3D4E;
-  font-weight: 700;
-}
+  font-weight: 700; }
 
 fieldset {
-  border: none;
-}
+  border: none; }
 
 pre {
   -webkit-overflow-scrolling: touch;
@@ -972,59 +814,47 @@ pre {
   overflow-x: auto;
   padding: 1.25rem 1.5rem;
   white-space: pre;
-  word-wrap: normal;
-}
-pre code {
-  background-color: transparent;
-  color: currentColor;
-  font-size: 1em;
-  padding: 0;
-}
+  word-wrap: normal; }
+  pre code {
+    background-color: transparent;
+    color: currentColor;
+    font-size: 1em;
+    padding: 0; }
 
 table td,
 table th {
-  vertical-align: top;
-}
-table td:not([align]),
-table th:not([align]) {
-  text-align: inherit;
-}
+  vertical-align: top; }
+  table td:not([align]),
+  table th:not([align]) {
+    text-align: inherit; }
 table th {
-  color: #3A3D4E;
-}
+  color: #3A3D4E; }
 
 @keyframes spinAround {
   from {
-    transform: rotate(0deg);
-  }
+    transform: rotate(0deg); }
   to {
-    transform: rotate(359deg);
-  }
-}
+    transform: rotate(359deg); } }
 .card {
   background-color: #fafafa;
   border-radius: 0.25rem;
   box-shadow: 0 0.5em 1em -0.125em rgba(3, 3, 3, 0.1), 0 0px 0 1px rgba(3, 3, 3, 0.02);
   color: #83858D;
   max-width: 100%;
-  position: relative;
-}
+  position: relative; }
 
-.card-footer:first-child, .card-content:first-child, .card-header:first-child {
+.card-header:first-child, .card-content:first-child, .card-footer:first-child {
   border-top-left-radius: 0.25rem;
-  border-top-right-radius: 0.25rem;
-}
-.card-footer:last-child, .card-content:last-child, .card-header:last-child {
+  border-top-right-radius: 0.25rem; }
+.card-header:last-child, .card-content:last-child, .card-footer:last-child {
   border-bottom-left-radius: 0.25rem;
-  border-bottom-right-radius: 0.25rem;
-}
+  border-bottom-right-radius: 0.25rem; }
 
 .card-header {
   background-color: transparent;
   align-items: stretch;
   box-shadow: 0 0.125em 0.25em rgba(3, 3, 3, 0.1);
-  display: flex;
-}
+  display: flex; }
 
 .card-header-title {
   align-items: center;
@@ -1032,11 +862,9 @@ table th {
   display: flex;
   flex-grow: 1;
   font-weight: 700;
-  padding: 0.75rem 1rem;
-}
-.card-header-title.is-centered {
-  justify-content: center;
-}
+  padding: 0.75rem 1rem; }
+  .card-header-title.is-centered {
+    justify-content: center; }
 
 .card-header-icon {
   -moz-appearance: none;
@@ -1053,33 +881,27 @@ table th {
   cursor: pointer;
   display: flex;
   justify-content: center;
-  padding: 0.75rem 1rem;
-}
+  padding: 0.75rem 1rem; }
 
 .card-image {
   display: block;
-  position: relative;
-}
-.card-image:first-child img {
-  border-top-left-radius: 0.25rem;
-  border-top-right-radius: 0.25rem;
-}
-.card-image:last-child img {
-  border-bottom-left-radius: 0.25rem;
-  border-bottom-right-radius: 0.25rem;
-}
+  position: relative; }
+  .card-image:first-child img {
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem; }
+  .card-image:last-child img {
+    border-bottom-left-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem; }
 
 .card-content {
   background-color: transparent;
-  padding: 1.5rem;
-}
+  padding: 1.5rem; }
 
 .card-footer {
   background-color: transparent;
   border-top: 1px solid #f2f2f2;
   align-items: stretch;
-  display: flex;
-}
+  display: flex; }
 
 .card-footer-item {
   align-items: center;
@@ -1088,52 +910,38 @@ table th {
   flex-grow: 1;
   flex-shrink: 0;
   justify-content: center;
-  padding: 0.75rem;
-}
-.card-footer-item:not(:last-child) {
-  border-right: 1px solid #f2f2f2;
-}
+  padding: 0.75rem; }
+  .card-footer-item:not(:last-child) {
+    border-right: 1px solid #f2f2f2; }
 
 .card .media:not(:last-child) {
-  margin-bottom: 1.5rem;
-}
+  margin-bottom: 1.5rem; }
 
 .level {
   align-items: center;
-  justify-content: space-between;
-}
-.level code {
-  border-radius: 4px;
-}
-.level img {
-  display: inline-block;
-  vertical-align: top;
-}
-.level.is-mobile {
-  display: flex;
-}
-.level.is-mobile .level-left,
-.level.is-mobile .level-right {
-  display: flex;
-}
-.level.is-mobile .level-left + .level-right {
-  margin-top: 0;
-}
-.level.is-mobile .level-item:not(:last-child) {
-  margin-bottom: 0;
-  margin-right: 0.75rem;
-}
-.level.is-mobile .level-item:not(.is-narrow) {
-  flex-grow: 1;
-}
-@media screen and (min-width: 769px), print {
-  .level {
-    display: flex;
-  }
-  .level > .level-item:not(.is-narrow) {
-    flex-grow: 1;
-  }
-}
+  justify-content: space-between; }
+  .level code {
+    border-radius: 4px; }
+  .level img {
+    display: inline-block;
+    vertical-align: top; }
+  .level.is-mobile {
+    display: flex; }
+    .level.is-mobile .level-left,
+    .level.is-mobile .level-right {
+      display: flex; }
+    .level.is-mobile .level-left + .level-right {
+      margin-top: 0; }
+    .level.is-mobile .level-item:not(:last-child) {
+      margin-bottom: 0;
+      margin-right: 0.75rem; }
+    .level.is-mobile .level-item:not(.is-narrow) {
+      flex-grow: 1; }
+  @media screen and (min-width: 769px), print {
+    .level {
+      display: flex; }
+      .level > .level-item:not(.is-narrow) {
+        flex-grow: 1; } }
 
 .level-item {
   align-items: center;
@@ -1141,236 +949,172 @@ table th {
   flex-basis: auto;
   flex-grow: 0;
   flex-shrink: 0;
-  justify-content: center;
-}
-.level-item .title,
-.level-item .subtitle {
-  margin-bottom: 0;
-}
-@media screen and (max-width: 768px) {
-  .level-item:not(:last-child) {
-    margin-bottom: 0.75rem;
-  }
-}
+  justify-content: center; }
+  .level-item .title,
+  .level-item .subtitle {
+    margin-bottom: 0; }
+  @media screen and (max-width: 768px) {
+    .level-item:not(:last-child) {
+      margin-bottom: 0.75rem; } }
 
 .level-left,
 .level-right {
   flex-basis: auto;
   flex-grow: 0;
-  flex-shrink: 0;
-}
-.level-left .level-item.is-flexible,
-.level-right .level-item.is-flexible {
-  flex-grow: 1;
-}
-@media screen and (min-width: 769px), print {
-  .level-left .level-item:not(:last-child),
-.level-right .level-item:not(:last-child) {
-    margin-right: 0.75rem;
-  }
-}
+  flex-shrink: 0; }
+  .level-left .level-item.is-flexible,
+  .level-right .level-item.is-flexible {
+    flex-grow: 1; }
+  @media screen and (min-width: 769px), print {
+    .level-left .level-item:not(:last-child),
+    .level-right .level-item:not(:last-child) {
+      margin-right: 0.75rem; } }
 
 .level-left {
   align-items: center;
-  justify-content: flex-start;
-}
-@media screen and (max-width: 768px) {
-  .level-left + .level-right {
-    margin-top: 1.5rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .level-left {
-    display: flex;
-  }
-}
+  justify-content: flex-start; }
+  @media screen and (max-width: 768px) {
+    .level-left + .level-right {
+      margin-top: 1.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .level-left {
+      display: flex; } }
 
 .level-right {
   align-items: center;
-  justify-content: flex-end;
-}
-@media screen and (min-width: 769px), print {
-  .level-right {
-    display: flex;
-  }
-}
+  justify-content: flex-end; }
+  @media screen and (min-width: 769px), print {
+    .level-right {
+      display: flex; } }
 
 .menu {
-  font-size: 1rem;
-}
-.menu.is-small {
-  font-size: 0.75rem;
-}
-.menu.is-medium {
-  font-size: 1.25rem;
-}
-.menu.is-large {
-  font-size: 1.5rem;
-}
+  font-size: 1rem; }
+  .menu.is-small {
+    font-size: 0.75rem; }
+  .menu.is-medium {
+    font-size: 1.25rem; }
+  .menu.is-large {
+    font-size: 1.5rem; }
 
 .menu-list {
-  line-height: 1.05;
-}
-.menu-list a {
-  border-radius: 0px;
-  color: #83858D;
-  display: block;
-  padding: 0.5em 0.5em;
-}
-.menu-list a:hover {
-  background-color: #f5f5f5;
-  color: #3A3D4E;
-}
-.menu-list a.is-active {
-  background-color: #004FB3;
-  color: #fff;
-}
-.menu-list li ul {
-  border-left: 1px solid #e5e5e5;
-  margin: 0.5em;
-  padding-left: 0.5em;
-}
+  line-height: 1.05; }
+  .menu-list a {
+    border-radius: 0px;
+    color: #83858D;
+    display: block;
+    padding: 0.5em 0.5em; }
+    .menu-list a:hover {
+      background-color: #f5f5f5;
+      color: #3A3D4E; }
+    .menu-list a.is-active {
+      background-color: #004FB3;
+      color: #fff; }
+  .menu-list li ul {
+    border-left: 1px solid #e5e5e5;
+    margin: 0.5em;
+    padding-left: 0.5em; }
 
 .menu-label {
   color: #cccccc;
   font-size: 0.75rem;
   letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-.menu-label:not(:first-child) {
-  margin-top: 1em;
-}
-.menu-label:not(:last-child) {
-  margin-bottom: 1em;
-}
+  text-transform: uppercase; }
+  .menu-label:not(:first-child) {
+    margin-top: 1em; }
+  .menu-label:not(:last-child) {
+    margin-bottom: 1em; }
 
 .message {
   background-color: #f5f5f5;
   border-radius: 4px;
-  font-size: 1rem;
-}
-.message strong {
-  color: currentColor;
-}
-.message a:not(.button):not(.tag):not(.dropdown-item) {
-  color: currentColor;
-  text-decoration: underline;
-}
-.message.is-small {
-  font-size: 0.75rem;
-}
-.message.is-medium {
-  font-size: 1.25rem;
-}
-.message.is-large {
-  font-size: 1.5rem;
-}
-.message.is-white {
-  background-color: #fafafa;
-}
-.message.is-white .message-header {
-  background-color: #fafafa;
-  color: #030303;
-}
-.message.is-white .message-body {
-  border-color: #fafafa;
-}
-.message.is-black {
-  background-color: #fafafa;
-}
-.message.is-black .message-header {
-  background-color: #030303;
-  color: #fafafa;
-}
-.message.is-black .message-body {
-  border-color: #030303;
-}
-.message.is-light {
-  background-color: #fafafa;
-}
-.message.is-light .message-header {
-  background-color: #f5f5f5;
-  color: rgba(0, 0, 0, 0.7);
-}
-.message.is-light .message-body {
-  border-color: #f5f5f5;
-}
-.message.is-dark {
-  background-color: #f9f9fb;
-}
-.message.is-dark .message-header {
-  background-color: #3A3D4E;
-  color: #fff;
-}
-.message.is-dark .message-body {
-  border-color: #3A3D4E;
-}
-.message.is-primary {
-  background-color: #ebfff9;
-}
-.message.is-primary .message-header {
-  background-color: #005C43;
-  color: #fff;
-}
-.message.is-primary .message-body {
-  border-color: #005C43;
-  color: #05ffbb;
-}
-.message.is-link {
-  background-color: #ebf4ff;
-}
-.message.is-link .message-header {
-  background-color: #004FB3;
-  color: #fff;
-}
-.message.is-link .message-body {
-  border-color: #004FB3;
-  color: #0573ff;
-}
-.message.is-info {
-  background-color: #eef6fc;
-}
-.message.is-info .message-header {
-  background-color: hsl(204deg, 71%, 53%);
-  color: #fff;
-}
-.message.is-info .message-body {
-  border-color: hsl(204deg, 71%, 53%);
-  color: #1d72aa;
-}
-.message.is-success {
-  background-color: #f0ffeb;
-}
-.message.is-success .message-header {
-  background-color: #1C6301;
-  color: #fff;
-}
-.message.is-success .message-body {
-  border-color: #1C6301;
-  color: #47fc03;
-}
-.message.is-warning {
-  background-color: #fcf9ed;
-}
-.message.is-warning .message-header {
-  background-color: #EED891;
-  color: rgba(0, 0, 0, 0.7);
-}
-.message.is-warning .message-body {
-  border-color: #EED891;
-  color: #806614;
-}
-.message.is-danger {
-  background-color: #ffebf1;
-}
-.message.is-danger .message-header {
-  background-color: #A30031;
-  color: #fff;
-}
-.message.is-danger .message-body {
-  border-color: #A30031;
-  color: #ff0a54;
-}
+  font-size: 1rem; }
+  .message strong {
+    color: currentColor; }
+  .message a:not(.button):not(.tag):not(.dropdown-item) {
+    color: currentColor;
+    text-decoration: underline; }
+  .message.is-small {
+    font-size: 0.75rem; }
+  .message.is-medium {
+    font-size: 1.25rem; }
+  .message.is-large {
+    font-size: 1.5rem; }
+  .message.is-white {
+    background-color: #fafafa; }
+    .message.is-white .message-header {
+      background-color: #fafafa;
+      color: #030303; }
+    .message.is-white .message-body {
+      border-color: #fafafa; }
+  .message.is-black {
+    background-color: #fafafa; }
+    .message.is-black .message-header {
+      background-color: #030303;
+      color: #fafafa; }
+    .message.is-black .message-body {
+      border-color: #030303; }
+  .message.is-light {
+    background-color: #fafafa; }
+    .message.is-light .message-header {
+      background-color: #f5f5f5;
+      color: rgba(0, 0, 0, 0.7); }
+    .message.is-light .message-body {
+      border-color: #f5f5f5; }
+  .message.is-dark {
+    background-color: #f9f9fb; }
+    .message.is-dark .message-header {
+      background-color: #3A3D4E;
+      color: #fff; }
+    .message.is-dark .message-body {
+      border-color: #3A3D4E; }
+  .message.is-primary {
+    background-color: #ebfff9; }
+    .message.is-primary .message-header {
+      background-color: #005C43;
+      color: #fff; }
+    .message.is-primary .message-body {
+      border-color: #005C43;
+      color: #05ffbb; }
+  .message.is-link {
+    background-color: #ebf4ff; }
+    .message.is-link .message-header {
+      background-color: #004FB3;
+      color: #fff; }
+    .message.is-link .message-body {
+      border-color: #004FB3;
+      color: #0573ff; }
+  .message.is-info {
+    background-color: #eef6fc; }
+    .message.is-info .message-header {
+      background-color: #3298dc;
+      color: #fff; }
+    .message.is-info .message-body {
+      border-color: #3298dc;
+      color: #1d72aa; }
+  .message.is-success {
+    background-color: #f0ffeb; }
+    .message.is-success .message-header {
+      background-color: #1C6301;
+      color: #fff; }
+    .message.is-success .message-body {
+      border-color: #1C6301;
+      color: #47fc03; }
+  .message.is-warning {
+    background-color: #fcf9ed; }
+    .message.is-warning .message-header {
+      background-color: #EED891;
+      color: rgba(0, 0, 0, 0.7); }
+    .message.is-warning .message-body {
+      border-color: #EED891;
+      color: #806614; }
+  .message.is-danger {
+    background-color: #ffebf1; }
+    .message.is-danger .message-header {
+      background-color: #A30031;
+      color: #fff; }
+    .message.is-danger .message-body {
+      border-color: #A30031;
+      color: #ff0a54; }
 
 .message-header {
   align-items: center;
@@ -1382,18 +1126,15 @@ table th {
   justify-content: space-between;
   line-height: 1.25;
   padding: 0.75em 1em;
-  position: relative;
-}
-.message-header .delete {
-  flex-grow: 0;
-  flex-shrink: 0;
-  margin-left: 0.75em;
-}
-.message-header + .message-body {
-  border-width: 0;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
+  position: relative; }
+  .message-header .delete {
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin-left: 0.75em; }
+  .message-header + .message-body {
+    border-width: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0; }
 
 .message-body {
   border-color: #e5e5e5;
@@ -1401,634 +1142,509 @@ table th {
   border-style: solid;
   border-width: 0 0 0 4px;
   color: #83858D;
-  padding: 1.25em 1.5em;
-}
-.message-body code,
-.message-body pre {
-  background-color: #fafafa;
-}
-.message-body pre code {
-  background-color: transparent;
-}
+  padding: 1.25em 1.5em; }
+  .message-body code,
+  .message-body pre {
+    background-color: #fafafa; }
+  .message-body pre code {
+    background-color: transparent; }
 
 .navbar {
   background-color: #fafafa;
   min-height: 3.75rem;
   position: relative;
-  z-index: 30;
-}
-.navbar.is-white {
-  background-color: #fafafa;
-  color: #030303;
-}
-.navbar.is-white .navbar-brand > .navbar-item,
-.navbar.is-white .navbar-brand .navbar-link {
-  color: #030303;
-}
-.navbar.is-white .navbar-brand > a.navbar-item:focus, .navbar.is-white .navbar-brand > a.navbar-item:hover, .navbar.is-white .navbar-brand > a.navbar-item.is-active,
-.navbar.is-white .navbar-brand .navbar-link:focus,
-.navbar.is-white .navbar-brand .navbar-link:hover,
-.navbar.is-white .navbar-brand .navbar-link.is-active {
-  background-color: #ededed;
-  color: #030303;
-}
-.navbar.is-white .navbar-brand .navbar-link::after {
-  border-color: #030303;
-}
-.navbar.is-white .navbar-burger {
-  color: #030303;
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-white .navbar-start > .navbar-item,
-.navbar.is-white .navbar-start .navbar-link,
-.navbar.is-white .navbar-end > .navbar-item,
-.navbar.is-white .navbar-end .navbar-link {
-    color: #030303;
-  }
-  .navbar.is-white .navbar-start > a.navbar-item:focus, .navbar.is-white .navbar-start > a.navbar-item:hover, .navbar.is-white .navbar-start > a.navbar-item.is-active,
-.navbar.is-white .navbar-start .navbar-link:focus,
-.navbar.is-white .navbar-start .navbar-link:hover,
-.navbar.is-white .navbar-start .navbar-link.is-active,
-.navbar.is-white .navbar-end > a.navbar-item:focus,
-.navbar.is-white .navbar-end > a.navbar-item:hover,
-.navbar.is-white .navbar-end > a.navbar-item.is-active,
-.navbar.is-white .navbar-end .navbar-link:focus,
-.navbar.is-white .navbar-end .navbar-link:hover,
-.navbar.is-white .navbar-end .navbar-link.is-active {
-    background-color: #ededed;
-    color: #030303;
-  }
-  .navbar.is-white .navbar-start .navbar-link::after,
-.navbar.is-white .navbar-end .navbar-link::after {
-    border-color: #030303;
-  }
-  .navbar.is-white .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-white .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-white .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #ededed;
-    color: #030303;
-  }
-  .navbar.is-white .navbar-dropdown a.navbar-item.is-active {
+  z-index: 30; }
+  .navbar.is-white {
     background-color: #fafafa;
-    color: #030303;
-  }
-}
-.navbar.is-black {
-  background-color: #030303;
-  color: #fafafa;
-}
-.navbar.is-black .navbar-brand > .navbar-item,
-.navbar.is-black .navbar-brand .navbar-link {
-  color: #fafafa;
-}
-.navbar.is-black .navbar-brand > a.navbar-item:focus, .navbar.is-black .navbar-brand > a.navbar-item:hover, .navbar.is-black .navbar-brand > a.navbar-item.is-active,
-.navbar.is-black .navbar-brand .navbar-link:focus,
-.navbar.is-black .navbar-brand .navbar-link:hover,
-.navbar.is-black .navbar-brand .navbar-link.is-active {
-  background-color: black;
-  color: #fafafa;
-}
-.navbar.is-black .navbar-brand .navbar-link::after {
-  border-color: #fafafa;
-}
-.navbar.is-black .navbar-burger {
-  color: #fafafa;
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-black .navbar-start > .navbar-item,
-.navbar.is-black .navbar-start .navbar-link,
-.navbar.is-black .navbar-end > .navbar-item,
-.navbar.is-black .navbar-end .navbar-link {
-    color: #fafafa;
-  }
-  .navbar.is-black .navbar-start > a.navbar-item:focus, .navbar.is-black .navbar-start > a.navbar-item:hover, .navbar.is-black .navbar-start > a.navbar-item.is-active,
-.navbar.is-black .navbar-start .navbar-link:focus,
-.navbar.is-black .navbar-start .navbar-link:hover,
-.navbar.is-black .navbar-start .navbar-link.is-active,
-.navbar.is-black .navbar-end > a.navbar-item:focus,
-.navbar.is-black .navbar-end > a.navbar-item:hover,
-.navbar.is-black .navbar-end > a.navbar-item.is-active,
-.navbar.is-black .navbar-end .navbar-link:focus,
-.navbar.is-black .navbar-end .navbar-link:hover,
-.navbar.is-black .navbar-end .navbar-link.is-active {
-    background-color: black;
-    color: #fafafa;
-  }
-  .navbar.is-black .navbar-start .navbar-link::after,
-.navbar.is-black .navbar-end .navbar-link::after {
-    border-color: #fafafa;
-  }
-  .navbar.is-black .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-black .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-black .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: black;
-    color: #fafafa;
-  }
-  .navbar.is-black .navbar-dropdown a.navbar-item.is-active {
+    color: #030303; }
+    .navbar.is-white .navbar-brand > .navbar-item,
+    .navbar.is-white .navbar-brand .navbar-link {
+      color: #030303; }
+    .navbar.is-white .navbar-brand > a.navbar-item:focus, .navbar.is-white .navbar-brand > a.navbar-item:hover, .navbar.is-white .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-white .navbar-brand .navbar-link:focus,
+    .navbar.is-white .navbar-brand .navbar-link:hover,
+    .navbar.is-white .navbar-brand .navbar-link.is-active {
+      background-color: #ededed;
+      color: #030303; }
+    .navbar.is-white .navbar-brand .navbar-link::after {
+      border-color: #030303; }
+    .navbar.is-white .navbar-burger {
+      color: #030303; }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-white .navbar-start > .navbar-item,
+      .navbar.is-white .navbar-start .navbar-link,
+      .navbar.is-white .navbar-end > .navbar-item,
+      .navbar.is-white .navbar-end .navbar-link {
+        color: #030303; }
+      .navbar.is-white .navbar-start > a.navbar-item:focus, .navbar.is-white .navbar-start > a.navbar-item:hover, .navbar.is-white .navbar-start > a.navbar-item.is-active,
+      .navbar.is-white .navbar-start .navbar-link:focus,
+      .navbar.is-white .navbar-start .navbar-link:hover,
+      .navbar.is-white .navbar-start .navbar-link.is-active,
+      .navbar.is-white .navbar-end > a.navbar-item:focus,
+      .navbar.is-white .navbar-end > a.navbar-item:hover,
+      .navbar.is-white .navbar-end > a.navbar-item.is-active,
+      .navbar.is-white .navbar-end .navbar-link:focus,
+      .navbar.is-white .navbar-end .navbar-link:hover,
+      .navbar.is-white .navbar-end .navbar-link.is-active {
+        background-color: #ededed;
+        color: #030303; }
+      .navbar.is-white .navbar-start .navbar-link::after,
+      .navbar.is-white .navbar-end .navbar-link::after {
+        border-color: #030303; }
+      .navbar.is-white .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-white .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-white .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #ededed;
+        color: #030303; }
+      .navbar.is-white .navbar-dropdown a.navbar-item.is-active {
+        background-color: #fafafa;
+        color: #030303; } }
+  .navbar.is-black {
     background-color: #030303;
-    color: #fafafa;
-  }
-}
-.navbar.is-light {
-  background-color: #f5f5f5;
-  color: rgba(0, 0, 0, 0.7);
-}
-.navbar.is-light .navbar-brand > .navbar-item,
-.navbar.is-light .navbar-brand .navbar-link {
-  color: rgba(0, 0, 0, 0.7);
-}
-.navbar.is-light .navbar-brand > a.navbar-item:focus, .navbar.is-light .navbar-brand > a.navbar-item:hover, .navbar.is-light .navbar-brand > a.navbar-item.is-active,
-.navbar.is-light .navbar-brand .navbar-link:focus,
-.navbar.is-light .navbar-brand .navbar-link:hover,
-.navbar.is-light .navbar-brand .navbar-link.is-active {
-  background-color: #e8e8e8;
-  color: rgba(0, 0, 0, 0.7);
-}
-.navbar.is-light .navbar-brand .navbar-link::after {
-  border-color: rgba(0, 0, 0, 0.7);
-}
-.navbar.is-light .navbar-burger {
-  color: rgba(0, 0, 0, 0.7);
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-light .navbar-start > .navbar-item,
-.navbar.is-light .navbar-start .navbar-link,
-.navbar.is-light .navbar-end > .navbar-item,
-.navbar.is-light .navbar-end .navbar-link {
-    color: rgba(0, 0, 0, 0.7);
-  }
-  .navbar.is-light .navbar-start > a.navbar-item:focus, .navbar.is-light .navbar-start > a.navbar-item:hover, .navbar.is-light .navbar-start > a.navbar-item.is-active,
-.navbar.is-light .navbar-start .navbar-link:focus,
-.navbar.is-light .navbar-start .navbar-link:hover,
-.navbar.is-light .navbar-start .navbar-link.is-active,
-.navbar.is-light .navbar-end > a.navbar-item:focus,
-.navbar.is-light .navbar-end > a.navbar-item:hover,
-.navbar.is-light .navbar-end > a.navbar-item.is-active,
-.navbar.is-light .navbar-end .navbar-link:focus,
-.navbar.is-light .navbar-end .navbar-link:hover,
-.navbar.is-light .navbar-end .navbar-link.is-active {
-    background-color: #e8e8e8;
-    color: rgba(0, 0, 0, 0.7);
-  }
-  .navbar.is-light .navbar-start .navbar-link::after,
-.navbar.is-light .navbar-end .navbar-link::after {
-    border-color: rgba(0, 0, 0, 0.7);
-  }
-  .navbar.is-light .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-light .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-light .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #e8e8e8;
-    color: rgba(0, 0, 0, 0.7);
-  }
-  .navbar.is-light .navbar-dropdown a.navbar-item.is-active {
+    color: #fafafa; }
+    .navbar.is-black .navbar-brand > .navbar-item,
+    .navbar.is-black .navbar-brand .navbar-link {
+      color: #fafafa; }
+    .navbar.is-black .navbar-brand > a.navbar-item:focus, .navbar.is-black .navbar-brand > a.navbar-item:hover, .navbar.is-black .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-black .navbar-brand .navbar-link:focus,
+    .navbar.is-black .navbar-brand .navbar-link:hover,
+    .navbar.is-black .navbar-brand .navbar-link.is-active {
+      background-color: black;
+      color: #fafafa; }
+    .navbar.is-black .navbar-brand .navbar-link::after {
+      border-color: #fafafa; }
+    .navbar.is-black .navbar-burger {
+      color: #fafafa; }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-black .navbar-start > .navbar-item,
+      .navbar.is-black .navbar-start .navbar-link,
+      .navbar.is-black .navbar-end > .navbar-item,
+      .navbar.is-black .navbar-end .navbar-link {
+        color: #fafafa; }
+      .navbar.is-black .navbar-start > a.navbar-item:focus, .navbar.is-black .navbar-start > a.navbar-item:hover, .navbar.is-black .navbar-start > a.navbar-item.is-active,
+      .navbar.is-black .navbar-start .navbar-link:focus,
+      .navbar.is-black .navbar-start .navbar-link:hover,
+      .navbar.is-black .navbar-start .navbar-link.is-active,
+      .navbar.is-black .navbar-end > a.navbar-item:focus,
+      .navbar.is-black .navbar-end > a.navbar-item:hover,
+      .navbar.is-black .navbar-end > a.navbar-item.is-active,
+      .navbar.is-black .navbar-end .navbar-link:focus,
+      .navbar.is-black .navbar-end .navbar-link:hover,
+      .navbar.is-black .navbar-end .navbar-link.is-active {
+        background-color: black;
+        color: #fafafa; }
+      .navbar.is-black .navbar-start .navbar-link::after,
+      .navbar.is-black .navbar-end .navbar-link::after {
+        border-color: #fafafa; }
+      .navbar.is-black .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-black .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-black .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: black;
+        color: #fafafa; }
+      .navbar.is-black .navbar-dropdown a.navbar-item.is-active {
+        background-color: #030303;
+        color: #fafafa; } }
+  .navbar.is-light {
     background-color: #f5f5f5;
-    color: rgba(0, 0, 0, 0.7);
-  }
-}
-.navbar.is-dark {
-  background-color: #3A3D4E;
-  color: #fff;
-}
-.navbar.is-dark .navbar-brand > .navbar-item,
-.navbar.is-dark .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-dark .navbar-brand > a.navbar-item:focus, .navbar.is-dark .navbar-brand > a.navbar-item:hover, .navbar.is-dark .navbar-brand > a.navbar-item.is-active,
-.navbar.is-dark .navbar-brand .navbar-link:focus,
-.navbar.is-dark .navbar-brand .navbar-link:hover,
-.navbar.is-dark .navbar-brand .navbar-link.is-active {
-  background-color: #2f323f;
-  color: #fff;
-}
-.navbar.is-dark .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-dark .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-dark .navbar-start > .navbar-item,
-.navbar.is-dark .navbar-start .navbar-link,
-.navbar.is-dark .navbar-end > .navbar-item,
-.navbar.is-dark .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-dark .navbar-start > a.navbar-item:focus, .navbar.is-dark .navbar-start > a.navbar-item:hover, .navbar.is-dark .navbar-start > a.navbar-item.is-active,
-.navbar.is-dark .navbar-start .navbar-link:focus,
-.navbar.is-dark .navbar-start .navbar-link:hover,
-.navbar.is-dark .navbar-start .navbar-link.is-active,
-.navbar.is-dark .navbar-end > a.navbar-item:focus,
-.navbar.is-dark .navbar-end > a.navbar-item:hover,
-.navbar.is-dark .navbar-end > a.navbar-item.is-active,
-.navbar.is-dark .navbar-end .navbar-link:focus,
-.navbar.is-dark .navbar-end .navbar-link:hover,
-.navbar.is-dark .navbar-end .navbar-link.is-active {
-    background-color: #2f323f;
-    color: #fff;
-  }
-  .navbar.is-dark .navbar-start .navbar-link::after,
-.navbar.is-dark .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-dark .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-dark .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-dark .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #2f323f;
-    color: #fff;
-  }
-  .navbar.is-dark .navbar-dropdown a.navbar-item.is-active {
+    color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-light .navbar-brand > .navbar-item,
+    .navbar.is-light .navbar-brand .navbar-link {
+      color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-light .navbar-brand > a.navbar-item:focus, .navbar.is-light .navbar-brand > a.navbar-item:hover, .navbar.is-light .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-light .navbar-brand .navbar-link:focus,
+    .navbar.is-light .navbar-brand .navbar-link:hover,
+    .navbar.is-light .navbar-brand .navbar-link.is-active {
+      background-color: #e8e8e8;
+      color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-light .navbar-brand .navbar-link::after {
+      border-color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-light .navbar-burger {
+      color: rgba(0, 0, 0, 0.7); }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-light .navbar-start > .navbar-item,
+      .navbar.is-light .navbar-start .navbar-link,
+      .navbar.is-light .navbar-end > .navbar-item,
+      .navbar.is-light .navbar-end .navbar-link {
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-light .navbar-start > a.navbar-item:focus, .navbar.is-light .navbar-start > a.navbar-item:hover, .navbar.is-light .navbar-start > a.navbar-item.is-active,
+      .navbar.is-light .navbar-start .navbar-link:focus,
+      .navbar.is-light .navbar-start .navbar-link:hover,
+      .navbar.is-light .navbar-start .navbar-link.is-active,
+      .navbar.is-light .navbar-end > a.navbar-item:focus,
+      .navbar.is-light .navbar-end > a.navbar-item:hover,
+      .navbar.is-light .navbar-end > a.navbar-item.is-active,
+      .navbar.is-light .navbar-end .navbar-link:focus,
+      .navbar.is-light .navbar-end .navbar-link:hover,
+      .navbar.is-light .navbar-end .navbar-link.is-active {
+        background-color: #e8e8e8;
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-light .navbar-start .navbar-link::after,
+      .navbar.is-light .navbar-end .navbar-link::after {
+        border-color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-light .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-light .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-light .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #e8e8e8;
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-light .navbar-dropdown a.navbar-item.is-active {
+        background-color: #f5f5f5;
+        color: rgba(0, 0, 0, 0.7); } }
+  .navbar.is-dark {
     background-color: #3A3D4E;
-    color: #fff;
-  }
-}
-.navbar.is-primary {
-  background-color: #005C43;
-  color: #fff;
-}
-.navbar.is-primary .navbar-brand > .navbar-item,
-.navbar.is-primary .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-primary .navbar-brand > a.navbar-item:focus, .navbar.is-primary .navbar-brand > a.navbar-item:hover, .navbar.is-primary .navbar-brand > a.navbar-item.is-active,
-.navbar.is-primary .navbar-brand .navbar-link:focus,
-.navbar.is-primary .navbar-brand .navbar-link:hover,
-.navbar.is-primary .navbar-brand .navbar-link.is-active {
-  background-color: #004330;
-  color: #fff;
-}
-.navbar.is-primary .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-primary .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-primary .navbar-start > .navbar-item,
-.navbar.is-primary .navbar-start .navbar-link,
-.navbar.is-primary .navbar-end > .navbar-item,
-.navbar.is-primary .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-primary .navbar-start > a.navbar-item:focus, .navbar.is-primary .navbar-start > a.navbar-item:hover, .navbar.is-primary .navbar-start > a.navbar-item.is-active,
-.navbar.is-primary .navbar-start .navbar-link:focus,
-.navbar.is-primary .navbar-start .navbar-link:hover,
-.navbar.is-primary .navbar-start .navbar-link.is-active,
-.navbar.is-primary .navbar-end > a.navbar-item:focus,
-.navbar.is-primary .navbar-end > a.navbar-item:hover,
-.navbar.is-primary .navbar-end > a.navbar-item.is-active,
-.navbar.is-primary .navbar-end .navbar-link:focus,
-.navbar.is-primary .navbar-end .navbar-link:hover,
-.navbar.is-primary .navbar-end .navbar-link.is-active {
-    background-color: #004330;
-    color: #fff;
-  }
-  .navbar.is-primary .navbar-start .navbar-link::after,
-.navbar.is-primary .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-primary .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-primary .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-primary .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #004330;
-    color: #fff;
-  }
-  .navbar.is-primary .navbar-dropdown a.navbar-item.is-active {
+    color: #fff; }
+    .navbar.is-dark .navbar-brand > .navbar-item,
+    .navbar.is-dark .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-dark .navbar-brand > a.navbar-item:focus, .navbar.is-dark .navbar-brand > a.navbar-item:hover, .navbar.is-dark .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-dark .navbar-brand .navbar-link:focus,
+    .navbar.is-dark .navbar-brand .navbar-link:hover,
+    .navbar.is-dark .navbar-brand .navbar-link.is-active {
+      background-color: #2f323f;
+      color: #fff; }
+    .navbar.is-dark .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-dark .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-dark .navbar-start > .navbar-item,
+      .navbar.is-dark .navbar-start .navbar-link,
+      .navbar.is-dark .navbar-end > .navbar-item,
+      .navbar.is-dark .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-dark .navbar-start > a.navbar-item:focus, .navbar.is-dark .navbar-start > a.navbar-item:hover, .navbar.is-dark .navbar-start > a.navbar-item.is-active,
+      .navbar.is-dark .navbar-start .navbar-link:focus,
+      .navbar.is-dark .navbar-start .navbar-link:hover,
+      .navbar.is-dark .navbar-start .navbar-link.is-active,
+      .navbar.is-dark .navbar-end > a.navbar-item:focus,
+      .navbar.is-dark .navbar-end > a.navbar-item:hover,
+      .navbar.is-dark .navbar-end > a.navbar-item.is-active,
+      .navbar.is-dark .navbar-end .navbar-link:focus,
+      .navbar.is-dark .navbar-end .navbar-link:hover,
+      .navbar.is-dark .navbar-end .navbar-link.is-active {
+        background-color: #2f323f;
+        color: #fff; }
+      .navbar.is-dark .navbar-start .navbar-link::after,
+      .navbar.is-dark .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-dark .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-dark .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-dark .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #2f323f;
+        color: #fff; }
+      .navbar.is-dark .navbar-dropdown a.navbar-item.is-active {
+        background-color: #3A3D4E;
+        color: #fff; } }
+  .navbar.is-primary {
     background-color: #005C43;
-    color: #fff;
-  }
-}
-.navbar.is-link {
-  background-color: #004FB3;
-  color: #fff;
-}
-.navbar.is-link .navbar-brand > .navbar-item,
-.navbar.is-link .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-link .navbar-brand > a.navbar-item:focus, .navbar.is-link .navbar-brand > a.navbar-item:hover, .navbar.is-link .navbar-brand > a.navbar-item.is-active,
-.navbar.is-link .navbar-brand .navbar-link:focus,
-.navbar.is-link .navbar-brand .navbar-link:hover,
-.navbar.is-link .navbar-brand .navbar-link.is-active {
-  background-color: #00449a;
-  color: #fff;
-}
-.navbar.is-link .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-link .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-link .navbar-start > .navbar-item,
-.navbar.is-link .navbar-start .navbar-link,
-.navbar.is-link .navbar-end > .navbar-item,
-.navbar.is-link .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-link .navbar-start > a.navbar-item:focus, .navbar.is-link .navbar-start > a.navbar-item:hover, .navbar.is-link .navbar-start > a.navbar-item.is-active,
-.navbar.is-link .navbar-start .navbar-link:focus,
-.navbar.is-link .navbar-start .navbar-link:hover,
-.navbar.is-link .navbar-start .navbar-link.is-active,
-.navbar.is-link .navbar-end > a.navbar-item:focus,
-.navbar.is-link .navbar-end > a.navbar-item:hover,
-.navbar.is-link .navbar-end > a.navbar-item.is-active,
-.navbar.is-link .navbar-end .navbar-link:focus,
-.navbar.is-link .navbar-end .navbar-link:hover,
-.navbar.is-link .navbar-end .navbar-link.is-active {
-    background-color: #00449a;
-    color: #fff;
-  }
-  .navbar.is-link .navbar-start .navbar-link::after,
-.navbar.is-link .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-link .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-link .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-link .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #00449a;
-    color: #fff;
-  }
-  .navbar.is-link .navbar-dropdown a.navbar-item.is-active {
+    color: #fff; }
+    .navbar.is-primary .navbar-brand > .navbar-item,
+    .navbar.is-primary .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-primary .navbar-brand > a.navbar-item:focus, .navbar.is-primary .navbar-brand > a.navbar-item:hover, .navbar.is-primary .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-primary .navbar-brand .navbar-link:focus,
+    .navbar.is-primary .navbar-brand .navbar-link:hover,
+    .navbar.is-primary .navbar-brand .navbar-link.is-active {
+      background-color: #004330;
+      color: #fff; }
+    .navbar.is-primary .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-primary .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-primary .navbar-start > .navbar-item,
+      .navbar.is-primary .navbar-start .navbar-link,
+      .navbar.is-primary .navbar-end > .navbar-item,
+      .navbar.is-primary .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-primary .navbar-start > a.navbar-item:focus, .navbar.is-primary .navbar-start > a.navbar-item:hover, .navbar.is-primary .navbar-start > a.navbar-item.is-active,
+      .navbar.is-primary .navbar-start .navbar-link:focus,
+      .navbar.is-primary .navbar-start .navbar-link:hover,
+      .navbar.is-primary .navbar-start .navbar-link.is-active,
+      .navbar.is-primary .navbar-end > a.navbar-item:focus,
+      .navbar.is-primary .navbar-end > a.navbar-item:hover,
+      .navbar.is-primary .navbar-end > a.navbar-item.is-active,
+      .navbar.is-primary .navbar-end .navbar-link:focus,
+      .navbar.is-primary .navbar-end .navbar-link:hover,
+      .navbar.is-primary .navbar-end .navbar-link.is-active {
+        background-color: #004330;
+        color: #fff; }
+      .navbar.is-primary .navbar-start .navbar-link::after,
+      .navbar.is-primary .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-primary .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-primary .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-primary .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #004330;
+        color: #fff; }
+      .navbar.is-primary .navbar-dropdown a.navbar-item.is-active {
+        background-color: #005C43;
+        color: #fff; } }
+  .navbar.is-link {
     background-color: #004FB3;
-    color: #fff;
-  }
-}
-.navbar.is-info {
-  background-color: hsl(204deg, 71%, 53%);
-  color: #fff;
-}
-.navbar.is-info .navbar-brand > .navbar-item,
-.navbar.is-info .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-info .navbar-brand > a.navbar-item:focus, .navbar.is-info .navbar-brand > a.navbar-item:hover, .navbar.is-info .navbar-brand > a.navbar-item.is-active,
-.navbar.is-info .navbar-brand .navbar-link:focus,
-.navbar.is-info .navbar-brand .navbar-link:hover,
-.navbar.is-info .navbar-brand .navbar-link.is-active {
-  background-color: #238cd1;
-  color: #fff;
-}
-.navbar.is-info .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-info .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-info .navbar-start > .navbar-item,
-.navbar.is-info .navbar-start .navbar-link,
-.navbar.is-info .navbar-end > .navbar-item,
-.navbar.is-info .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-info .navbar-start > a.navbar-item:focus, .navbar.is-info .navbar-start > a.navbar-item:hover, .navbar.is-info .navbar-start > a.navbar-item.is-active,
-.navbar.is-info .navbar-start .navbar-link:focus,
-.navbar.is-info .navbar-start .navbar-link:hover,
-.navbar.is-info .navbar-start .navbar-link.is-active,
-.navbar.is-info .navbar-end > a.navbar-item:focus,
-.navbar.is-info .navbar-end > a.navbar-item:hover,
-.navbar.is-info .navbar-end > a.navbar-item.is-active,
-.navbar.is-info .navbar-end .navbar-link:focus,
-.navbar.is-info .navbar-end .navbar-link:hover,
-.navbar.is-info .navbar-end .navbar-link.is-active {
-    background-color: #238cd1;
-    color: #fff;
-  }
-  .navbar.is-info .navbar-start .navbar-link::after,
-.navbar.is-info .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-info .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-info .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-info .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #238cd1;
-    color: #fff;
-  }
-  .navbar.is-info .navbar-dropdown a.navbar-item.is-active {
-    background-color: hsl(204deg, 71%, 53%);
-    color: #fff;
-  }
-}
-.navbar.is-success {
-  background-color: #1C6301;
-  color: #fff;
-}
-.navbar.is-success .navbar-brand > .navbar-item,
-.navbar.is-success .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-success .navbar-brand > a.navbar-item:focus, .navbar.is-success .navbar-brand > a.navbar-item:hover, .navbar.is-success .navbar-brand > a.navbar-item.is-active,
-.navbar.is-success .navbar-brand .navbar-link:focus,
-.navbar.is-success .navbar-brand .navbar-link:hover,
-.navbar.is-success .navbar-brand .navbar-link.is-active {
-  background-color: #154a01;
-  color: #fff;
-}
-.navbar.is-success .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-success .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-success .navbar-start > .navbar-item,
-.navbar.is-success .navbar-start .navbar-link,
-.navbar.is-success .navbar-end > .navbar-item,
-.navbar.is-success .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-success .navbar-start > a.navbar-item:focus, .navbar.is-success .navbar-start > a.navbar-item:hover, .navbar.is-success .navbar-start > a.navbar-item.is-active,
-.navbar.is-success .navbar-start .navbar-link:focus,
-.navbar.is-success .navbar-start .navbar-link:hover,
-.navbar.is-success .navbar-start .navbar-link.is-active,
-.navbar.is-success .navbar-end > a.navbar-item:focus,
-.navbar.is-success .navbar-end > a.navbar-item:hover,
-.navbar.is-success .navbar-end > a.navbar-item.is-active,
-.navbar.is-success .navbar-end .navbar-link:focus,
-.navbar.is-success .navbar-end .navbar-link:hover,
-.navbar.is-success .navbar-end .navbar-link.is-active {
-    background-color: #154a01;
-    color: #fff;
-  }
-  .navbar.is-success .navbar-start .navbar-link::after,
-.navbar.is-success .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-success .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-success .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-success .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #154a01;
-    color: #fff;
-  }
-  .navbar.is-success .navbar-dropdown a.navbar-item.is-active {
+    color: #fff; }
+    .navbar.is-link .navbar-brand > .navbar-item,
+    .navbar.is-link .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-link .navbar-brand > a.navbar-item:focus, .navbar.is-link .navbar-brand > a.navbar-item:hover, .navbar.is-link .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-link .navbar-brand .navbar-link:focus,
+    .navbar.is-link .navbar-brand .navbar-link:hover,
+    .navbar.is-link .navbar-brand .navbar-link.is-active {
+      background-color: #00449a;
+      color: #fff; }
+    .navbar.is-link .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-link .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-link .navbar-start > .navbar-item,
+      .navbar.is-link .navbar-start .navbar-link,
+      .navbar.is-link .navbar-end > .navbar-item,
+      .navbar.is-link .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-link .navbar-start > a.navbar-item:focus, .navbar.is-link .navbar-start > a.navbar-item:hover, .navbar.is-link .navbar-start > a.navbar-item.is-active,
+      .navbar.is-link .navbar-start .navbar-link:focus,
+      .navbar.is-link .navbar-start .navbar-link:hover,
+      .navbar.is-link .navbar-start .navbar-link.is-active,
+      .navbar.is-link .navbar-end > a.navbar-item:focus,
+      .navbar.is-link .navbar-end > a.navbar-item:hover,
+      .navbar.is-link .navbar-end > a.navbar-item.is-active,
+      .navbar.is-link .navbar-end .navbar-link:focus,
+      .navbar.is-link .navbar-end .navbar-link:hover,
+      .navbar.is-link .navbar-end .navbar-link.is-active {
+        background-color: #00449a;
+        color: #fff; }
+      .navbar.is-link .navbar-start .navbar-link::after,
+      .navbar.is-link .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-link .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-link .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-link .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #00449a;
+        color: #fff; }
+      .navbar.is-link .navbar-dropdown a.navbar-item.is-active {
+        background-color: #004FB3;
+        color: #fff; } }
+  .navbar.is-info {
+    background-color: #3298dc;
+    color: #fff; }
+    .navbar.is-info .navbar-brand > .navbar-item,
+    .navbar.is-info .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-info .navbar-brand > a.navbar-item:focus, .navbar.is-info .navbar-brand > a.navbar-item:hover, .navbar.is-info .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-info .navbar-brand .navbar-link:focus,
+    .navbar.is-info .navbar-brand .navbar-link:hover,
+    .navbar.is-info .navbar-brand .navbar-link.is-active {
+      background-color: #238cd1;
+      color: #fff; }
+    .navbar.is-info .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-info .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-info .navbar-start > .navbar-item,
+      .navbar.is-info .navbar-start .navbar-link,
+      .navbar.is-info .navbar-end > .navbar-item,
+      .navbar.is-info .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-info .navbar-start > a.navbar-item:focus, .navbar.is-info .navbar-start > a.navbar-item:hover, .navbar.is-info .navbar-start > a.navbar-item.is-active,
+      .navbar.is-info .navbar-start .navbar-link:focus,
+      .navbar.is-info .navbar-start .navbar-link:hover,
+      .navbar.is-info .navbar-start .navbar-link.is-active,
+      .navbar.is-info .navbar-end > a.navbar-item:focus,
+      .navbar.is-info .navbar-end > a.navbar-item:hover,
+      .navbar.is-info .navbar-end > a.navbar-item.is-active,
+      .navbar.is-info .navbar-end .navbar-link:focus,
+      .navbar.is-info .navbar-end .navbar-link:hover,
+      .navbar.is-info .navbar-end .navbar-link.is-active {
+        background-color: #238cd1;
+        color: #fff; }
+      .navbar.is-info .navbar-start .navbar-link::after,
+      .navbar.is-info .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-info .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-info .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-info .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #238cd1;
+        color: #fff; }
+      .navbar.is-info .navbar-dropdown a.navbar-item.is-active {
+        background-color: #3298dc;
+        color: #fff; } }
+  .navbar.is-success {
     background-color: #1C6301;
-    color: #fff;
-  }
-}
-.navbar.is-warning {
-  background-color: #EED891;
-  color: rgba(0, 0, 0, 0.7);
-}
-.navbar.is-warning .navbar-brand > .navbar-item,
-.navbar.is-warning .navbar-brand .navbar-link {
-  color: rgba(0, 0, 0, 0.7);
-}
-.navbar.is-warning .navbar-brand > a.navbar-item:focus, .navbar.is-warning .navbar-brand > a.navbar-item:hover, .navbar.is-warning .navbar-brand > a.navbar-item.is-active,
-.navbar.is-warning .navbar-brand .navbar-link:focus,
-.navbar.is-warning .navbar-brand .navbar-link:hover,
-.navbar.is-warning .navbar-brand .navbar-link.is-active {
-  background-color: #ebd07b;
-  color: rgba(0, 0, 0, 0.7);
-}
-.navbar.is-warning .navbar-brand .navbar-link::after {
-  border-color: rgba(0, 0, 0, 0.7);
-}
-.navbar.is-warning .navbar-burger {
-  color: rgba(0, 0, 0, 0.7);
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-warning .navbar-start > .navbar-item,
-.navbar.is-warning .navbar-start .navbar-link,
-.navbar.is-warning .navbar-end > .navbar-item,
-.navbar.is-warning .navbar-end .navbar-link {
-    color: rgba(0, 0, 0, 0.7);
-  }
-  .navbar.is-warning .navbar-start > a.navbar-item:focus, .navbar.is-warning .navbar-start > a.navbar-item:hover, .navbar.is-warning .navbar-start > a.navbar-item.is-active,
-.navbar.is-warning .navbar-start .navbar-link:focus,
-.navbar.is-warning .navbar-start .navbar-link:hover,
-.navbar.is-warning .navbar-start .navbar-link.is-active,
-.navbar.is-warning .navbar-end > a.navbar-item:focus,
-.navbar.is-warning .navbar-end > a.navbar-item:hover,
-.navbar.is-warning .navbar-end > a.navbar-item.is-active,
-.navbar.is-warning .navbar-end .navbar-link:focus,
-.navbar.is-warning .navbar-end .navbar-link:hover,
-.navbar.is-warning .navbar-end .navbar-link.is-active {
-    background-color: #ebd07b;
-    color: rgba(0, 0, 0, 0.7);
-  }
-  .navbar.is-warning .navbar-start .navbar-link::after,
-.navbar.is-warning .navbar-end .navbar-link::after {
-    border-color: rgba(0, 0, 0, 0.7);
-  }
-  .navbar.is-warning .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-warning .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-warning .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #ebd07b;
-    color: rgba(0, 0, 0, 0.7);
-  }
-  .navbar.is-warning .navbar-dropdown a.navbar-item.is-active {
+    color: #fff; }
+    .navbar.is-success .navbar-brand > .navbar-item,
+    .navbar.is-success .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-success .navbar-brand > a.navbar-item:focus, .navbar.is-success .navbar-brand > a.navbar-item:hover, .navbar.is-success .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-success .navbar-brand .navbar-link:focus,
+    .navbar.is-success .navbar-brand .navbar-link:hover,
+    .navbar.is-success .navbar-brand .navbar-link.is-active {
+      background-color: #154a01;
+      color: #fff; }
+    .navbar.is-success .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-success .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-success .navbar-start > .navbar-item,
+      .navbar.is-success .navbar-start .navbar-link,
+      .navbar.is-success .navbar-end > .navbar-item,
+      .navbar.is-success .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-success .navbar-start > a.navbar-item:focus, .navbar.is-success .navbar-start > a.navbar-item:hover, .navbar.is-success .navbar-start > a.navbar-item.is-active,
+      .navbar.is-success .navbar-start .navbar-link:focus,
+      .navbar.is-success .navbar-start .navbar-link:hover,
+      .navbar.is-success .navbar-start .navbar-link.is-active,
+      .navbar.is-success .navbar-end > a.navbar-item:focus,
+      .navbar.is-success .navbar-end > a.navbar-item:hover,
+      .navbar.is-success .navbar-end > a.navbar-item.is-active,
+      .navbar.is-success .navbar-end .navbar-link:focus,
+      .navbar.is-success .navbar-end .navbar-link:hover,
+      .navbar.is-success .navbar-end .navbar-link.is-active {
+        background-color: #154a01;
+        color: #fff; }
+      .navbar.is-success .navbar-start .navbar-link::after,
+      .navbar.is-success .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-success .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-success .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-success .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #154a01;
+        color: #fff; }
+      .navbar.is-success .navbar-dropdown a.navbar-item.is-active {
+        background-color: #1C6301;
+        color: #fff; } }
+  .navbar.is-warning {
     background-color: #EED891;
-    color: rgba(0, 0, 0, 0.7);
-  }
-}
-.navbar.is-danger {
-  background-color: #A30031;
-  color: #fff;
-}
-.navbar.is-danger .navbar-brand > .navbar-item,
-.navbar.is-danger .navbar-brand .navbar-link {
-  color: #fff;
-}
-.navbar.is-danger .navbar-brand > a.navbar-item:focus, .navbar.is-danger .navbar-brand > a.navbar-item:hover, .navbar.is-danger .navbar-brand > a.navbar-item.is-active,
-.navbar.is-danger .navbar-brand .navbar-link:focus,
-.navbar.is-danger .navbar-brand .navbar-link:hover,
-.navbar.is-danger .navbar-brand .navbar-link.is-active {
-  background-color: #8a0029;
-  color: #fff;
-}
-.navbar.is-danger .navbar-brand .navbar-link::after {
-  border-color: #fff;
-}
-.navbar.is-danger .navbar-burger {
-  color: #fff;
-}
-@media screen and (min-width: 1204px) {
-  .navbar.is-danger .navbar-start > .navbar-item,
-.navbar.is-danger .navbar-start .navbar-link,
-.navbar.is-danger .navbar-end > .navbar-item,
-.navbar.is-danger .navbar-end .navbar-link {
-    color: #fff;
-  }
-  .navbar.is-danger .navbar-start > a.navbar-item:focus, .navbar.is-danger .navbar-start > a.navbar-item:hover, .navbar.is-danger .navbar-start > a.navbar-item.is-active,
-.navbar.is-danger .navbar-start .navbar-link:focus,
-.navbar.is-danger .navbar-start .navbar-link:hover,
-.navbar.is-danger .navbar-start .navbar-link.is-active,
-.navbar.is-danger .navbar-end > a.navbar-item:focus,
-.navbar.is-danger .navbar-end > a.navbar-item:hover,
-.navbar.is-danger .navbar-end > a.navbar-item.is-active,
-.navbar.is-danger .navbar-end .navbar-link:focus,
-.navbar.is-danger .navbar-end .navbar-link:hover,
-.navbar.is-danger .navbar-end .navbar-link.is-active {
-    background-color: #8a0029;
-    color: #fff;
-  }
-  .navbar.is-danger .navbar-start .navbar-link::after,
-.navbar.is-danger .navbar-end .navbar-link::after {
-    border-color: #fff;
-  }
-  .navbar.is-danger .navbar-item.has-dropdown:focus .navbar-link,
-.navbar.is-danger .navbar-item.has-dropdown:hover .navbar-link,
-.navbar.is-danger .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #8a0029;
-    color: #fff;
-  }
-  .navbar.is-danger .navbar-dropdown a.navbar-item.is-active {
+    color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-warning .navbar-brand > .navbar-item,
+    .navbar.is-warning .navbar-brand .navbar-link {
+      color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-warning .navbar-brand > a.navbar-item:focus, .navbar.is-warning .navbar-brand > a.navbar-item:hover, .navbar.is-warning .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-warning .navbar-brand .navbar-link:focus,
+    .navbar.is-warning .navbar-brand .navbar-link:hover,
+    .navbar.is-warning .navbar-brand .navbar-link.is-active {
+      background-color: #ebd07b;
+      color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-warning .navbar-brand .navbar-link::after {
+      border-color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-warning .navbar-burger {
+      color: rgba(0, 0, 0, 0.7); }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-warning .navbar-start > .navbar-item,
+      .navbar.is-warning .navbar-start .navbar-link,
+      .navbar.is-warning .navbar-end > .navbar-item,
+      .navbar.is-warning .navbar-end .navbar-link {
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-warning .navbar-start > a.navbar-item:focus, .navbar.is-warning .navbar-start > a.navbar-item:hover, .navbar.is-warning .navbar-start > a.navbar-item.is-active,
+      .navbar.is-warning .navbar-start .navbar-link:focus,
+      .navbar.is-warning .navbar-start .navbar-link:hover,
+      .navbar.is-warning .navbar-start .navbar-link.is-active,
+      .navbar.is-warning .navbar-end > a.navbar-item:focus,
+      .navbar.is-warning .navbar-end > a.navbar-item:hover,
+      .navbar.is-warning .navbar-end > a.navbar-item.is-active,
+      .navbar.is-warning .navbar-end .navbar-link:focus,
+      .navbar.is-warning .navbar-end .navbar-link:hover,
+      .navbar.is-warning .navbar-end .navbar-link.is-active {
+        background-color: #ebd07b;
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-warning .navbar-start .navbar-link::after,
+      .navbar.is-warning .navbar-end .navbar-link::after {
+        border-color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-warning .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-warning .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-warning .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #ebd07b;
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-warning .navbar-dropdown a.navbar-item.is-active {
+        background-color: #EED891;
+        color: rgba(0, 0, 0, 0.7); } }
+  .navbar.is-danger {
     background-color: #A30031;
-    color: #fff;
-  }
-}
-.navbar > .container {
-  align-items: stretch;
-  display: flex;
-  min-height: 3.75rem;
-  width: 100%;
-}
-.navbar.has-shadow {
-  box-shadow: 0 2px 0 0 #f5f5f5;
-}
-.navbar.is-fixed-bottom, .navbar.is-fixed-top {
-  left: 0;
-  position: fixed;
-  right: 0;
-  z-index: 30;
-}
-.navbar.is-fixed-bottom {
-  bottom: 0;
-}
-.navbar.is-fixed-bottom.has-shadow {
-  box-shadow: 0 -2px 0 0 #f5f5f5;
-}
-.navbar.is-fixed-top {
-  top: 0;
-}
+    color: #fff; }
+    .navbar.is-danger .navbar-brand > .navbar-item,
+    .navbar.is-danger .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-danger .navbar-brand > a.navbar-item:focus, .navbar.is-danger .navbar-brand > a.navbar-item:hover, .navbar.is-danger .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-danger .navbar-brand .navbar-link:focus,
+    .navbar.is-danger .navbar-brand .navbar-link:hover,
+    .navbar.is-danger .navbar-brand .navbar-link.is-active {
+      background-color: #8a0029;
+      color: #fff; }
+    .navbar.is-danger .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-danger .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1204px) {
+      .navbar.is-danger .navbar-start > .navbar-item,
+      .navbar.is-danger .navbar-start .navbar-link,
+      .navbar.is-danger .navbar-end > .navbar-item,
+      .navbar.is-danger .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-danger .navbar-start > a.navbar-item:focus, .navbar.is-danger .navbar-start > a.navbar-item:hover, .navbar.is-danger .navbar-start > a.navbar-item.is-active,
+      .navbar.is-danger .navbar-start .navbar-link:focus,
+      .navbar.is-danger .navbar-start .navbar-link:hover,
+      .navbar.is-danger .navbar-start .navbar-link.is-active,
+      .navbar.is-danger .navbar-end > a.navbar-item:focus,
+      .navbar.is-danger .navbar-end > a.navbar-item:hover,
+      .navbar.is-danger .navbar-end > a.navbar-item.is-active,
+      .navbar.is-danger .navbar-end .navbar-link:focus,
+      .navbar.is-danger .navbar-end .navbar-link:hover,
+      .navbar.is-danger .navbar-end .navbar-link.is-active {
+        background-color: #8a0029;
+        color: #fff; }
+      .navbar.is-danger .navbar-start .navbar-link::after,
+      .navbar.is-danger .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-danger .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-danger .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-danger .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #8a0029;
+        color: #fff; }
+      .navbar.is-danger .navbar-dropdown a.navbar-item.is-active {
+        background-color: #A30031;
+        color: #fff; } }
+  .navbar > .container {
+    align-items: stretch;
+    display: flex;
+    min-height: 3.75rem;
+    width: 100%; }
+  .navbar.has-shadow {
+    box-shadow: 0 2px 0 0 #f5f5f5; }
+  .navbar.is-fixed-bottom, .navbar.is-fixed-top {
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30; }
+  .navbar.is-fixed-bottom {
+    bottom: 0; }
+    .navbar.is-fixed-bottom.has-shadow {
+      box-shadow: 0 -2px 0 0 #f5f5f5; }
+  .navbar.is-fixed-top {
+    top: 0; }
 
 html.has-navbar-fixed-top,
 body.has-navbar-fixed-top {
-  padding-top: 3.75rem;
-}
+  padding-top: 3.75rem; }
 html.has-navbar-fixed-bottom,
 body.has-navbar-fixed-bottom {
-  padding-bottom: 3.75rem;
-}
+  padding-bottom: 3.75rem; }
 
 .navbar-brand,
 .navbar-tabs {
   align-items: stretch;
   display: flex;
   flex-shrink: 0;
-  min-height: 3.75rem;
-}
+  min-height: 3.75rem; }
 
 .navbar-brand a.navbar-item:focus, .navbar-brand a.navbar-item:hover {
-  background-color: transparent;
-}
+  background-color: transparent; }
 
 .navbar-tabs {
   -webkit-overflow-scrolling: touch;
   max-width: 100vw;
   overflow-x: auto;
-  overflow-y: hidden;
-}
+  overflow-y: hidden; }
 
 .navbar-burger {
   color: #83858D;
@@ -2042,45 +1658,35 @@ body.has-navbar-fixed-bottom {
   height: 3.75rem;
   position: relative;
   width: 3.75rem;
-  margin-left: auto;
-}
-.navbar-burger span {
-  background-color: currentColor;
-  display: block;
-  height: 1px;
-  left: calc(50% - 8px);
-  position: absolute;
-  transform-origin: center;
-  transition-duration: 86ms;
-  transition-property: background-color, opacity, transform;
-  transition-timing-function: ease-out;
-  width: 16px;
-}
-.navbar-burger span:nth-child(1) {
-  top: calc(50% - 6px);
-}
-.navbar-burger span:nth-child(2) {
-  top: calc(50% - 1px);
-}
-.navbar-burger span:nth-child(3) {
-  top: calc(50% + 4px);
-}
-.navbar-burger:hover {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-.navbar-burger.is-active span:nth-child(1) {
-  transform: translateY(5px) rotate(45deg);
-}
-.navbar-burger.is-active span:nth-child(2) {
-  opacity: 0;
-}
-.navbar-burger.is-active span:nth-child(3) {
-  transform: translateY(-5px) rotate(-45deg);
-}
+  margin-left: auto; }
+  .navbar-burger span {
+    background-color: currentColor;
+    display: block;
+    height: 1px;
+    left: calc(50% - 8px);
+    position: absolute;
+    transform-origin: center;
+    transition-duration: 86ms;
+    transition-property: background-color, opacity, transform;
+    transition-timing-function: ease-out;
+    width: 16px; }
+    .navbar-burger span:nth-child(1) {
+      top: calc(50% - 6px); }
+    .navbar-burger span:nth-child(2) {
+      top: calc(50% - 1px); }
+    .navbar-burger span:nth-child(3) {
+      top: calc(50% + 4px); }
+  .navbar-burger:hover {
+    background-color: rgba(0, 0, 0, 0.05); }
+  .navbar-burger.is-active span:nth-child(1) {
+    transform: translateY(5px) rotate(45deg); }
+  .navbar-burger.is-active span:nth-child(2) {
+    opacity: 0; }
+  .navbar-burger.is-active span:nth-child(3) {
+    transform: translateY(-5px) rotate(-45deg); }
 
 .navbar-menu {
-  display: none;
-}
+  display: none; }
 
 .navbar-item,
 .navbar-link {
@@ -2088,221 +1694,185 @@ body.has-navbar-fixed-bottom {
   display: block;
   line-height: 1.5;
   padding: 0.5rem 0.75rem;
-  position: relative;
-}
-.navbar-item .icon:only-child,
-.navbar-link .icon:only-child {
-  margin-left: -0.25rem;
-  margin-right: -0.25rem;
-}
+  position: relative; }
+  .navbar-item .icon:only-child,
+  .navbar-link .icon:only-child {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem; }
 
 a.navbar-item,
 .navbar-link {
-  cursor: pointer;
-}
-a.navbar-item:focus, a.navbar-item:focus-within, a.navbar-item:hover, a.navbar-item.is-active,
-.navbar-link:focus,
-.navbar-link:focus-within,
-.navbar-link:hover,
-.navbar-link.is-active {
-  background-color: #f7f7f7;
-  color: #004FB3;
-}
+  cursor: pointer; }
+  a.navbar-item:focus, a.navbar-item:focus-within, a.navbar-item:hover, a.navbar-item.is-active,
+  .navbar-link:focus,
+  .navbar-link:focus-within,
+  .navbar-link:hover,
+  .navbar-link.is-active {
+    background-color: #f7f7f7;
+    color: #004FB3; }
 
 .navbar-item {
   flex-grow: 0;
-  flex-shrink: 0;
-}
-.navbar-item img {
-  max-height: 1.75rem;
-}
-.navbar-item.has-dropdown {
-  padding: 0;
-}
-.navbar-item.is-expanded {
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-.navbar-item.is-tab {
-  border-bottom: 1px solid transparent;
-  min-height: 3.75rem;
-  padding-bottom: calc(0.5rem - 1px);
-}
-.navbar-item.is-tab:focus, .navbar-item.is-tab:hover {
-  background-color: transparent;
-  border-bottom-color: #004FB3;
-}
-.navbar-item.is-tab.is-active {
-  background-color: transparent;
-  border-bottom-color: #004FB3;
-  border-bottom-style: solid;
-  border-bottom-width: 3px;
-  color: #004FB3;
-  padding-bottom: calc(0.5rem - 3px);
-}
+  flex-shrink: 0; }
+  .navbar-item img {
+    max-height: 1.75rem; }
+  .navbar-item.has-dropdown {
+    padding: 0; }
+  .navbar-item.is-expanded {
+    flex-grow: 1;
+    flex-shrink: 1; }
+  .navbar-item.is-tab {
+    border-bottom: 1px solid transparent;
+    min-height: 3.75rem;
+    padding-bottom: calc(0.5rem - 1px); }
+    .navbar-item.is-tab:focus, .navbar-item.is-tab:hover {
+      background-color: transparent;
+      border-bottom-color: #004FB3; }
+    .navbar-item.is-tab.is-active {
+      background-color: transparent;
+      border-bottom-color: #004FB3;
+      border-bottom-style: solid;
+      border-bottom-width: 3px;
+      color: #004FB3;
+      padding-bottom: calc(0.5rem - 3px); }
 
 .navbar-content {
   flex-grow: 1;
-  flex-shrink: 1;
-}
+  flex-shrink: 1; }
 
 .navbar-link:not(.is-arrowless) {
-  padding-right: 2.5em;
-}
-.navbar-link:not(.is-arrowless)::after {
-  border-color: #004FB3;
-  margin-top: -0.375em;
-  right: 1.125em;
-}
+  padding-right: 2.5em; }
+  .navbar-link:not(.is-arrowless)::after {
+    border-color: #004FB3;
+    margin-top: -0.375em;
+    right: 1.125em; }
 
 .navbar-dropdown {
   font-size: 0.875rem;
   padding-bottom: 0.5rem;
-  padding-top: 0.5rem;
-}
-.navbar-dropdown .navbar-item {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-}
+  padding-top: 0.5rem; }
+  .navbar-dropdown .navbar-item {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem; }
 
 .navbar-divider {
   background-color: #f5f5f5;
   border: none;
   display: none;
   height: 2px;
-  margin: 0.5rem 0;
-}
+  margin: 0.5rem 0; }
 
 @media screen and (max-width: 1203px) {
   .navbar > .container {
-    display: block;
-  }
+    display: block; }
+
   .navbar-brand .navbar-item,
-.navbar-tabs .navbar-item {
+  .navbar-tabs .navbar-item {
     align-items: center;
-    display: flex;
-  }
+    display: flex; }
+
   .navbar-link::after {
-    display: none;
-  }
+    display: none; }
+
   .navbar-menu {
     background-color: #fafafa;
     box-shadow: 0 8px 16px rgba(3, 3, 3, 0.1);
-    padding: 0.5rem 0;
-  }
-  .navbar-menu.is-active {
-    display: block;
-  }
+    padding: 0.5rem 0; }
+    .navbar-menu.is-active {
+      display: block; }
+
   .navbar.is-fixed-bottom-touch, .navbar.is-fixed-top-touch {
     left: 0;
     position: fixed;
     right: 0;
-    z-index: 30;
-  }
+    z-index: 30; }
   .navbar.is-fixed-bottom-touch {
-    bottom: 0;
-  }
-  .navbar.is-fixed-bottom-touch.has-shadow {
-    box-shadow: 0 -2px 3px rgba(3, 3, 3, 0.1);
-  }
+    bottom: 0; }
+    .navbar.is-fixed-bottom-touch.has-shadow {
+      box-shadow: 0 -2px 3px rgba(3, 3, 3, 0.1); }
   .navbar.is-fixed-top-touch {
-    top: 0;
-  }
+    top: 0; }
   .navbar.is-fixed-top .navbar-menu, .navbar.is-fixed-top-touch .navbar-menu {
     -webkit-overflow-scrolling: touch;
     max-height: calc(100vh - 3.75rem);
-    overflow: auto;
-  }
+    overflow: auto; }
+
   html.has-navbar-fixed-top-touch,
-body.has-navbar-fixed-top-touch {
-    padding-top: 3.75rem;
-  }
+  body.has-navbar-fixed-top-touch {
+    padding-top: 3.75rem; }
   html.has-navbar-fixed-bottom-touch,
-body.has-navbar-fixed-bottom-touch {
-    padding-bottom: 3.75rem;
-  }
-}
+  body.has-navbar-fixed-bottom-touch {
+    padding-bottom: 3.75rem; } }
 @media screen and (min-width: 1204px) {
   .navbar,
-.navbar-menu,
-.navbar-start,
-.navbar-end {
+  .navbar-menu,
+  .navbar-start,
+  .navbar-end {
     align-items: stretch;
-    display: flex;
-  }
+    display: flex; }
+
   .navbar {
-    min-height: 3.75rem;
-  }
-  .navbar.is-spaced {
-    padding: 1rem 2rem;
-  }
-  .navbar.is-spaced .navbar-start,
-.navbar.is-spaced .navbar-end {
-    align-items: center;
-  }
-  .navbar.is-spaced a.navbar-item,
-.navbar.is-spaced .navbar-link {
-    border-radius: 4px;
-  }
-  .navbar.is-transparent a.navbar-item:focus, .navbar.is-transparent a.navbar-item:hover, .navbar.is-transparent a.navbar-item.is-active,
-.navbar.is-transparent .navbar-link:focus,
-.navbar.is-transparent .navbar-link:hover,
-.navbar.is-transparent .navbar-link.is-active {
-    background-color: transparent !important;
-  }
-  .navbar.is-transparent .navbar-item.has-dropdown.is-active .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus-within .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:hover .navbar-link {
-    background-color: transparent !important;
-  }
-  .navbar.is-transparent .navbar-dropdown a.navbar-item:focus, .navbar.is-transparent .navbar-dropdown a.navbar-item:hover {
-    background-color: #f5f5f5;
-    color: #030303;
-  }
-  .navbar.is-transparent .navbar-dropdown a.navbar-item.is-active {
-    background-color: #f5f5f5;
-    color: #004FB3;
-  }
+    min-height: 3.75rem; }
+    .navbar.is-spaced {
+      padding: 1rem 2rem; }
+      .navbar.is-spaced .navbar-start,
+      .navbar.is-spaced .navbar-end {
+        align-items: center; }
+      .navbar.is-spaced a.navbar-item,
+      .navbar.is-spaced .navbar-link {
+        border-radius: 4px; }
+    .navbar.is-transparent a.navbar-item:focus, .navbar.is-transparent a.navbar-item:hover, .navbar.is-transparent a.navbar-item.is-active,
+    .navbar.is-transparent .navbar-link:focus,
+    .navbar.is-transparent .navbar-link:hover,
+    .navbar.is-transparent .navbar-link.is-active {
+      background-color: transparent !important; }
+    .navbar.is-transparent .navbar-item.has-dropdown.is-active .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus-within .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:hover .navbar-link {
+      background-color: transparent !important; }
+    .navbar.is-transparent .navbar-dropdown a.navbar-item:focus, .navbar.is-transparent .navbar-dropdown a.navbar-item:hover {
+      background-color: #f5f5f5;
+      color: #030303; }
+    .navbar.is-transparent .navbar-dropdown a.navbar-item.is-active {
+      background-color: #f5f5f5;
+      color: #004FB3; }
+
   .navbar-burger {
-    display: none;
-  }
+    display: none; }
+
   .navbar-item,
-.navbar-link {
+  .navbar-link {
     align-items: center;
-    display: flex;
-  }
+    display: flex; }
+
   .navbar-item.has-dropdown {
-    align-items: stretch;
-  }
+    align-items: stretch; }
   .navbar-item.has-dropdown-up .navbar-link::after {
-    transform: rotate(135deg) translate(0.25em, -0.25em);
-  }
+    transform: rotate(135deg) translate(0.25em, -0.25em); }
   .navbar-item.has-dropdown-up .navbar-dropdown {
     border-bottom: 2px solid #e5e5e5;
     border-radius: 6px 6px 0 0;
     border-top: none;
     bottom: 100%;
     box-shadow: 0 -8px 8px rgba(3, 3, 3, 0.1);
-    top: auto;
-  }
+    top: auto; }
   .navbar-item.is-active .navbar-dropdown, .navbar-item.is-hoverable:focus .navbar-dropdown, .navbar-item.is-hoverable:focus-within .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown {
-    display: block;
-  }
-  .navbar.is-spaced .navbar-item.is-active .navbar-dropdown, .navbar-item.is-active .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:focus .navbar-dropdown, .navbar-item.is-hoverable:focus .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:focus-within .navbar-dropdown, .navbar-item.is-hoverable:focus-within .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:hover .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown.is-boxed {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
-  }
+    display: block; }
+    .navbar.is-spaced .navbar-item.is-active .navbar-dropdown, .navbar-item.is-active .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:focus .navbar-dropdown, .navbar-item.is-hoverable:focus .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:focus-within .navbar-dropdown, .navbar-item.is-hoverable:focus-within .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:hover .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown.is-boxed {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0); }
+
   .navbar-menu {
     flex-grow: 1;
-    flex-shrink: 0;
-  }
+    flex-shrink: 0; }
+
   .navbar-start {
     justify-content: flex-start;
-    margin-right: auto;
-  }
+    margin-right: auto; }
+
   .navbar-end {
     justify-content: flex-end;
-    margin-left: auto;
-  }
+    margin-left: auto; }
+
   .navbar-dropdown {
     background-color: #fafafa;
     border-bottom-left-radius: 6px;
@@ -2315,115 +1885,94 @@ body.has-navbar-fixed-bottom-touch {
     min-width: 100%;
     position: absolute;
     top: 100%;
-    z-index: 20;
-  }
-  .navbar-dropdown .navbar-item {
-    padding: 0.375rem 1rem;
-    white-space: nowrap;
-  }
-  .navbar-dropdown a.navbar-item {
-    padding-right: 3rem;
-  }
-  .navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover {
-    background-color: #f5f5f5;
-    color: #030303;
-  }
-  .navbar-dropdown a.navbar-item.is-active {
-    background-color: #f5f5f5;
-    color: #004FB3;
-  }
-  .navbar.is-spaced .navbar-dropdown, .navbar-dropdown.is-boxed {
-    border-radius: 6px;
-    border-top: none;
-    box-shadow: 0 8px 8px rgba(3, 3, 3, 0.1), 0 0 0 1px rgba(3, 3, 3, 0.1);
-    display: block;
-    opacity: 0;
-    pointer-events: none;
-    top: calc(100% + (-4px));
-    transform: translateY(-5px);
-    transition-duration: 86ms;
-    transition-property: opacity, transform;
-  }
-  .navbar-dropdown.is-right {
-    left: auto;
-    right: 0;
-  }
+    z-index: 20; }
+    .navbar-dropdown .navbar-item {
+      padding: 0.375rem 1rem;
+      white-space: nowrap; }
+    .navbar-dropdown a.navbar-item {
+      padding-right: 3rem; }
+      .navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover {
+        background-color: #f5f5f5;
+        color: #030303; }
+      .navbar-dropdown a.navbar-item.is-active {
+        background-color: #f5f5f5;
+        color: #004FB3; }
+    .navbar.is-spaced .navbar-dropdown, .navbar-dropdown.is-boxed {
+      border-radius: 6px;
+      border-top: none;
+      box-shadow: 0 8px 8px rgba(3, 3, 3, 0.1), 0 0 0 1px rgba(3, 3, 3, 0.1);
+      display: block;
+      opacity: 0;
+      pointer-events: none;
+      top: calc(100% + (-4px));
+      transform: translateY(-5px);
+      transition-duration: 86ms;
+      transition-property: opacity, transform; }
+    .navbar-dropdown.is-right {
+      left: auto;
+      right: 0; }
+
   .navbar-divider {
-    display: block;
-  }
+    display: block; }
+
   .navbar > .container .navbar-brand,
-.container > .navbar .navbar-brand {
-    margin-left: -0.75rem;
-  }
+  .container > .navbar .navbar-brand {
+    margin-left: -0.75rem; }
   .navbar > .container .navbar-menu,
-.container > .navbar .navbar-menu {
-    margin-right: -0.75rem;
-  }
+  .container > .navbar .navbar-menu {
+    margin-right: -0.75rem; }
+
   .navbar.is-fixed-bottom-desktop, .navbar.is-fixed-top-desktop {
     left: 0;
     position: fixed;
     right: 0;
-    z-index: 30;
-  }
+    z-index: 30; }
   .navbar.is-fixed-bottom-desktop {
-    bottom: 0;
-  }
-  .navbar.is-fixed-bottom-desktop.has-shadow {
-    box-shadow: 0 -2px 3px rgba(3, 3, 3, 0.1);
-  }
+    bottom: 0; }
+    .navbar.is-fixed-bottom-desktop.has-shadow {
+      box-shadow: 0 -2px 3px rgba(3, 3, 3, 0.1); }
   .navbar.is-fixed-top-desktop {
-    top: 0;
-  }
+    top: 0; }
+
   html.has-navbar-fixed-top-desktop,
-body.has-navbar-fixed-top-desktop {
-    padding-top: 3.75rem;
-  }
+  body.has-navbar-fixed-top-desktop {
+    padding-top: 3.75rem; }
   html.has-navbar-fixed-bottom-desktop,
-body.has-navbar-fixed-bottom-desktop {
-    padding-bottom: 3.75rem;
-  }
+  body.has-navbar-fixed-bottom-desktop {
+    padding-bottom: 3.75rem; }
   html.has-spaced-navbar-fixed-top,
-body.has-spaced-navbar-fixed-top {
-    padding-top: 5.75rem;
-  }
+  body.has-spaced-navbar-fixed-top {
+    padding-top: 5.75rem; }
   html.has-spaced-navbar-fixed-bottom,
-body.has-spaced-navbar-fixed-bottom {
-    padding-bottom: 5.75rem;
-  }
+  body.has-spaced-navbar-fixed-bottom {
+    padding-bottom: 5.75rem; }
+
   a.navbar-item.is-active,
-.navbar-link.is-active {
-    color: #030303;
-  }
+  .navbar-link.is-active {
+    color: #030303; }
   a.navbar-item.is-active:not(:focus):not(:hover),
-.navbar-link.is-active:not(:focus):not(:hover) {
-    background-color: transparent;
-  }
+  .navbar-link.is-active:not(:focus):not(:hover) {
+    background-color: transparent; }
+
   .navbar-item.has-dropdown:focus .navbar-link, .navbar-item.has-dropdown:hover .navbar-link, .navbar-item.has-dropdown.is-active .navbar-link {
-    background-color: #f7f7f7;
-  }
-}
+    background-color: #f7f7f7; } }
 .hero.is-fullheight-with-navbar {
-  min-height: calc(100vh - 3.75rem);
-}
+  min-height: calc(100vh - 3.75rem); }
 
 .dropdown {
   display: inline-flex;
   position: relative;
-  vertical-align: top;
-}
-.dropdown.is-active .dropdown-menu, .dropdown.is-hoverable:hover .dropdown-menu {
-  display: block;
-}
-.dropdown.is-right .dropdown-menu {
-  left: auto;
-  right: 0;
-}
-.dropdown.is-up .dropdown-menu {
-  bottom: 100%;
-  padding-bottom: 4px;
-  padding-top: initial;
-  top: auto;
-}
+  vertical-align: top; }
+  .dropdown.is-active .dropdown-menu, .dropdown.is-hoverable:hover .dropdown-menu {
+    display: block; }
+  .dropdown.is-right .dropdown-menu {
+    left: auto;
+    right: 0; }
+  .dropdown.is-up .dropdown-menu {
+    bottom: 100%;
+    padding-bottom: 4px;
+    padding-top: initial;
+    top: auto; }
 
 .dropdown-menu {
   display: none;
@@ -2432,16 +1981,14 @@ body.has-spaced-navbar-fixed-bottom {
   padding-top: 4px;
   position: absolute;
   top: 100%;
-  z-index: 20;
-}
+  z-index: 20; }
 
 .dropdown-content {
   background-color: #fafafa;
   border-radius: 4px;
   box-shadow: 0 0.5em 1em -0.125em rgba(3, 3, 3, 0.1), 0 0px 0 1px rgba(3, 3, 3, 0.02);
   padding-bottom: 0.5rem;
-  padding-top: 0.5rem;
-}
+  padding-top: 0.5rem; }
 
 .dropdown-item {
   color: #83858D;
@@ -2449,34 +1996,29 @@ body.has-spaced-navbar-fixed-bottom {
   font-size: 0.875rem;
   line-height: 1.5;
   padding: 0.375rem 1rem;
-  position: relative;
-}
+  position: relative; }
 
 a.dropdown-item,
 button.dropdown-item {
   padding-right: 3rem;
   text-align: inherit;
   white-space: nowrap;
-  width: 100%;
-}
-a.dropdown-item:hover,
-button.dropdown-item:hover {
-  background-color: #f5f5f5;
-  color: #030303;
-}
-a.dropdown-item.is-active,
-button.dropdown-item.is-active {
-  background-color: #004FB3;
-  color: #fff;
-}
+  width: 100%; }
+  a.dropdown-item:hover,
+  button.dropdown-item:hover {
+    background-color: #f5f5f5;
+    color: #030303; }
+  a.dropdown-item.is-active,
+  button.dropdown-item.is-active {
+    background-color: #004FB3;
+    color: #fff; }
 
 .dropdown-divider {
   background-color: #f2f2f2;
   border: none;
   display: block;
   height: 1px;
-  margin: 0.5rem 0;
-}
+  margin: 0.5rem 0; }
 
 .box {
   background-color: #fafafa;
@@ -2484,15 +2026,12 @@ button.dropdown-item.is-active {
   box-shadow: 0 0.5em 1em -0.125em rgba(3, 3, 3, 0.1), 0 0px 0 1px rgba(3, 3, 3, 0.02);
   color: #83858D;
   display: block;
-  padding: 1.25rem;
-}
+  padding: 1.25rem; }
 
 a.box:hover, a.box:focus {
-  box-shadow: 0 0.5em 1em -0.125em rgba(3, 3, 3, 0.1), 0 0 0 1px #004FB3;
-}
+  box-shadow: 0 0.5em 1em -0.125em rgba(3, 3, 3, 0.1), 0 0 0 1px #004FB3; }
 a.box:active {
-  box-shadow: inset 0 1px 2px rgba(3, 3, 3, 0.2), 0 0 0 1px #004FB3;
-}
+  box-shadow: inset 0 1px 2px rgba(3, 3, 3, 0.2), 0 0 0 1px #004FB3; }
 
 .button {
   background-color: #fafafa;
@@ -2506,1154 +2045,890 @@ a.box:active {
   padding-right: 1em;
   padding-top: calc(0.5em - 1px);
   text-align: center;
-  white-space: nowrap;
-}
-.button strong {
-  color: inherit;
-}
-.button .icon, .button .icon.is-small, .button .icon.is-medium, .button .icon.is-large {
-  height: 1.5em;
-  width: 1.5em;
-}
-.button .icon:first-child:not(:last-child) {
-  margin-left: calc(-0.5em - 1px);
-  margin-right: 0.25em;
-}
-.button .icon:last-child:not(:first-child) {
-  margin-left: 0.25em;
-  margin-right: calc(-0.5em - 1px);
-}
-.button .icon:first-child:last-child {
-  margin-left: calc(-0.5em - 1px);
-  margin-right: calc(-0.5em - 1px);
-}
-.button:hover, .button.is-hovered {
-  border-color: #d8d8d8;
-  color: #3A3D4E;
-}
-.button:focus, .button.is-focused {
-  border-color: #004FB3;
-  color: #3A3D4E;
-}
-.button:focus:not(:active), .button.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25);
-}
-.button:active, .button.is-active {
-  border-color: #83858D;
-  color: #3A3D4E;
-}
-.button.is-text {
-  background-color: transparent;
-  border-color: transparent;
-  color: #83858D;
-  text-decoration: underline;
-}
-.button.is-text:hover, .button.is-text.is-hovered, .button.is-text:focus, .button.is-text.is-focused {
-  background-color: #f5f5f5;
-  color: #3A3D4E;
-}
-.button.is-text:active, .button.is-text.is-active {
-  background-color: #e8e8e8;
-  color: #3A3D4E;
-}
-.button.is-text[disabled], fieldset[disabled] .button.is-text {
-  background-color: transparent;
-  border-color: transparent;
-  box-shadow: none;
-}
-.button.is-ghost {
-  background: none;
-  border-color: transparent;
-  color: #004FB3;
-  text-decoration: none;
-}
-.button.is-ghost:hover, .button.is-ghost.is-hovered {
-  color: #004FB3;
-  text-decoration: underline;
-}
-.button.is-white {
-  background-color: #fafafa;
-  border-color: transparent;
-  color: #030303;
-}
-.button.is-white:hover, .button.is-white.is-hovered {
-  background-color: #f4f4f4;
-  border-color: transparent;
-  color: #030303;
-}
-.button.is-white:focus, .button.is-white.is-focused {
-  border-color: transparent;
-  color: #030303;
-}
-.button.is-white:focus:not(:active), .button.is-white.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(250, 250, 250, 0.25);
-}
-.button.is-white:active, .button.is-white.is-active {
-  background-color: #ededed;
-  border-color: transparent;
-  color: #030303;
-}
-.button.is-white[disabled], fieldset[disabled] .button.is-white {
-  background-color: #fafafa;
-  border-color: #fafafa;
-  box-shadow: none;
-}
-.button.is-white.is-inverted {
-  background-color: #030303;
-  color: #fafafa;
-}
-.button.is-white.is-inverted:hover, .button.is-white.is-inverted.is-hovered {
-  background-color: black;
-}
-.button.is-white.is-inverted[disabled], fieldset[disabled] .button.is-white.is-inverted {
-  background-color: #030303;
-  border-color: transparent;
-  box-shadow: none;
-  color: #fafafa;
-}
-.button.is-white.is-loading::after {
-  border-color: transparent transparent #030303 #030303 !important;
-}
-.button.is-white.is-outlined {
-  background-color: transparent;
-  border-color: #fafafa;
-  color: #fafafa;
-}
-.button.is-white.is-outlined:hover, .button.is-white.is-outlined.is-hovered, .button.is-white.is-outlined:focus, .button.is-white.is-outlined.is-focused {
-  background-color: #fafafa;
-  border-color: #fafafa;
-  color: #030303;
-}
-.button.is-white.is-outlined.is-loading::after {
-  border-color: transparent transparent #fafafa #fafafa !important;
-}
-.button.is-white.is-outlined.is-loading:hover::after, .button.is-white.is-outlined.is-loading.is-hovered::after, .button.is-white.is-outlined.is-loading:focus::after, .button.is-white.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #030303 #030303 !important;
-}
-.button.is-white.is-outlined[disabled], fieldset[disabled] .button.is-white.is-outlined {
-  background-color: transparent;
-  border-color: #fafafa;
-  box-shadow: none;
-  color: #fafafa;
-}
-.button.is-white.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #030303;
-  color: #030303;
-}
-.button.is-white.is-inverted.is-outlined:hover, .button.is-white.is-inverted.is-outlined.is-hovered, .button.is-white.is-inverted.is-outlined:focus, .button.is-white.is-inverted.is-outlined.is-focused {
-  background-color: #030303;
-  color: #fafafa;
-}
-.button.is-white.is-inverted.is-outlined.is-loading:hover::after, .button.is-white.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-white.is-inverted.is-outlined.is-loading:focus::after, .button.is-white.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #fafafa #fafafa !important;
-}
-.button.is-white.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-white.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #030303;
-  box-shadow: none;
-  color: #030303;
-}
-.button.is-black {
-  background-color: #030303;
-  border-color: transparent;
-  color: #fafafa;
-}
-.button.is-black:hover, .button.is-black.is-hovered {
-  background-color: black;
-  border-color: transparent;
-  color: #fafafa;
-}
-.button.is-black:focus, .button.is-black.is-focused {
-  border-color: transparent;
-  color: #fafafa;
-}
-.button.is-black:focus:not(:active), .button.is-black.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(3, 3, 3, 0.25);
-}
-.button.is-black:active, .button.is-black.is-active {
-  background-color: black;
-  border-color: transparent;
-  color: #fafafa;
-}
-.button.is-black[disabled], fieldset[disabled] .button.is-black {
-  background-color: #030303;
-  border-color: #030303;
-  box-shadow: none;
-}
-.button.is-black.is-inverted {
-  background-color: #fafafa;
-  color: #030303;
-}
-.button.is-black.is-inverted:hover, .button.is-black.is-inverted.is-hovered {
-  background-color: #ededed;
-}
-.button.is-black.is-inverted[disabled], fieldset[disabled] .button.is-black.is-inverted {
-  background-color: #fafafa;
-  border-color: transparent;
-  box-shadow: none;
-  color: #030303;
-}
-.button.is-black.is-loading::after {
-  border-color: transparent transparent #fafafa #fafafa !important;
-}
-.button.is-black.is-outlined {
-  background-color: transparent;
-  border-color: #030303;
-  color: #030303;
-}
-.button.is-black.is-outlined:hover, .button.is-black.is-outlined.is-hovered, .button.is-black.is-outlined:focus, .button.is-black.is-outlined.is-focused {
-  background-color: #030303;
-  border-color: #030303;
-  color: #fafafa;
-}
-.button.is-black.is-outlined.is-loading::after {
-  border-color: transparent transparent #030303 #030303 !important;
-}
-.button.is-black.is-outlined.is-loading:hover::after, .button.is-black.is-outlined.is-loading.is-hovered::after, .button.is-black.is-outlined.is-loading:focus::after, .button.is-black.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #fafafa #fafafa !important;
-}
-.button.is-black.is-outlined[disabled], fieldset[disabled] .button.is-black.is-outlined {
-  background-color: transparent;
-  border-color: #030303;
-  box-shadow: none;
-  color: #030303;
-}
-.button.is-black.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fafafa;
-  color: #fafafa;
-}
-.button.is-black.is-inverted.is-outlined:hover, .button.is-black.is-inverted.is-outlined.is-hovered, .button.is-black.is-inverted.is-outlined:focus, .button.is-black.is-inverted.is-outlined.is-focused {
-  background-color: #fafafa;
-  color: #030303;
-}
-.button.is-black.is-inverted.is-outlined.is-loading:hover::after, .button.is-black.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-black.is-inverted.is-outlined.is-loading:focus::after, .button.is-black.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #030303 #030303 !important;
-}
-.button.is-black.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-black.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fafafa;
-  box-shadow: none;
-  color: #fafafa;
-}
-.button.is-light {
-  background-color: #f5f5f5;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-light:hover, .button.is-light.is-hovered {
-  background-color: #efefef;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-light:focus, .button.is-light.is-focused {
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-light:focus:not(:active), .button.is-light.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
-}
-.button.is-light:active, .button.is-light.is-active {
-  background-color: #e8e8e8;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-light[disabled], fieldset[disabled] .button.is-light {
-  background-color: #f5f5f5;
-  border-color: #f5f5f5;
-  box-shadow: none;
-}
-.button.is-light.is-inverted {
-  background-color: rgba(0, 0, 0, 0.7);
-  color: #f5f5f5;
-}
-.button.is-light.is-inverted:hover, .button.is-light.is-inverted.is-hovered {
-  background-color: rgba(0, 0, 0, 0.7);
-}
-.button.is-light.is-inverted[disabled], fieldset[disabled] .button.is-light.is-inverted {
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: transparent;
-  box-shadow: none;
-  color: #f5f5f5;
-}
-.button.is-light.is-loading::after {
-  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
-}
-.button.is-light.is-outlined {
-  background-color: transparent;
-  border-color: #f5f5f5;
-  color: #f5f5f5;
-}
-.button.is-light.is-outlined:hover, .button.is-light.is-outlined.is-hovered, .button.is-light.is-outlined:focus, .button.is-light.is-outlined.is-focused {
-  background-color: #f5f5f5;
-  border-color: #f5f5f5;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-light.is-outlined.is-loading::after {
-  border-color: transparent transparent #f5f5f5 #f5f5f5 !important;
-}
-.button.is-light.is-outlined.is-loading:hover::after, .button.is-light.is-outlined.is-loading.is-hovered::after, .button.is-light.is-outlined.is-loading:focus::after, .button.is-light.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
-}
-.button.is-light.is-outlined[disabled], fieldset[disabled] .button.is-light.is-outlined {
-  background-color: transparent;
-  border-color: #f5f5f5;
-  box-shadow: none;
-  color: #f5f5f5;
-}
-.button.is-light.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: rgba(0, 0, 0, 0.7);
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-light.is-inverted.is-outlined:hover, .button.is-light.is-inverted.is-outlined.is-hovered, .button.is-light.is-inverted.is-outlined:focus, .button.is-light.is-inverted.is-outlined.is-focused {
-  background-color: rgba(0, 0, 0, 0.7);
-  color: #f5f5f5;
-}
-.button.is-light.is-inverted.is-outlined.is-loading:hover::after, .button.is-light.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-light.is-inverted.is-outlined.is-loading:focus::after, .button.is-light.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #f5f5f5 #f5f5f5 !important;
-}
-.button.is-light.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-light.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: rgba(0, 0, 0, 0.7);
-  box-shadow: none;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-dark {
-  background-color: #3A3D4E;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-dark:hover, .button.is-dark.is-hovered {
-  background-color: #353747;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-dark:focus, .button.is-dark.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-dark:focus:not(:active), .button.is-dark.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(58, 61, 78, 0.25);
-}
-.button.is-dark:active, .button.is-dark.is-active {
-  background-color: #2f323f;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-dark[disabled], fieldset[disabled] .button.is-dark {
-  background-color: #3A3D4E;
-  border-color: #3A3D4E;
-  box-shadow: none;
-}
-.button.is-dark.is-inverted {
-  background-color: #fff;
-  color: #3A3D4E;
-}
-.button.is-dark.is-inverted:hover, .button.is-dark.is-inverted.is-hovered {
-  background-color: #f2f2f2;
-}
-.button.is-dark.is-inverted[disabled], fieldset[disabled] .button.is-dark.is-inverted {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #3A3D4E;
-}
-.button.is-dark.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-dark.is-outlined {
-  background-color: transparent;
-  border-color: #3A3D4E;
-  color: #3A3D4E;
-}
-.button.is-dark.is-outlined:hover, .button.is-dark.is-outlined.is-hovered, .button.is-dark.is-outlined:focus, .button.is-dark.is-outlined.is-focused {
-  background-color: #3A3D4E;
-  border-color: #3A3D4E;
-  color: #fff;
-}
-.button.is-dark.is-outlined.is-loading::after {
-  border-color: transparent transparent #3A3D4E #3A3D4E !important;
-}
-.button.is-dark.is-outlined.is-loading:hover::after, .button.is-dark.is-outlined.is-loading.is-hovered::after, .button.is-dark.is-outlined.is-loading:focus::after, .button.is-dark.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-dark.is-outlined[disabled], fieldset[disabled] .button.is-dark.is-outlined {
-  background-color: transparent;
-  border-color: #3A3D4E;
-  box-shadow: none;
-  color: #3A3D4E;
-}
-.button.is-dark.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-dark.is-inverted.is-outlined:hover, .button.is-dark.is-inverted.is-outlined.is-hovered, .button.is-dark.is-inverted.is-outlined:focus, .button.is-dark.is-inverted.is-outlined.is-focused {
-  background-color: #fff;
-  color: #3A3D4E;
-}
-.button.is-dark.is-inverted.is-outlined.is-loading:hover::after, .button.is-dark.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-dark.is-inverted.is-outlined.is-loading:focus::after, .button.is-dark.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #3A3D4E #3A3D4E !important;
-}
-.button.is-dark.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-dark.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-primary {
-  background-color: #005C43;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary:hover, .button.is-primary.is-hovered {
-  background-color: #004f3a;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary:focus, .button.is-primary.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary:focus:not(:active), .button.is-primary.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(0, 92, 67, 0.25);
-}
-.button.is-primary:active, .button.is-primary.is-active {
-  background-color: #004330;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-primary[disabled], fieldset[disabled] .button.is-primary {
-  background-color: #005C43;
-  border-color: #005C43;
-  box-shadow: none;
-}
-.button.is-primary.is-inverted {
-  background-color: #fff;
-  color: #005C43;
-}
-.button.is-primary.is-inverted:hover, .button.is-primary.is-inverted.is-hovered {
-  background-color: #f2f2f2;
-}
-.button.is-primary.is-inverted[disabled], fieldset[disabled] .button.is-primary.is-inverted {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #005C43;
-}
-.button.is-primary.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-primary.is-outlined {
-  background-color: transparent;
-  border-color: #005C43;
-  color: #005C43;
-}
-.button.is-primary.is-outlined:hover, .button.is-primary.is-outlined.is-hovered, .button.is-primary.is-outlined:focus, .button.is-primary.is-outlined.is-focused {
-  background-color: #005C43;
-  border-color: #005C43;
-  color: #fff;
-}
-.button.is-primary.is-outlined.is-loading::after {
-  border-color: transparent transparent #005C43 #005C43 !important;
-}
-.button.is-primary.is-outlined.is-loading:hover::after, .button.is-primary.is-outlined.is-loading.is-hovered::after, .button.is-primary.is-outlined.is-loading:focus::after, .button.is-primary.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-primary.is-outlined[disabled], fieldset[disabled] .button.is-primary.is-outlined {
-  background-color: transparent;
-  border-color: #005C43;
-  box-shadow: none;
-  color: #005C43;
-}
-.button.is-primary.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-primary.is-inverted.is-outlined:hover, .button.is-primary.is-inverted.is-outlined.is-hovered, .button.is-primary.is-inverted.is-outlined:focus, .button.is-primary.is-inverted.is-outlined.is-focused {
-  background-color: #fff;
-  color: #005C43;
-}
-.button.is-primary.is-inverted.is-outlined.is-loading:hover::after, .button.is-primary.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-primary.is-inverted.is-outlined.is-loading:focus::after, .button.is-primary.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #005C43 #005C43 !important;
-}
-.button.is-primary.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-primary.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-primary.is-light {
-  background-color: #ebfff9;
-  color: #05ffbb;
-}
-.button.is-primary.is-light:hover, .button.is-primary.is-light.is-hovered {
-  background-color: #defff6;
-  border-color: transparent;
-  color: #05ffbb;
-}
-.button.is-primary.is-light:active, .button.is-primary.is-light.is-active {
-  background-color: #d1fff3;
-  border-color: transparent;
-  color: #05ffbb;
-}
-.button.is-link {
-  background-color: #004FB3;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link:hover, .button.is-link.is-hovered {
-  background-color: #0049a6;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link:focus, .button.is-link.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link:focus:not(:active), .button.is-link.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25);
-}
-.button.is-link:active, .button.is-link.is-active {
-  background-color: #00449a;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-link[disabled], fieldset[disabled] .button.is-link {
-  background-color: #004FB3;
-  border-color: #004FB3;
-  box-shadow: none;
-}
-.button.is-link.is-inverted {
-  background-color: #fff;
-  color: #004FB3;
-}
-.button.is-link.is-inverted:hover, .button.is-link.is-inverted.is-hovered {
-  background-color: #f2f2f2;
-}
-.button.is-link.is-inverted[disabled], fieldset[disabled] .button.is-link.is-inverted {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #004FB3;
-}
-.button.is-link.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-link.is-outlined {
-  background-color: transparent;
-  border-color: #004FB3;
-  color: #004FB3;
-}
-.button.is-link.is-outlined:hover, .button.is-link.is-outlined.is-hovered, .button.is-link.is-outlined:focus, .button.is-link.is-outlined.is-focused {
-  background-color: #004FB3;
-  border-color: #004FB3;
-  color: #fff;
-}
-.button.is-link.is-outlined.is-loading::after {
-  border-color: transparent transparent #004FB3 #004FB3 !important;
-}
-.button.is-link.is-outlined.is-loading:hover::after, .button.is-link.is-outlined.is-loading.is-hovered::after, .button.is-link.is-outlined.is-loading:focus::after, .button.is-link.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-link.is-outlined[disabled], fieldset[disabled] .button.is-link.is-outlined {
-  background-color: transparent;
-  border-color: #004FB3;
-  box-shadow: none;
-  color: #004FB3;
-}
-.button.is-link.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-link.is-inverted.is-outlined:hover, .button.is-link.is-inverted.is-outlined.is-hovered, .button.is-link.is-inverted.is-outlined:focus, .button.is-link.is-inverted.is-outlined.is-focused {
-  background-color: #fff;
-  color: #004FB3;
-}
-.button.is-link.is-inverted.is-outlined.is-loading:hover::after, .button.is-link.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-link.is-inverted.is-outlined.is-loading:focus::after, .button.is-link.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #004FB3 #004FB3 !important;
-}
-.button.is-link.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-link.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-link.is-light {
-  background-color: #ebf4ff;
-  color: #0573ff;
-}
-.button.is-link.is-light:hover, .button.is-link.is-light.is-hovered {
-  background-color: #deecff;
-  border-color: transparent;
-  color: #0573ff;
-}
-.button.is-link.is-light:active, .button.is-link.is-light.is-active {
-  background-color: #d1e5ff;
-  border-color: transparent;
-  color: #0573ff;
-}
-.button.is-info {
-  background-color: hsl(204deg, 71%, 53%);
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info:hover, .button.is-info.is-hovered {
-  background-color: #2793da;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info:focus, .button.is-info.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info:focus:not(:active), .button.is-info.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(50, 152, 220, 0.25);
-}
-.button.is-info:active, .button.is-info.is-active {
-  background-color: #238cd1;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-info[disabled], fieldset[disabled] .button.is-info {
-  background-color: hsl(204deg, 71%, 53%);
-  border-color: hsl(204deg, 71%, 53%);
-  box-shadow: none;
-}
-.button.is-info.is-inverted {
-  background-color: #fff;
-  color: hsl(204deg, 71%, 53%);
-}
-.button.is-info.is-inverted:hover, .button.is-info.is-inverted.is-hovered {
-  background-color: #f2f2f2;
-}
-.button.is-info.is-inverted[disabled], fieldset[disabled] .button.is-info.is-inverted {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: hsl(204deg, 71%, 53%);
-}
-.button.is-info.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-info.is-outlined {
-  background-color: transparent;
-  border-color: hsl(204deg, 71%, 53%);
-  color: hsl(204deg, 71%, 53%);
-}
-.button.is-info.is-outlined:hover, .button.is-info.is-outlined.is-hovered, .button.is-info.is-outlined:focus, .button.is-info.is-outlined.is-focused {
-  background-color: hsl(204deg, 71%, 53%);
-  border-color: hsl(204deg, 71%, 53%);
-  color: #fff;
-}
-.button.is-info.is-outlined.is-loading::after {
-  border-color: transparent transparent hsl(204deg, 71%, 53%) hsl(204deg, 71%, 53%) !important;
-}
-.button.is-info.is-outlined.is-loading:hover::after, .button.is-info.is-outlined.is-loading.is-hovered::after, .button.is-info.is-outlined.is-loading:focus::after, .button.is-info.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-info.is-outlined[disabled], fieldset[disabled] .button.is-info.is-outlined {
-  background-color: transparent;
-  border-color: hsl(204deg, 71%, 53%);
-  box-shadow: none;
-  color: hsl(204deg, 71%, 53%);
-}
-.button.is-info.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-info.is-inverted.is-outlined:hover, .button.is-info.is-inverted.is-outlined.is-hovered, .button.is-info.is-inverted.is-outlined:focus, .button.is-info.is-inverted.is-outlined.is-focused {
-  background-color: #fff;
-  color: hsl(204deg, 71%, 53%);
-}
-.button.is-info.is-inverted.is-outlined.is-loading:hover::after, .button.is-info.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-info.is-inverted.is-outlined.is-loading:focus::after, .button.is-info.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent hsl(204deg, 71%, 53%) hsl(204deg, 71%, 53%) !important;
-}
-.button.is-info.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-info.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-info.is-light {
-  background-color: #eef6fc;
-  color: #1d72aa;
-}
-.button.is-info.is-light:hover, .button.is-info.is-light.is-hovered {
-  background-color: #e3f1fa;
-  border-color: transparent;
-  color: #1d72aa;
-}
-.button.is-info.is-light:active, .button.is-info.is-light.is-active {
-  background-color: #d8ebf8;
-  border-color: transparent;
-  color: #1d72aa;
-}
-.button.is-success {
-  background-color: #1C6301;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success:hover, .button.is-success.is-hovered {
-  background-color: #185601;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success:focus, .button.is-success.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success:focus:not(:active), .button.is-success.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(28, 99, 1, 0.25);
-}
-.button.is-success:active, .button.is-success.is-active {
-  background-color: #154a01;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-success[disabled], fieldset[disabled] .button.is-success {
-  background-color: #1C6301;
-  border-color: #1C6301;
-  box-shadow: none;
-}
-.button.is-success.is-inverted {
-  background-color: #fff;
-  color: #1C6301;
-}
-.button.is-success.is-inverted:hover, .button.is-success.is-inverted.is-hovered {
-  background-color: #f2f2f2;
-}
-.button.is-success.is-inverted[disabled], fieldset[disabled] .button.is-success.is-inverted {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #1C6301;
-}
-.button.is-success.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-success.is-outlined {
-  background-color: transparent;
-  border-color: #1C6301;
-  color: #1C6301;
-}
-.button.is-success.is-outlined:hover, .button.is-success.is-outlined.is-hovered, .button.is-success.is-outlined:focus, .button.is-success.is-outlined.is-focused {
-  background-color: #1C6301;
-  border-color: #1C6301;
-  color: #fff;
-}
-.button.is-success.is-outlined.is-loading::after {
-  border-color: transparent transparent #1C6301 #1C6301 !important;
-}
-.button.is-success.is-outlined.is-loading:hover::after, .button.is-success.is-outlined.is-loading.is-hovered::after, .button.is-success.is-outlined.is-loading:focus::after, .button.is-success.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-success.is-outlined[disabled], fieldset[disabled] .button.is-success.is-outlined {
-  background-color: transparent;
-  border-color: #1C6301;
-  box-shadow: none;
-  color: #1C6301;
-}
-.button.is-success.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-success.is-inverted.is-outlined:hover, .button.is-success.is-inverted.is-outlined.is-hovered, .button.is-success.is-inverted.is-outlined:focus, .button.is-success.is-inverted.is-outlined.is-focused {
-  background-color: #fff;
-  color: #1C6301;
-}
-.button.is-success.is-inverted.is-outlined.is-loading:hover::after, .button.is-success.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-success.is-inverted.is-outlined.is-loading:focus::after, .button.is-success.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #1C6301 #1C6301 !important;
-}
-.button.is-success.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-success.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-success.is-light {
-  background-color: #f0ffeb;
-  color: #47fc03;
-}
-.button.is-success.is-light:hover, .button.is-success.is-light.is-hovered {
-  background-color: #e7ffde;
-  border-color: transparent;
-  color: #47fc03;
-}
-.button.is-success.is-light:active, .button.is-success.is-light.is-active {
-  background-color: #deffd2;
-  border-color: transparent;
-  color: #47fc03;
-}
-.button.is-warning {
-  background-color: #EED891;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-warning:hover, .button.is-warning.is-hovered {
-  background-color: #ecd486;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-warning:focus, .button.is-warning.is-focused {
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-warning:focus:not(:active), .button.is-warning.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(238, 216, 145, 0.25);
-}
-.button.is-warning:active, .button.is-warning.is-active {
-  background-color: #ebd07b;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-warning[disabled], fieldset[disabled] .button.is-warning {
-  background-color: #EED891;
-  border-color: #EED891;
-  box-shadow: none;
-}
-.button.is-warning.is-inverted {
-  background-color: rgba(0, 0, 0, 0.7);
-  color: #EED891;
-}
-.button.is-warning.is-inverted:hover, .button.is-warning.is-inverted.is-hovered {
-  background-color: rgba(0, 0, 0, 0.7);
-}
-.button.is-warning.is-inverted[disabled], fieldset[disabled] .button.is-warning.is-inverted {
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: transparent;
-  box-shadow: none;
-  color: #EED891;
-}
-.button.is-warning.is-loading::after {
-  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
-}
-.button.is-warning.is-outlined {
-  background-color: transparent;
-  border-color: #EED891;
-  color: #EED891;
-}
-.button.is-warning.is-outlined:hover, .button.is-warning.is-outlined.is-hovered, .button.is-warning.is-outlined:focus, .button.is-warning.is-outlined.is-focused {
-  background-color: #EED891;
-  border-color: #EED891;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-warning.is-outlined.is-loading::after {
-  border-color: transparent transparent #EED891 #EED891 !important;
-}
-.button.is-warning.is-outlined.is-loading:hover::after, .button.is-warning.is-outlined.is-loading.is-hovered::after, .button.is-warning.is-outlined.is-loading:focus::after, .button.is-warning.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
-}
-.button.is-warning.is-outlined[disabled], fieldset[disabled] .button.is-warning.is-outlined {
-  background-color: transparent;
-  border-color: #EED891;
-  box-shadow: none;
-  color: #EED891;
-}
-.button.is-warning.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: rgba(0, 0, 0, 0.7);
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-warning.is-inverted.is-outlined:hover, .button.is-warning.is-inverted.is-outlined.is-hovered, .button.is-warning.is-inverted.is-outlined:focus, .button.is-warning.is-inverted.is-outlined.is-focused {
-  background-color: rgba(0, 0, 0, 0.7);
-  color: #EED891;
-}
-.button.is-warning.is-inverted.is-outlined.is-loading:hover::after, .button.is-warning.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-warning.is-inverted.is-outlined.is-loading:focus::after, .button.is-warning.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #EED891 #EED891 !important;
-}
-.button.is-warning.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-warning.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: rgba(0, 0, 0, 0.7);
-  box-shadow: none;
-  color: rgba(0, 0, 0, 0.7);
-}
-.button.is-warning.is-light {
-  background-color: #fcf9ed;
-  color: #806614;
-}
-.button.is-warning.is-light:hover, .button.is-warning.is-light.is-hovered {
-  background-color: #fbf5e2;
-  border-color: transparent;
-  color: #806614;
-}
-.button.is-warning.is-light:active, .button.is-warning.is-light.is-active {
-  background-color: #f9f1d7;
-  border-color: transparent;
-  color: #806614;
-}
-.button.is-danger {
-  background-color: #A30031;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger:hover, .button.is-danger.is-hovered {
-  background-color: #96002d;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger:focus, .button.is-danger.is-focused {
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger:focus:not(:active), .button.is-danger.is-focused:not(:active) {
-  box-shadow: 0 0 0 0.125em rgba(163, 0, 49, 0.25);
-}
-.button.is-danger:active, .button.is-danger.is-active {
-  background-color: #8a0029;
-  border-color: transparent;
-  color: #fff;
-}
-.button.is-danger[disabled], fieldset[disabled] .button.is-danger {
-  background-color: #A30031;
-  border-color: #A30031;
-  box-shadow: none;
-}
-.button.is-danger.is-inverted {
-  background-color: #fff;
-  color: #A30031;
-}
-.button.is-danger.is-inverted:hover, .button.is-danger.is-inverted.is-hovered {
-  background-color: #f2f2f2;
-}
-.button.is-danger.is-inverted[disabled], fieldset[disabled] .button.is-danger.is-inverted {
-  background-color: #fff;
-  border-color: transparent;
-  box-shadow: none;
-  color: #A30031;
-}
-.button.is-danger.is-loading::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-danger.is-outlined {
-  background-color: transparent;
-  border-color: #A30031;
-  color: #A30031;
-}
-.button.is-danger.is-outlined:hover, .button.is-danger.is-outlined.is-hovered, .button.is-danger.is-outlined:focus, .button.is-danger.is-outlined.is-focused {
-  background-color: #A30031;
-  border-color: #A30031;
-  color: #fff;
-}
-.button.is-danger.is-outlined.is-loading::after {
-  border-color: transparent transparent #A30031 #A30031 !important;
-}
-.button.is-danger.is-outlined.is-loading:hover::after, .button.is-danger.is-outlined.is-loading.is-hovered::after, .button.is-danger.is-outlined.is-loading:focus::after, .button.is-danger.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #fff #fff !important;
-}
-.button.is-danger.is-outlined[disabled], fieldset[disabled] .button.is-danger.is-outlined {
-  background-color: transparent;
-  border-color: #A30031;
-  box-shadow: none;
-  color: #A30031;
-}
-.button.is-danger.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  color: #fff;
-}
-.button.is-danger.is-inverted.is-outlined:hover, .button.is-danger.is-inverted.is-outlined.is-hovered, .button.is-danger.is-inverted.is-outlined:focus, .button.is-danger.is-inverted.is-outlined.is-focused {
-  background-color: #fff;
-  color: #A30031;
-}
-.button.is-danger.is-inverted.is-outlined.is-loading:hover::after, .button.is-danger.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-danger.is-inverted.is-outlined.is-loading:focus::after, .button.is-danger.is-inverted.is-outlined.is-loading.is-focused::after {
-  border-color: transparent transparent #A30031 #A30031 !important;
-}
-.button.is-danger.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-danger.is-inverted.is-outlined {
-  background-color: transparent;
-  border-color: #fff;
-  box-shadow: none;
-  color: #fff;
-}
-.button.is-danger.is-light {
-  background-color: #ffebf1;
-  color: #ff0a54;
-}
-.button.is-danger.is-light:hover, .button.is-danger.is-light.is-hovered {
-  background-color: #ffdee8;
-  border-color: transparent;
-  color: #ff0a54;
-}
-.button.is-danger.is-light:active, .button.is-danger.is-light.is-active {
-  background-color: #ffd1df;
-  border-color: transparent;
-  color: #ff0a54;
-}
-.button.is-small {
-  font-size: 0.75rem;
-}
-.button.is-small:not(.is-rounded) {
-  border-radius: 2px;
-}
-.button.is-normal {
-  font-size: 1rem;
-}
-.button.is-medium {
-  font-size: 1.25rem;
-}
-.button.is-large {
-  font-size: 1.5rem;
-}
-.button[disabled], fieldset[disabled] .button {
-  background-color: #fafafa;
-  border-color: #e5e5e5;
-  box-shadow: none;
-  opacity: 0.5;
-}
-.button.is-fullwidth {
-  display: flex;
-  width: 100%;
-}
-.button.is-loading {
-  color: transparent !important;
-  pointer-events: none;
-}
-.button.is-loading::after {
-  position: absolute;
-  left: calc(50% - (1em * 0.5));
-  top: calc(50% - (1em * 0.5));
-  position: absolute !important;
-}
-.button.is-static {
-  background-color: #f5f5f5;
-  border-color: #e5e5e5;
-  color: #cccccc;
-  box-shadow: none;
-  pointer-events: none;
-}
-.button.is-rounded {
-  border-radius: 9999px;
-  padding-left: calc(1em + 0.25em);
-  padding-right: calc(1em + 0.25em);
-}
+  white-space: nowrap; }
+  .button strong {
+    color: inherit; }
+  .button .icon, .button .icon.is-small, .button .icon.is-medium, .button .icon.is-large {
+    height: 1.5em;
+    width: 1.5em; }
+  .button .icon:first-child:not(:last-child) {
+    margin-left: calc(-0.5em - 1px);
+    margin-right: 0.25em; }
+  .button .icon:last-child:not(:first-child) {
+    margin-left: 0.25em;
+    margin-right: calc(-0.5em - 1px); }
+  .button .icon:first-child:last-child {
+    margin-left: calc(-0.5em - 1px);
+    margin-right: calc(-0.5em - 1px); }
+  .button:hover, .button.is-hovered {
+    border-color: #d8d8d8;
+    color: #3A3D4E; }
+  .button:focus, .button.is-focused {
+    border-color: #004FB3;
+    color: #3A3D4E; }
+    .button:focus:not(:active), .button.is-focused:not(:active) {
+      box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25); }
+  .button:active, .button.is-active {
+    border-color: #83858D;
+    color: #3A3D4E; }
+  .button.is-text {
+    background-color: transparent;
+    border-color: transparent;
+    color: #83858D;
+    text-decoration: underline; }
+    .button.is-text:hover, .button.is-text.is-hovered, .button.is-text:focus, .button.is-text.is-focused {
+      background-color: #f5f5f5;
+      color: #3A3D4E; }
+    .button.is-text:active, .button.is-text.is-active {
+      background-color: #e8e8e8;
+      color: #3A3D4E; }
+    .button.is-text[disabled], fieldset[disabled] .button.is-text {
+      background-color: transparent;
+      border-color: transparent;
+      box-shadow: none; }
+  .button.is-ghost {
+    background: none;
+    border-color: transparent;
+    color: #004FB3;
+    text-decoration: none; }
+    .button.is-ghost:hover, .button.is-ghost.is-hovered {
+      color: #004FB3;
+      text-decoration: underline; }
+  .button.is-white {
+    background-color: #fafafa;
+    border-color: transparent;
+    color: #030303; }
+    .button.is-white:hover, .button.is-white.is-hovered {
+      background-color: #f4f4f4;
+      border-color: transparent;
+      color: #030303; }
+    .button.is-white:focus, .button.is-white.is-focused {
+      border-color: transparent;
+      color: #030303; }
+      .button.is-white:focus:not(:active), .button.is-white.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(250, 250, 250, 0.25); }
+    .button.is-white:active, .button.is-white.is-active {
+      background-color: #ededed;
+      border-color: transparent;
+      color: #030303; }
+    .button.is-white[disabled], fieldset[disabled] .button.is-white {
+      background-color: #fafafa;
+      border-color: #fafafa;
+      box-shadow: none; }
+    .button.is-white.is-inverted {
+      background-color: #030303;
+      color: #fafafa; }
+      .button.is-white.is-inverted:hover, .button.is-white.is-inverted.is-hovered {
+        background-color: black; }
+      .button.is-white.is-inverted[disabled], fieldset[disabled] .button.is-white.is-inverted {
+        background-color: #030303;
+        border-color: transparent;
+        box-shadow: none;
+        color: #fafafa; }
+    .button.is-white.is-loading::after {
+      border-color: transparent transparent #030303 #030303 !important; }
+    .button.is-white.is-outlined {
+      background-color: transparent;
+      border-color: #fafafa;
+      color: #fafafa; }
+      .button.is-white.is-outlined:hover, .button.is-white.is-outlined.is-hovered, .button.is-white.is-outlined:focus, .button.is-white.is-outlined.is-focused {
+        background-color: #fafafa;
+        border-color: #fafafa;
+        color: #030303; }
+      .button.is-white.is-outlined.is-loading::after {
+        border-color: transparent transparent #fafafa #fafafa !important; }
+      .button.is-white.is-outlined.is-loading:hover::after, .button.is-white.is-outlined.is-loading.is-hovered::after, .button.is-white.is-outlined.is-loading:focus::after, .button.is-white.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #030303 #030303 !important; }
+      .button.is-white.is-outlined[disabled], fieldset[disabled] .button.is-white.is-outlined {
+        background-color: transparent;
+        border-color: #fafafa;
+        box-shadow: none;
+        color: #fafafa; }
+    .button.is-white.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #030303;
+      color: #030303; }
+      .button.is-white.is-inverted.is-outlined:hover, .button.is-white.is-inverted.is-outlined.is-hovered, .button.is-white.is-inverted.is-outlined:focus, .button.is-white.is-inverted.is-outlined.is-focused {
+        background-color: #030303;
+        color: #fafafa; }
+      .button.is-white.is-inverted.is-outlined.is-loading:hover::after, .button.is-white.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-white.is-inverted.is-outlined.is-loading:focus::after, .button.is-white.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #fafafa #fafafa !important; }
+      .button.is-white.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-white.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: #030303;
+        box-shadow: none;
+        color: #030303; }
+  .button.is-black {
+    background-color: #030303;
+    border-color: transparent;
+    color: #fafafa; }
+    .button.is-black:hover, .button.is-black.is-hovered {
+      background-color: black;
+      border-color: transparent;
+      color: #fafafa; }
+    .button.is-black:focus, .button.is-black.is-focused {
+      border-color: transparent;
+      color: #fafafa; }
+      .button.is-black:focus:not(:active), .button.is-black.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(3, 3, 3, 0.25); }
+    .button.is-black:active, .button.is-black.is-active {
+      background-color: black;
+      border-color: transparent;
+      color: #fafafa; }
+    .button.is-black[disabled], fieldset[disabled] .button.is-black {
+      background-color: #030303;
+      border-color: #030303;
+      box-shadow: none; }
+    .button.is-black.is-inverted {
+      background-color: #fafafa;
+      color: #030303; }
+      .button.is-black.is-inverted:hover, .button.is-black.is-inverted.is-hovered {
+        background-color: #ededed; }
+      .button.is-black.is-inverted[disabled], fieldset[disabled] .button.is-black.is-inverted {
+        background-color: #fafafa;
+        border-color: transparent;
+        box-shadow: none;
+        color: #030303; }
+    .button.is-black.is-loading::after {
+      border-color: transparent transparent #fafafa #fafafa !important; }
+    .button.is-black.is-outlined {
+      background-color: transparent;
+      border-color: #030303;
+      color: #030303; }
+      .button.is-black.is-outlined:hover, .button.is-black.is-outlined.is-hovered, .button.is-black.is-outlined:focus, .button.is-black.is-outlined.is-focused {
+        background-color: #030303;
+        border-color: #030303;
+        color: #fafafa; }
+      .button.is-black.is-outlined.is-loading::after {
+        border-color: transparent transparent #030303 #030303 !important; }
+      .button.is-black.is-outlined.is-loading:hover::after, .button.is-black.is-outlined.is-loading.is-hovered::after, .button.is-black.is-outlined.is-loading:focus::after, .button.is-black.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #fafafa #fafafa !important; }
+      .button.is-black.is-outlined[disabled], fieldset[disabled] .button.is-black.is-outlined {
+        background-color: transparent;
+        border-color: #030303;
+        box-shadow: none;
+        color: #030303; }
+    .button.is-black.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fafafa;
+      color: #fafafa; }
+      .button.is-black.is-inverted.is-outlined:hover, .button.is-black.is-inverted.is-outlined.is-hovered, .button.is-black.is-inverted.is-outlined:focus, .button.is-black.is-inverted.is-outlined.is-focused {
+        background-color: #fafafa;
+        color: #030303; }
+      .button.is-black.is-inverted.is-outlined.is-loading:hover::after, .button.is-black.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-black.is-inverted.is-outlined.is-loading:focus::after, .button.is-black.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #030303 #030303 !important; }
+      .button.is-black.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-black.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: #fafafa;
+        box-shadow: none;
+        color: #fafafa; }
+  .button.is-light {
+    background-color: #f5f5f5;
+    border-color: transparent;
+    color: rgba(0, 0, 0, 0.7); }
+    .button.is-light:hover, .button.is-light.is-hovered {
+      background-color: #efefef;
+      border-color: transparent;
+      color: rgba(0, 0, 0, 0.7); }
+    .button.is-light:focus, .button.is-light.is-focused {
+      border-color: transparent;
+      color: rgba(0, 0, 0, 0.7); }
+      .button.is-light:focus:not(:active), .button.is-light.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25); }
+    .button.is-light:active, .button.is-light.is-active {
+      background-color: #e8e8e8;
+      border-color: transparent;
+      color: rgba(0, 0, 0, 0.7); }
+    .button.is-light[disabled], fieldset[disabled] .button.is-light {
+      background-color: #f5f5f5;
+      border-color: #f5f5f5;
+      box-shadow: none; }
+    .button.is-light.is-inverted {
+      background-color: rgba(0, 0, 0, 0.7);
+      color: #f5f5f5; }
+      .button.is-light.is-inverted:hover, .button.is-light.is-inverted.is-hovered {
+        background-color: rgba(0, 0, 0, 0.7); }
+      .button.is-light.is-inverted[disabled], fieldset[disabled] .button.is-light.is-inverted {
+        background-color: rgba(0, 0, 0, 0.7);
+        border-color: transparent;
+        box-shadow: none;
+        color: #f5f5f5; }
+    .button.is-light.is-loading::after {
+      border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important; }
+    .button.is-light.is-outlined {
+      background-color: transparent;
+      border-color: #f5f5f5;
+      color: #f5f5f5; }
+      .button.is-light.is-outlined:hover, .button.is-light.is-outlined.is-hovered, .button.is-light.is-outlined:focus, .button.is-light.is-outlined.is-focused {
+        background-color: #f5f5f5;
+        border-color: #f5f5f5;
+        color: rgba(0, 0, 0, 0.7); }
+      .button.is-light.is-outlined.is-loading::after {
+        border-color: transparent transparent #f5f5f5 #f5f5f5 !important; }
+      .button.is-light.is-outlined.is-loading:hover::after, .button.is-light.is-outlined.is-loading.is-hovered::after, .button.is-light.is-outlined.is-loading:focus::after, .button.is-light.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important; }
+      .button.is-light.is-outlined[disabled], fieldset[disabled] .button.is-light.is-outlined {
+        background-color: transparent;
+        border-color: #f5f5f5;
+        box-shadow: none;
+        color: #f5f5f5; }
+    .button.is-light.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: rgba(0, 0, 0, 0.7);
+      color: rgba(0, 0, 0, 0.7); }
+      .button.is-light.is-inverted.is-outlined:hover, .button.is-light.is-inverted.is-outlined.is-hovered, .button.is-light.is-inverted.is-outlined:focus, .button.is-light.is-inverted.is-outlined.is-focused {
+        background-color: rgba(0, 0, 0, 0.7);
+        color: #f5f5f5; }
+      .button.is-light.is-inverted.is-outlined.is-loading:hover::after, .button.is-light.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-light.is-inverted.is-outlined.is-loading:focus::after, .button.is-light.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #f5f5f5 #f5f5f5 !important; }
+      .button.is-light.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-light.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: rgba(0, 0, 0, 0.7);
+        box-shadow: none;
+        color: rgba(0, 0, 0, 0.7); }
+  .button.is-dark {
+    background-color: #3A3D4E;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-dark:hover, .button.is-dark.is-hovered {
+      background-color: #353747;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-dark:focus, .button.is-dark.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-dark:focus:not(:active), .button.is-dark.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(58, 61, 78, 0.25); }
+    .button.is-dark:active, .button.is-dark.is-active {
+      background-color: #2f323f;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-dark[disabled], fieldset[disabled] .button.is-dark {
+      background-color: #3A3D4E;
+      border-color: #3A3D4E;
+      box-shadow: none; }
+    .button.is-dark.is-inverted {
+      background-color: #fff;
+      color: #3A3D4E; }
+      .button.is-dark.is-inverted:hover, .button.is-dark.is-inverted.is-hovered {
+        background-color: #f2f2f2; }
+      .button.is-dark.is-inverted[disabled], fieldset[disabled] .button.is-dark.is-inverted {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #3A3D4E; }
+    .button.is-dark.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-dark.is-outlined {
+      background-color: transparent;
+      border-color: #3A3D4E;
+      color: #3A3D4E; }
+      .button.is-dark.is-outlined:hover, .button.is-dark.is-outlined.is-hovered, .button.is-dark.is-outlined:focus, .button.is-dark.is-outlined.is-focused {
+        background-color: #3A3D4E;
+        border-color: #3A3D4E;
+        color: #fff; }
+      .button.is-dark.is-outlined.is-loading::after {
+        border-color: transparent transparent #3A3D4E #3A3D4E !important; }
+      .button.is-dark.is-outlined.is-loading:hover::after, .button.is-dark.is-outlined.is-loading.is-hovered::after, .button.is-dark.is-outlined.is-loading:focus::after, .button.is-dark.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #fff #fff !important; }
+      .button.is-dark.is-outlined[disabled], fieldset[disabled] .button.is-dark.is-outlined {
+        background-color: transparent;
+        border-color: #3A3D4E;
+        box-shadow: none;
+        color: #3A3D4E; }
+    .button.is-dark.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-dark.is-inverted.is-outlined:hover, .button.is-dark.is-inverted.is-outlined.is-hovered, .button.is-dark.is-inverted.is-outlined:focus, .button.is-dark.is-inverted.is-outlined.is-focused {
+        background-color: #fff;
+        color: #3A3D4E; }
+      .button.is-dark.is-inverted.is-outlined.is-loading:hover::after, .button.is-dark.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-dark.is-inverted.is-outlined.is-loading:focus::after, .button.is-dark.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #3A3D4E #3A3D4E !important; }
+      .button.is-dark.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-dark.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+  .button.is-primary {
+    background-color: #005C43;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-primary:hover, .button.is-primary.is-hovered {
+      background-color: #004f3a;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-primary:focus, .button.is-primary.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-primary:focus:not(:active), .button.is-primary.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(0, 92, 67, 0.25); }
+    .button.is-primary:active, .button.is-primary.is-active {
+      background-color: #004330;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-primary[disabled], fieldset[disabled] .button.is-primary {
+      background-color: #005C43;
+      border-color: #005C43;
+      box-shadow: none; }
+    .button.is-primary.is-inverted {
+      background-color: #fff;
+      color: #005C43; }
+      .button.is-primary.is-inverted:hover, .button.is-primary.is-inverted.is-hovered {
+        background-color: #f2f2f2; }
+      .button.is-primary.is-inverted[disabled], fieldset[disabled] .button.is-primary.is-inverted {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #005C43; }
+    .button.is-primary.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-primary.is-outlined {
+      background-color: transparent;
+      border-color: #005C43;
+      color: #005C43; }
+      .button.is-primary.is-outlined:hover, .button.is-primary.is-outlined.is-hovered, .button.is-primary.is-outlined:focus, .button.is-primary.is-outlined.is-focused {
+        background-color: #005C43;
+        border-color: #005C43;
+        color: #fff; }
+      .button.is-primary.is-outlined.is-loading::after {
+        border-color: transparent transparent #005C43 #005C43 !important; }
+      .button.is-primary.is-outlined.is-loading:hover::after, .button.is-primary.is-outlined.is-loading.is-hovered::after, .button.is-primary.is-outlined.is-loading:focus::after, .button.is-primary.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #fff #fff !important; }
+      .button.is-primary.is-outlined[disabled], fieldset[disabled] .button.is-primary.is-outlined {
+        background-color: transparent;
+        border-color: #005C43;
+        box-shadow: none;
+        color: #005C43; }
+    .button.is-primary.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-primary.is-inverted.is-outlined:hover, .button.is-primary.is-inverted.is-outlined.is-hovered, .button.is-primary.is-inverted.is-outlined:focus, .button.is-primary.is-inverted.is-outlined.is-focused {
+        background-color: #fff;
+        color: #005C43; }
+      .button.is-primary.is-inverted.is-outlined.is-loading:hover::after, .button.is-primary.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-primary.is-inverted.is-outlined.is-loading:focus::after, .button.is-primary.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #005C43 #005C43 !important; }
+      .button.is-primary.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-primary.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+    .button.is-primary.is-light {
+      background-color: #ebfff9;
+      color: #05ffbb; }
+      .button.is-primary.is-light:hover, .button.is-primary.is-light.is-hovered {
+        background-color: #defff6;
+        border-color: transparent;
+        color: #05ffbb; }
+      .button.is-primary.is-light:active, .button.is-primary.is-light.is-active {
+        background-color: #d1fff3;
+        border-color: transparent;
+        color: #05ffbb; }
+  .button.is-link {
+    background-color: #004FB3;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-link:hover, .button.is-link.is-hovered {
+      background-color: #0049a6;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-link:focus, .button.is-link.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-link:focus:not(:active), .button.is-link.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25); }
+    .button.is-link:active, .button.is-link.is-active {
+      background-color: #00449a;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-link[disabled], fieldset[disabled] .button.is-link {
+      background-color: #004FB3;
+      border-color: #004FB3;
+      box-shadow: none; }
+    .button.is-link.is-inverted {
+      background-color: #fff;
+      color: #004FB3; }
+      .button.is-link.is-inverted:hover, .button.is-link.is-inverted.is-hovered {
+        background-color: #f2f2f2; }
+      .button.is-link.is-inverted[disabled], fieldset[disabled] .button.is-link.is-inverted {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #004FB3; }
+    .button.is-link.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-link.is-outlined {
+      background-color: transparent;
+      border-color: #004FB3;
+      color: #004FB3; }
+      .button.is-link.is-outlined:hover, .button.is-link.is-outlined.is-hovered, .button.is-link.is-outlined:focus, .button.is-link.is-outlined.is-focused {
+        background-color: #004FB3;
+        border-color: #004FB3;
+        color: #fff; }
+      .button.is-link.is-outlined.is-loading::after {
+        border-color: transparent transparent #004FB3 #004FB3 !important; }
+      .button.is-link.is-outlined.is-loading:hover::after, .button.is-link.is-outlined.is-loading.is-hovered::after, .button.is-link.is-outlined.is-loading:focus::after, .button.is-link.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #fff #fff !important; }
+      .button.is-link.is-outlined[disabled], fieldset[disabled] .button.is-link.is-outlined {
+        background-color: transparent;
+        border-color: #004FB3;
+        box-shadow: none;
+        color: #004FB3; }
+    .button.is-link.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-link.is-inverted.is-outlined:hover, .button.is-link.is-inverted.is-outlined.is-hovered, .button.is-link.is-inverted.is-outlined:focus, .button.is-link.is-inverted.is-outlined.is-focused {
+        background-color: #fff;
+        color: #004FB3; }
+      .button.is-link.is-inverted.is-outlined.is-loading:hover::after, .button.is-link.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-link.is-inverted.is-outlined.is-loading:focus::after, .button.is-link.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #004FB3 #004FB3 !important; }
+      .button.is-link.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-link.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+    .button.is-link.is-light {
+      background-color: #ebf4ff;
+      color: #0573ff; }
+      .button.is-link.is-light:hover, .button.is-link.is-light.is-hovered {
+        background-color: #deecff;
+        border-color: transparent;
+        color: #0573ff; }
+      .button.is-link.is-light:active, .button.is-link.is-light.is-active {
+        background-color: #d1e5ff;
+        border-color: transparent;
+        color: #0573ff; }
+  .button.is-info {
+    background-color: #3298dc;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-info:hover, .button.is-info.is-hovered {
+      background-color: #2793da;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-info:focus, .button.is-info.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-info:focus:not(:active), .button.is-info.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(50, 152, 220, 0.25); }
+    .button.is-info:active, .button.is-info.is-active {
+      background-color: #238cd1;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-info[disabled], fieldset[disabled] .button.is-info {
+      background-color: #3298dc;
+      border-color: #3298dc;
+      box-shadow: none; }
+    .button.is-info.is-inverted {
+      background-color: #fff;
+      color: #3298dc; }
+      .button.is-info.is-inverted:hover, .button.is-info.is-inverted.is-hovered {
+        background-color: #f2f2f2; }
+      .button.is-info.is-inverted[disabled], fieldset[disabled] .button.is-info.is-inverted {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #3298dc; }
+    .button.is-info.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-info.is-outlined {
+      background-color: transparent;
+      border-color: #3298dc;
+      color: #3298dc; }
+      .button.is-info.is-outlined:hover, .button.is-info.is-outlined.is-hovered, .button.is-info.is-outlined:focus, .button.is-info.is-outlined.is-focused {
+        background-color: #3298dc;
+        border-color: #3298dc;
+        color: #fff; }
+      .button.is-info.is-outlined.is-loading::after {
+        border-color: transparent transparent #3298dc #3298dc !important; }
+      .button.is-info.is-outlined.is-loading:hover::after, .button.is-info.is-outlined.is-loading.is-hovered::after, .button.is-info.is-outlined.is-loading:focus::after, .button.is-info.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #fff #fff !important; }
+      .button.is-info.is-outlined[disabled], fieldset[disabled] .button.is-info.is-outlined {
+        background-color: transparent;
+        border-color: #3298dc;
+        box-shadow: none;
+        color: #3298dc; }
+    .button.is-info.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-info.is-inverted.is-outlined:hover, .button.is-info.is-inverted.is-outlined.is-hovered, .button.is-info.is-inverted.is-outlined:focus, .button.is-info.is-inverted.is-outlined.is-focused {
+        background-color: #fff;
+        color: #3298dc; }
+      .button.is-info.is-inverted.is-outlined.is-loading:hover::after, .button.is-info.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-info.is-inverted.is-outlined.is-loading:focus::after, .button.is-info.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #3298dc #3298dc !important; }
+      .button.is-info.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-info.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+    .button.is-info.is-light {
+      background-color: #eef6fc;
+      color: #1d72aa; }
+      .button.is-info.is-light:hover, .button.is-info.is-light.is-hovered {
+        background-color: #e3f1fa;
+        border-color: transparent;
+        color: #1d72aa; }
+      .button.is-info.is-light:active, .button.is-info.is-light.is-active {
+        background-color: #d8ebf8;
+        border-color: transparent;
+        color: #1d72aa; }
+  .button.is-success {
+    background-color: #1C6301;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-success:hover, .button.is-success.is-hovered {
+      background-color: #185601;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-success:focus, .button.is-success.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-success:focus:not(:active), .button.is-success.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(28, 99, 1, 0.25); }
+    .button.is-success:active, .button.is-success.is-active {
+      background-color: #154a01;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-success[disabled], fieldset[disabled] .button.is-success {
+      background-color: #1C6301;
+      border-color: #1C6301;
+      box-shadow: none; }
+    .button.is-success.is-inverted {
+      background-color: #fff;
+      color: #1C6301; }
+      .button.is-success.is-inverted:hover, .button.is-success.is-inverted.is-hovered {
+        background-color: #f2f2f2; }
+      .button.is-success.is-inverted[disabled], fieldset[disabled] .button.is-success.is-inverted {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #1C6301; }
+    .button.is-success.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-success.is-outlined {
+      background-color: transparent;
+      border-color: #1C6301;
+      color: #1C6301; }
+      .button.is-success.is-outlined:hover, .button.is-success.is-outlined.is-hovered, .button.is-success.is-outlined:focus, .button.is-success.is-outlined.is-focused {
+        background-color: #1C6301;
+        border-color: #1C6301;
+        color: #fff; }
+      .button.is-success.is-outlined.is-loading::after {
+        border-color: transparent transparent #1C6301 #1C6301 !important; }
+      .button.is-success.is-outlined.is-loading:hover::after, .button.is-success.is-outlined.is-loading.is-hovered::after, .button.is-success.is-outlined.is-loading:focus::after, .button.is-success.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #fff #fff !important; }
+      .button.is-success.is-outlined[disabled], fieldset[disabled] .button.is-success.is-outlined {
+        background-color: transparent;
+        border-color: #1C6301;
+        box-shadow: none;
+        color: #1C6301; }
+    .button.is-success.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-success.is-inverted.is-outlined:hover, .button.is-success.is-inverted.is-outlined.is-hovered, .button.is-success.is-inverted.is-outlined:focus, .button.is-success.is-inverted.is-outlined.is-focused {
+        background-color: #fff;
+        color: #1C6301; }
+      .button.is-success.is-inverted.is-outlined.is-loading:hover::after, .button.is-success.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-success.is-inverted.is-outlined.is-loading:focus::after, .button.is-success.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #1C6301 #1C6301 !important; }
+      .button.is-success.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-success.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+    .button.is-success.is-light {
+      background-color: #f0ffeb;
+      color: #47fc03; }
+      .button.is-success.is-light:hover, .button.is-success.is-light.is-hovered {
+        background-color: #e7ffde;
+        border-color: transparent;
+        color: #47fc03; }
+      .button.is-success.is-light:active, .button.is-success.is-light.is-active {
+        background-color: #deffd2;
+        border-color: transparent;
+        color: #47fc03; }
+  .button.is-warning {
+    background-color: #EED891;
+    border-color: transparent;
+    color: rgba(0, 0, 0, 0.7); }
+    .button.is-warning:hover, .button.is-warning.is-hovered {
+      background-color: #ecd486;
+      border-color: transparent;
+      color: rgba(0, 0, 0, 0.7); }
+    .button.is-warning:focus, .button.is-warning.is-focused {
+      border-color: transparent;
+      color: rgba(0, 0, 0, 0.7); }
+      .button.is-warning:focus:not(:active), .button.is-warning.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(238, 216, 145, 0.25); }
+    .button.is-warning:active, .button.is-warning.is-active {
+      background-color: #ebd07b;
+      border-color: transparent;
+      color: rgba(0, 0, 0, 0.7); }
+    .button.is-warning[disabled], fieldset[disabled] .button.is-warning {
+      background-color: #EED891;
+      border-color: #EED891;
+      box-shadow: none; }
+    .button.is-warning.is-inverted {
+      background-color: rgba(0, 0, 0, 0.7);
+      color: #EED891; }
+      .button.is-warning.is-inverted:hover, .button.is-warning.is-inverted.is-hovered {
+        background-color: rgba(0, 0, 0, 0.7); }
+      .button.is-warning.is-inverted[disabled], fieldset[disabled] .button.is-warning.is-inverted {
+        background-color: rgba(0, 0, 0, 0.7);
+        border-color: transparent;
+        box-shadow: none;
+        color: #EED891; }
+    .button.is-warning.is-loading::after {
+      border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important; }
+    .button.is-warning.is-outlined {
+      background-color: transparent;
+      border-color: #EED891;
+      color: #EED891; }
+      .button.is-warning.is-outlined:hover, .button.is-warning.is-outlined.is-hovered, .button.is-warning.is-outlined:focus, .button.is-warning.is-outlined.is-focused {
+        background-color: #EED891;
+        border-color: #EED891;
+        color: rgba(0, 0, 0, 0.7); }
+      .button.is-warning.is-outlined.is-loading::after {
+        border-color: transparent transparent #EED891 #EED891 !important; }
+      .button.is-warning.is-outlined.is-loading:hover::after, .button.is-warning.is-outlined.is-loading.is-hovered::after, .button.is-warning.is-outlined.is-loading:focus::after, .button.is-warning.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important; }
+      .button.is-warning.is-outlined[disabled], fieldset[disabled] .button.is-warning.is-outlined {
+        background-color: transparent;
+        border-color: #EED891;
+        box-shadow: none;
+        color: #EED891; }
+    .button.is-warning.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: rgba(0, 0, 0, 0.7);
+      color: rgba(0, 0, 0, 0.7); }
+      .button.is-warning.is-inverted.is-outlined:hover, .button.is-warning.is-inverted.is-outlined.is-hovered, .button.is-warning.is-inverted.is-outlined:focus, .button.is-warning.is-inverted.is-outlined.is-focused {
+        background-color: rgba(0, 0, 0, 0.7);
+        color: #EED891; }
+      .button.is-warning.is-inverted.is-outlined.is-loading:hover::after, .button.is-warning.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-warning.is-inverted.is-outlined.is-loading:focus::after, .button.is-warning.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #EED891 #EED891 !important; }
+      .button.is-warning.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-warning.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: rgba(0, 0, 0, 0.7);
+        box-shadow: none;
+        color: rgba(0, 0, 0, 0.7); }
+    .button.is-warning.is-light {
+      background-color: #fcf9ed;
+      color: #806614; }
+      .button.is-warning.is-light:hover, .button.is-warning.is-light.is-hovered {
+        background-color: #fbf5e2;
+        border-color: transparent;
+        color: #806614; }
+      .button.is-warning.is-light:active, .button.is-warning.is-light.is-active {
+        background-color: #f9f1d7;
+        border-color: transparent;
+        color: #806614; }
+  .button.is-danger {
+    background-color: #A30031;
+    border-color: transparent;
+    color: #fff; }
+    .button.is-danger:hover, .button.is-danger.is-hovered {
+      background-color: #96002d;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-danger:focus, .button.is-danger.is-focused {
+      border-color: transparent;
+      color: #fff; }
+      .button.is-danger:focus:not(:active), .button.is-danger.is-focused:not(:active) {
+        box-shadow: 0 0 0 0.125em rgba(163, 0, 49, 0.25); }
+    .button.is-danger:active, .button.is-danger.is-active {
+      background-color: #8a0029;
+      border-color: transparent;
+      color: #fff; }
+    .button.is-danger[disabled], fieldset[disabled] .button.is-danger {
+      background-color: #A30031;
+      border-color: #A30031;
+      box-shadow: none; }
+    .button.is-danger.is-inverted {
+      background-color: #fff;
+      color: #A30031; }
+      .button.is-danger.is-inverted:hover, .button.is-danger.is-inverted.is-hovered {
+        background-color: #f2f2f2; }
+      .button.is-danger.is-inverted[disabled], fieldset[disabled] .button.is-danger.is-inverted {
+        background-color: #fff;
+        border-color: transparent;
+        box-shadow: none;
+        color: #A30031; }
+    .button.is-danger.is-loading::after {
+      border-color: transparent transparent #fff #fff !important; }
+    .button.is-danger.is-outlined {
+      background-color: transparent;
+      border-color: #A30031;
+      color: #A30031; }
+      .button.is-danger.is-outlined:hover, .button.is-danger.is-outlined.is-hovered, .button.is-danger.is-outlined:focus, .button.is-danger.is-outlined.is-focused {
+        background-color: #A30031;
+        border-color: #A30031;
+        color: #fff; }
+      .button.is-danger.is-outlined.is-loading::after {
+        border-color: transparent transparent #A30031 #A30031 !important; }
+      .button.is-danger.is-outlined.is-loading:hover::after, .button.is-danger.is-outlined.is-loading.is-hovered::after, .button.is-danger.is-outlined.is-loading:focus::after, .button.is-danger.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #fff #fff !important; }
+      .button.is-danger.is-outlined[disabled], fieldset[disabled] .button.is-danger.is-outlined {
+        background-color: transparent;
+        border-color: #A30031;
+        box-shadow: none;
+        color: #A30031; }
+    .button.is-danger.is-inverted.is-outlined {
+      background-color: transparent;
+      border-color: #fff;
+      color: #fff; }
+      .button.is-danger.is-inverted.is-outlined:hover, .button.is-danger.is-inverted.is-outlined.is-hovered, .button.is-danger.is-inverted.is-outlined:focus, .button.is-danger.is-inverted.is-outlined.is-focused {
+        background-color: #fff;
+        color: #A30031; }
+      .button.is-danger.is-inverted.is-outlined.is-loading:hover::after, .button.is-danger.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-danger.is-inverted.is-outlined.is-loading:focus::after, .button.is-danger.is-inverted.is-outlined.is-loading.is-focused::after {
+        border-color: transparent transparent #A30031 #A30031 !important; }
+      .button.is-danger.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-danger.is-inverted.is-outlined {
+        background-color: transparent;
+        border-color: #fff;
+        box-shadow: none;
+        color: #fff; }
+    .button.is-danger.is-light {
+      background-color: #ffebf1;
+      color: #ff0a54; }
+      .button.is-danger.is-light:hover, .button.is-danger.is-light.is-hovered {
+        background-color: #ffdee8;
+        border-color: transparent;
+        color: #ff0a54; }
+      .button.is-danger.is-light:active, .button.is-danger.is-light.is-active {
+        background-color: #ffd1df;
+        border-color: transparent;
+        color: #ff0a54; }
+  .button.is-small {
+    font-size: 0.75rem; }
+    .button.is-small:not(.is-rounded) {
+      border-radius: 2px; }
+  .button.is-normal {
+    font-size: 1rem; }
+  .button.is-medium {
+    font-size: 1.25rem; }
+  .button.is-large {
+    font-size: 1.5rem; }
+  .button[disabled], fieldset[disabled] .button {
+    background-color: #fafafa;
+    border-color: #e5e5e5;
+    box-shadow: none;
+    opacity: 0.5; }
+  .button.is-fullwidth {
+    display: flex;
+    width: 100%; }
+  .button.is-loading {
+    color: transparent !important;
+    pointer-events: none; }
+    .button.is-loading::after {
+      position: absolute;
+      left: calc(50% - (1em * 0.5));
+      top: calc(50% - (1em * 0.5));
+      position: absolute !important; }
+  .button.is-static {
+    background-color: #f5f5f5;
+    border-color: #e5e5e5;
+    color: #cccccc;
+    box-shadow: none;
+    pointer-events: none; }
+  .button.is-rounded {
+    border-radius: 9999px;
+    padding-left: calc(1em + 0.25em);
+    padding-right: calc(1em + 0.25em); }
 
 .buttons {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-start;
-}
-.buttons .button {
-  margin-bottom: 0.5rem;
-}
-.buttons .button:not(:last-child):not(.is-fullwidth) {
-  margin-right: 0.5rem;
-}
-.buttons:last-child {
-  margin-bottom: -0.5rem;
-}
-.buttons:not(:last-child) {
-  margin-bottom: 1rem;
-}
-.buttons.are-small .button:not(.is-normal):not(.is-medium):not(.is-large) {
-  font-size: 0.75rem;
-}
-.buttons.are-small .button:not(.is-normal):not(.is-medium):not(.is-large):not(.is-rounded) {
-  border-radius: 2px;
-}
-.buttons.are-medium .button:not(.is-small):not(.is-normal):not(.is-large) {
-  font-size: 1.25rem;
-}
-.buttons.are-large .button:not(.is-small):not(.is-normal):not(.is-medium) {
-  font-size: 1.5rem;
-}
-.buttons.has-addons .button:not(:first-child) {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
-.buttons.has-addons .button:not(:last-child) {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-  margin-right: -1px;
-}
-.buttons.has-addons .button:last-child {
-  margin-right: 0;
-}
-.buttons.has-addons .button:hover, .buttons.has-addons .button.is-hovered {
-  z-index: 2;
-}
-.buttons.has-addons .button:focus, .buttons.has-addons .button.is-focused, .buttons.has-addons .button:active, .buttons.has-addons .button.is-active, .buttons.has-addons .button.is-selected {
-  z-index: 3;
-}
-.buttons.has-addons .button:focus:hover, .buttons.has-addons .button.is-focused:hover, .buttons.has-addons .button:active:hover, .buttons.has-addons .button.is-active:hover, .buttons.has-addons .button.is-selected:hover {
-  z-index: 4;
-}
-.buttons.has-addons .button.is-expanded {
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-.buttons.is-centered {
-  justify-content: center;
-}
-.buttons.is-centered:not(.has-addons) .button:not(.is-fullwidth) {
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
-}
-.buttons.is-right {
-  justify-content: flex-end;
-}
-.buttons.is-right:not(.has-addons) .button:not(.is-fullwidth) {
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
-}
+  justify-content: flex-start; }
+  .buttons .button {
+    margin-bottom: 0.5rem; }
+    .buttons .button:not(:last-child):not(.is-fullwidth) {
+      margin-right: 0.5rem; }
+  .buttons:last-child {
+    margin-bottom: -0.5rem; }
+  .buttons:not(:last-child) {
+    margin-bottom: 1rem; }
+  .buttons.are-small .button:not(.is-normal):not(.is-medium):not(.is-large) {
+    font-size: 0.75rem; }
+    .buttons.are-small .button:not(.is-normal):not(.is-medium):not(.is-large):not(.is-rounded) {
+      border-radius: 2px; }
+  .buttons.are-medium .button:not(.is-small):not(.is-normal):not(.is-large) {
+    font-size: 1.25rem; }
+  .buttons.are-large .button:not(.is-small):not(.is-normal):not(.is-medium) {
+    font-size: 1.5rem; }
+  .buttons.has-addons .button:not(:first-child) {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0; }
+  .buttons.has-addons .button:not(:last-child) {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+    margin-right: -1px; }
+  .buttons.has-addons .button:last-child {
+    margin-right: 0; }
+  .buttons.has-addons .button:hover, .buttons.has-addons .button.is-hovered {
+    z-index: 2; }
+  .buttons.has-addons .button:focus, .buttons.has-addons .button.is-focused, .buttons.has-addons .button:active, .buttons.has-addons .button.is-active, .buttons.has-addons .button.is-selected {
+    z-index: 3; }
+    .buttons.has-addons .button:focus:hover, .buttons.has-addons .button.is-focused:hover, .buttons.has-addons .button:active:hover, .buttons.has-addons .button.is-active:hover, .buttons.has-addons .button.is-selected:hover {
+      z-index: 4; }
+  .buttons.has-addons .button.is-expanded {
+    flex-grow: 1;
+    flex-shrink: 1; }
+  .buttons.is-centered {
+    justify-content: center; }
+    .buttons.is-centered:not(.has-addons) .button:not(.is-fullwidth) {
+      margin-left: 0.25rem;
+      margin-right: 0.25rem; }
+  .buttons.is-right {
+    justify-content: flex-end; }
+    .buttons.is-right:not(.has-addons) .button:not(.is-fullwidth) {
+      margin-left: 0.25rem;
+      margin-right: 0.25rem; }
 
 @media screen and (max-width: 768px) {
   .button.is-responsive.is-small {
-    font-size: 0.5625rem;
-  }
+    font-size: 0.5625rem; }
+
   .button.is-responsive,
-.button.is-responsive.is-normal {
-    font-size: 0.65625rem;
-  }
+  .button.is-responsive.is-normal {
+    font-size: 0.65625rem; }
+
   .button.is-responsive.is-medium {
-    font-size: 0.75rem;
-  }
+    font-size: 0.75rem; }
+
   .button.is-responsive.is-large {
-    font-size: 1rem;
-  }
-}
+    font-size: 1rem; } }
 @media screen and (min-width: 769px) and (max-width: 1203px) {
   .button.is-responsive.is-small {
-    font-size: 0.65625rem;
-  }
+    font-size: 0.65625rem; }
+
   .button.is-responsive,
-.button.is-responsive.is-normal {
-    font-size: 0.75rem;
-  }
+  .button.is-responsive.is-normal {
+    font-size: 0.75rem; }
+
   .button.is-responsive.is-medium {
-    font-size: 1rem;
-  }
+    font-size: 1rem; }
+
   .button.is-responsive.is-large {
-    font-size: 1.25rem;
-  }
-}
+    font-size: 1.25rem; } }
 .container {
   flex-grow: 1;
   margin: 0 auto;
   position: relative;
-  width: auto;
-}
-.container.is-fluid {
-  max-width: none !important;
-  padding-left: 32px;
-  padding-right: 32px;
-  width: 100%;
-}
-@media screen and (min-width: 1204px) {
-  .container {
-    max-width: 1140px;
-  }
-}
+  width: auto; }
+  .container.is-fluid {
+    max-width: none !important;
+    padding-left: 32px;
+    padding-right: 32px;
+    width: 100%; }
+  @media screen and (min-width: 1204px) {
+    .container {
+      max-width: 1140px; } }
 
 .content li + li {
-  margin-top: 0.25em;
-}
+  margin-top: 0.25em; }
 .content p:not(:last-child),
 .content dl:not(:last-child),
 .content ol:not(:last-child),
@@ -3661,8 +2936,7 @@ a.box:active {
 .content blockquote:not(:last-child),
 .content pre:not(:last-child),
 .content table:not(:last-child) {
-  margin-bottom: 1em;
-}
+  margin-bottom: 1em; }
 .content h1,
 .content h2,
 .content h3,
@@ -3671,174 +2945,130 @@ a.box:active {
 .content h6 {
   color: #3A3D4E;
   font-weight: 600;
-  line-height: 1.125;
-}
+  line-height: 1.125; }
 .content h1 {
   font-size: 2em;
-  margin-bottom: 0.5em;
-}
-.content h1:not(:first-child) {
-  margin-top: 1em;
-}
+  margin-bottom: 0.5em; }
+  .content h1:not(:first-child) {
+    margin-top: 1em; }
 .content h2 {
   font-size: 1.75em;
-  margin-bottom: 0.5714em;
-}
-.content h2:not(:first-child) {
-  margin-top: 1.1428em;
-}
+  margin-bottom: 0.5714em; }
+  .content h2:not(:first-child) {
+    margin-top: 1.1428em; }
 .content h3 {
   font-size: 1.5em;
-  margin-bottom: 0.6666em;
-}
-.content h3:not(:first-child) {
-  margin-top: 1.3333em;
-}
+  margin-bottom: 0.6666em; }
+  .content h3:not(:first-child) {
+    margin-top: 1.3333em; }
 .content h4 {
   font-size: 1.25em;
-  margin-bottom: 0.8em;
-}
+  margin-bottom: 0.8em; }
 .content h5 {
   font-size: 1.125em;
-  margin-bottom: 0.8888em;
-}
+  margin-bottom: 0.8888em; }
 .content h6 {
   font-size: 1em;
-  margin-bottom: 1em;
-}
+  margin-bottom: 1em; }
 .content blockquote {
   background-color: #f5f5f5;
   border-left: 5px solid #e5e5e5;
-  padding: 1.25em 1.5em;
-}
+  padding: 1.25em 1.5em; }
 .content ol {
   list-style-position: outside;
   margin-left: 2em;
-  margin-top: 1em;
-}
-.content ol:not([type]) {
-  list-style-type: decimal;
-}
-.content ol:not([type]).is-lower-alpha {
-  list-style-type: lower-alpha;
-}
-.content ol:not([type]).is-lower-roman {
-  list-style-type: lower-roman;
-}
-.content ol:not([type]).is-upper-alpha {
-  list-style-type: upper-alpha;
-}
-.content ol:not([type]).is-upper-roman {
-  list-style-type: upper-roman;
-}
+  margin-top: 1em; }
+  .content ol:not([type]) {
+    list-style-type: decimal; }
+    .content ol:not([type]).is-lower-alpha {
+      list-style-type: lower-alpha; }
+    .content ol:not([type]).is-lower-roman {
+      list-style-type: lower-roman; }
+    .content ol:not([type]).is-upper-alpha {
+      list-style-type: upper-alpha; }
+    .content ol:not([type]).is-upper-roman {
+      list-style-type: upper-roman; }
 .content ul {
   list-style: disc outside;
   margin-left: 2em;
-  margin-top: 1em;
-}
-.content ul ul {
-  list-style-type: circle;
-  margin-top: 0.5em;
-}
-.content ul ul ul {
-  list-style-type: square;
-}
+  margin-top: 1em; }
+  .content ul ul {
+    list-style-type: circle;
+    margin-top: 0.5em; }
+    .content ul ul ul {
+      list-style-type: square; }
 .content dd {
-  margin-left: 2em;
-}
+  margin-left: 2em; }
 .content figure {
   margin-left: 2em;
   margin-right: 2em;
-  text-align: center;
-}
-.content figure:not(:first-child) {
-  margin-top: 2em;
-}
-.content figure:not(:last-child) {
-  margin-bottom: 2em;
-}
-.content figure img {
-  display: inline-block;
-}
-.content figure figcaption {
-  font-style: italic;
-}
+  text-align: center; }
+  .content figure:not(:first-child) {
+    margin-top: 2em; }
+  .content figure:not(:last-child) {
+    margin-bottom: 2em; }
+  .content figure img {
+    display: inline-block; }
+  .content figure figcaption {
+    font-style: italic; }
 .content pre {
   -webkit-overflow-scrolling: touch;
   overflow-x: auto;
   padding: 1.25em 1.5em;
   white-space: pre;
-  word-wrap: normal;
-}
+  word-wrap: normal; }
 .content sup,
 .content sub {
-  font-size: 75%;
-}
+  font-size: 75%; }
 .content table {
-  width: 100%;
-}
-.content table td,
-.content table th {
-  border: 1px solid #e5e5e5;
-  border-width: 0 0 1px;
-  padding: 0.5em 0.75em;
-  vertical-align: top;
-}
-.content table th {
-  color: #3A3D4E;
-}
-.content table th:not([align]) {
-  text-align: inherit;
-}
-.content table thead td,
-.content table thead th {
-  border-width: 0 0 2px;
-  color: #3A3D4E;
-}
-.content table tfoot td,
-.content table tfoot th {
-  border-width: 2px 0 0;
-  color: #3A3D4E;
-}
-.content table tbody tr:last-child td,
-.content table tbody tr:last-child th {
-  border-bottom-width: 0;
-}
+  width: 100%; }
+  .content table td,
+  .content table th {
+    border: 1px solid #e5e5e5;
+    border-width: 0 0 1px;
+    padding: 0.5em 0.75em;
+    vertical-align: top; }
+  .content table th {
+    color: #3A3D4E; }
+    .content table th:not([align]) {
+      text-align: inherit; }
+  .content table thead td,
+  .content table thead th {
+    border-width: 0 0 2px;
+    color: #3A3D4E; }
+  .content table tfoot td,
+  .content table tfoot th {
+    border-width: 2px 0 0;
+    color: #3A3D4E; }
+  .content table tbody tr:last-child td,
+  .content table tbody tr:last-child th {
+    border-bottom-width: 0; }
 .content .tabs li + li {
-  margin-top: 0;
-}
+  margin-top: 0; }
 .content.is-small {
-  font-size: 0.75rem;
-}
+  font-size: 0.75rem; }
 .content.is-normal {
-  font-size: 1rem;
-}
+  font-size: 1rem; }
 .content.is-medium {
-  font-size: 1.25rem;
-}
+  font-size: 1.25rem; }
 .content.is-large {
-  font-size: 1.5rem;
-}
+  font-size: 1.5rem; }
 
 .icon {
   align-items: center;
   display: inline-flex;
   justify-content: center;
   height: 1.5rem;
-  width: 1.5rem;
-}
-.icon.is-small {
-  height: 1rem;
-  width: 1rem;
-}
-.icon.is-medium {
-  height: 2rem;
-  width: 2rem;
-}
-.icon.is-large {
-  height: 6rem;
-  width: 6rem;
-}
+  width: 1.5rem; }
+  .icon.is-small {
+    height: 1rem;
+    width: 1rem; }
+  .icon.is-medium {
+    height: 2rem;
+    width: 2rem; }
+  .icon.is-large {
+    height: 6rem;
+    width: 6rem; }
 
 .icon-text {
   align-items: flex-start;
@@ -3846,139 +3076,106 @@ a.box:active {
   display: inline-flex;
   flex-wrap: wrap;
   line-height: 1.5rem;
-  vertical-align: top;
-}
-.icon-text .icon {
-  flex-grow: 0;
-  flex-shrink: 0;
-}
-.icon-text .icon:not(:last-child) {
-  margin-right: 0.25em;
-}
-.icon-text .icon:not(:first-child) {
-  margin-left: 0.25em;
-}
+  vertical-align: top; }
+  .icon-text .icon {
+    flex-grow: 0;
+    flex-shrink: 0; }
+    .icon-text .icon:not(:last-child) {
+      margin-right: 0.25em; }
+    .icon-text .icon:not(:first-child) {
+      margin-left: 0.25em; }
 
 div.icon-text {
-  display: flex;
-}
+  display: flex; }
 
 .image {
   display: block;
-  position: relative;
-}
-.image img {
-  display: block;
-  height: auto;
-  width: 100%;
-}
-.image img.is-rounded {
-  border-radius: 9999px;
-}
-.image.is-fullwidth {
-  width: 100%;
-}
-.image.is-square img,
-.image.is-square .has-ratio, .image.is-1by1 img,
-.image.is-1by1 .has-ratio, .image.is-5by4 img,
-.image.is-5by4 .has-ratio, .image.is-4by3 img,
-.image.is-4by3 .has-ratio, .image.is-3by2 img,
-.image.is-3by2 .has-ratio, .image.is-5by3 img,
-.image.is-5by3 .has-ratio, .image.is-16by9 img,
-.image.is-16by9 .has-ratio, .image.is-2by1 img,
-.image.is-2by1 .has-ratio, .image.is-3by1 img,
-.image.is-3by1 .has-ratio, .image.is-4by5 img,
-.image.is-4by5 .has-ratio, .image.is-3by4 img,
-.image.is-3by4 .has-ratio, .image.is-2by3 img,
-.image.is-2by3 .has-ratio, .image.is-3by5 img,
-.image.is-3by5 .has-ratio, .image.is-9by16 img,
-.image.is-9by16 .has-ratio, .image.is-1by2 img,
-.image.is-1by2 .has-ratio, .image.is-1by3 img,
-.image.is-1by3 .has-ratio {
-  height: 100%;
-  width: 100%;
-}
-.image.is-square, .image.is-1by1 {
-  padding-top: 100%;
-}
-.image.is-5by4 {
-  padding-top: 80%;
-}
-.image.is-4by3 {
-  padding-top: 75%;
-}
-.image.is-3by2 {
-  padding-top: 66.6666%;
-}
-.image.is-5by3 {
-  padding-top: 60%;
-}
-.image.is-16by9 {
-  padding-top: 56.25%;
-}
-.image.is-2by1 {
-  padding-top: 50%;
-}
-.image.is-3by1 {
-  padding-top: 33.3333%;
-}
-.image.is-4by5 {
-  padding-top: 125%;
-}
-.image.is-3by4 {
-  padding-top: 133.3333%;
-}
-.image.is-2by3 {
-  padding-top: 150%;
-}
-.image.is-3by5 {
-  padding-top: 166.6666%;
-}
-.image.is-9by16 {
-  padding-top: 177.7777%;
-}
-.image.is-1by2 {
-  padding-top: 200%;
-}
-.image.is-1by3 {
-  padding-top: 300%;
-}
-.image.is-16x16 {
-  height: 16px;
-  width: 16px;
-}
-.image.is-24x24 {
-  height: 24px;
-  width: 24px;
-}
-.image.is-32x32 {
-  height: 32px;
-  width: 32px;
-}
-.image.is-48x48 {
-  height: 48px;
-  width: 48px;
-}
-.image.is-64x64 {
-  height: 64px;
-  width: 64px;
-}
-.image.is-96x96 {
-  height: 96px;
-  width: 96px;
-}
-.image.is-128x128 {
-  height: 128px;
-  width: 128px;
-}
+  position: relative; }
+  .image img {
+    display: block;
+    height: auto;
+    width: 100%; }
+    .image img.is-rounded {
+      border-radius: 9999px; }
+  .image.is-fullwidth {
+    width: 100%; }
+  .image.is-square img,
+  .image.is-square .has-ratio, .image.is-1by1 img,
+  .image.is-1by1 .has-ratio, .image.is-5by4 img,
+  .image.is-5by4 .has-ratio, .image.is-4by3 img,
+  .image.is-4by3 .has-ratio, .image.is-3by2 img,
+  .image.is-3by2 .has-ratio, .image.is-5by3 img,
+  .image.is-5by3 .has-ratio, .image.is-16by9 img,
+  .image.is-16by9 .has-ratio, .image.is-2by1 img,
+  .image.is-2by1 .has-ratio, .image.is-3by1 img,
+  .image.is-3by1 .has-ratio, .image.is-4by5 img,
+  .image.is-4by5 .has-ratio, .image.is-3by4 img,
+  .image.is-3by4 .has-ratio, .image.is-2by3 img,
+  .image.is-2by3 .has-ratio, .image.is-3by5 img,
+  .image.is-3by5 .has-ratio, .image.is-9by16 img,
+  .image.is-9by16 .has-ratio, .image.is-1by2 img,
+  .image.is-1by2 .has-ratio, .image.is-1by3 img,
+  .image.is-1by3 .has-ratio {
+    height: 100%;
+    width: 100%; }
+  .image.is-square, .image.is-1by1 {
+    padding-top: 100%; }
+  .image.is-5by4 {
+    padding-top: 80%; }
+  .image.is-4by3 {
+    padding-top: 75%; }
+  .image.is-3by2 {
+    padding-top: 66.6666%; }
+  .image.is-5by3 {
+    padding-top: 60%; }
+  .image.is-16by9 {
+    padding-top: 56.25%; }
+  .image.is-2by1 {
+    padding-top: 50%; }
+  .image.is-3by1 {
+    padding-top: 33.3333%; }
+  .image.is-4by5 {
+    padding-top: 125%; }
+  .image.is-3by4 {
+    padding-top: 133.3333%; }
+  .image.is-2by3 {
+    padding-top: 150%; }
+  .image.is-3by5 {
+    padding-top: 166.6666%; }
+  .image.is-9by16 {
+    padding-top: 177.7777%; }
+  .image.is-1by2 {
+    padding-top: 200%; }
+  .image.is-1by3 {
+    padding-top: 300%; }
+  .image.is-16x16 {
+    height: 16px;
+    width: 16px; }
+  .image.is-24x24 {
+    height: 24px;
+    width: 24px; }
+  .image.is-32x32 {
+    height: 32px;
+    width: 32px; }
+  .image.is-48x48 {
+    height: 48px;
+    width: 48px; }
+  .image.is-64x64 {
+    height: 64px;
+    width: 64px; }
+  .image.is-96x96 {
+    height: 96px;
+    width: 96px; }
+  .image.is-128x128 {
+    height: 128px;
+    width: 128px; }
 
 .heading {
   display: block;
   font-size: 11px;
   letter-spacing: 1px;
   margin-bottom: 5px;
-  text-transform: uppercase;
-}
+  text-transform: uppercase; }
 
 .number {
   align-items: center;
@@ -3992,950 +3189,710 @@ div.icon-text {
   min-width: 2.5em;
   padding: 0.25rem 0.5rem;
   text-align: center;
-  vertical-align: top;
-}
+  vertical-align: top; }
 
 .table {
   background-color: #fafafa;
-  color: #3A3D4E;
-}
-.table td,
-.table th {
-  border: 1px solid #e5e5e5;
-  border-width: 0 0 1px;
-  padding: 0.5em 0.75em;
-  vertical-align: top;
-}
-.table td.is-white,
-.table th.is-white {
-  background-color: #fafafa;
-  border-color: #fafafa;
-  color: #030303;
-}
-.table td.is-black,
-.table th.is-black {
-  background-color: #030303;
-  border-color: #030303;
-  color: #fafafa;
-}
-.table td.is-light,
-.table th.is-light {
-  background-color: #f5f5f5;
-  border-color: #f5f5f5;
-  color: rgba(0, 0, 0, 0.7);
-}
-.table td.is-dark,
-.table th.is-dark {
-  background-color: #3A3D4E;
-  border-color: #3A3D4E;
-  color: #fff;
-}
-.table td.is-primary,
-.table th.is-primary {
-  background-color: #005C43;
-  border-color: #005C43;
-  color: #fff;
-}
-.table td.is-link,
-.table th.is-link {
-  background-color: #004FB3;
-  border-color: #004FB3;
-  color: #fff;
-}
-.table td.is-info,
-.table th.is-info {
-  background-color: hsl(204deg, 71%, 53%);
-  border-color: hsl(204deg, 71%, 53%);
-  color: #fff;
-}
-.table td.is-success,
-.table th.is-success {
-  background-color: #1C6301;
-  border-color: #1C6301;
-  color: #fff;
-}
-.table td.is-warning,
-.table th.is-warning {
-  background-color: #EED891;
-  border-color: #EED891;
-  color: rgba(0, 0, 0, 0.7);
-}
-.table td.is-danger,
-.table th.is-danger {
-  background-color: #A30031;
-  border-color: #A30031;
-  color: #fff;
-}
-.table td.is-narrow,
-.table th.is-narrow {
-  white-space: nowrap;
-  width: 1%;
-}
-.table td.is-selected,
-.table th.is-selected {
-  background-color: #005C43;
-  color: #fff;
-}
-.table td.is-selected a,
-.table td.is-selected strong,
-.table th.is-selected a,
-.table th.is-selected strong {
-  color: currentColor;
-}
-.table td.is-vcentered,
-.table th.is-vcentered {
-  vertical-align: middle;
-}
-.table th {
-  color: #3A3D4E;
-}
-.table th:not([align]) {
-  text-align: left;
-}
-.table tr.is-selected {
-  background-color: #005C43;
-  color: #fff;
-}
-.table tr.is-selected a,
-.table tr.is-selected strong {
-  color: currentColor;
-}
-.table tr.is-selected td,
-.table tr.is-selected th {
-  border-color: #fff;
-  color: currentColor;
-}
-.table thead {
-  background-color: transparent;
-}
-.table thead td,
-.table thead th {
-  border-width: 0 0 2px;
-  color: #3A3D4E;
-}
-.table tfoot {
-  background-color: transparent;
-}
-.table tfoot td,
-.table tfoot th {
-  border-width: 2px 0 0;
-  color: #3A3D4E;
-}
-.table tbody {
-  background-color: transparent;
-}
-.table tbody tr:last-child td,
-.table tbody tr:last-child th {
-  border-bottom-width: 0;
-}
-.table.is-bordered td,
-.table.is-bordered th {
-  border-width: 1px;
-}
-.table.is-bordered tr:last-child td,
-.table.is-bordered tr:last-child th {
-  border-bottom-width: 1px;
-}
-.table.is-fullwidth {
-  width: 100%;
-}
-.table.is-hoverable tbody tr:not(.is-selected):hover {
-  background-color: #f7f7f7;
-}
-.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover {
-  background-color: #f7f7f7;
-}
-.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover:nth-child(even) {
-  background-color: #f5f5f5;
-}
-.table.is-narrow td,
-.table.is-narrow th {
-  padding: 0.25em 0.5em;
-}
-.table.is-striped tbody tr:not(.is-selected):nth-child(even) {
-  background-color: #f7f7f7;
-}
+  color: #3A3D4E; }
+  .table td,
+  .table th {
+    border: 1px solid #e5e5e5;
+    border-width: 0 0 1px;
+    padding: 0.5em 0.75em;
+    vertical-align: top; }
+    .table td.is-white,
+    .table th.is-white {
+      background-color: #fafafa;
+      border-color: #fafafa;
+      color: #030303; }
+    .table td.is-black,
+    .table th.is-black {
+      background-color: #030303;
+      border-color: #030303;
+      color: #fafafa; }
+    .table td.is-light,
+    .table th.is-light {
+      background-color: #f5f5f5;
+      border-color: #f5f5f5;
+      color: rgba(0, 0, 0, 0.7); }
+    .table td.is-dark,
+    .table th.is-dark {
+      background-color: #3A3D4E;
+      border-color: #3A3D4E;
+      color: #fff; }
+    .table td.is-primary,
+    .table th.is-primary {
+      background-color: #005C43;
+      border-color: #005C43;
+      color: #fff; }
+    .table td.is-link,
+    .table th.is-link {
+      background-color: #004FB3;
+      border-color: #004FB3;
+      color: #fff; }
+    .table td.is-info,
+    .table th.is-info {
+      background-color: #3298dc;
+      border-color: #3298dc;
+      color: #fff; }
+    .table td.is-success,
+    .table th.is-success {
+      background-color: #1C6301;
+      border-color: #1C6301;
+      color: #fff; }
+    .table td.is-warning,
+    .table th.is-warning {
+      background-color: #EED891;
+      border-color: #EED891;
+      color: rgba(0, 0, 0, 0.7); }
+    .table td.is-danger,
+    .table th.is-danger {
+      background-color: #A30031;
+      border-color: #A30031;
+      color: #fff; }
+    .table td.is-narrow,
+    .table th.is-narrow {
+      white-space: nowrap;
+      width: 1%; }
+    .table td.is-selected,
+    .table th.is-selected {
+      background-color: #005C43;
+      color: #fff; }
+      .table td.is-selected a,
+      .table td.is-selected strong,
+      .table th.is-selected a,
+      .table th.is-selected strong {
+        color: currentColor; }
+    .table td.is-vcentered,
+    .table th.is-vcentered {
+      vertical-align: middle; }
+  .table th {
+    color: #3A3D4E; }
+    .table th:not([align]) {
+      text-align: left; }
+  .table tr.is-selected {
+    background-color: #005C43;
+    color: #fff; }
+    .table tr.is-selected a,
+    .table tr.is-selected strong {
+      color: currentColor; }
+    .table tr.is-selected td,
+    .table tr.is-selected th {
+      border-color: #fff;
+      color: currentColor; }
+  .table thead {
+    background-color: transparent; }
+    .table thead td,
+    .table thead th {
+      border-width: 0 0 2px;
+      color: #3A3D4E; }
+  .table tfoot {
+    background-color: transparent; }
+    .table tfoot td,
+    .table tfoot th {
+      border-width: 2px 0 0;
+      color: #3A3D4E; }
+  .table tbody {
+    background-color: transparent; }
+    .table tbody tr:last-child td,
+    .table tbody tr:last-child th {
+      border-bottom-width: 0; }
+  .table.is-bordered td,
+  .table.is-bordered th {
+    border-width: 1px; }
+  .table.is-bordered tr:last-child td,
+  .table.is-bordered tr:last-child th {
+    border-bottom-width: 1px; }
+  .table.is-fullwidth {
+    width: 100%; }
+  .table.is-hoverable tbody tr:not(.is-selected):hover {
+    background-color: #f7f7f7; }
+  .table.is-hoverable.is-striped tbody tr:not(.is-selected):hover {
+    background-color: #f7f7f7; }
+    .table.is-hoverable.is-striped tbody tr:not(.is-selected):hover:nth-child(even) {
+      background-color: #f5f5f5; }
+  .table.is-narrow td,
+  .table.is-narrow th {
+    padding: 0.25em 0.5em; }
+  .table.is-striped tbody tr:not(.is-selected):nth-child(even) {
+    background-color: #f7f7f7; }
 
 .table-container {
   -webkit-overflow-scrolling: touch;
   overflow: auto;
   overflow-y: hidden;
-  max-width: 100%;
-}
+  max-width: 100%; }
 
 .title,
 .subtitle {
-  word-break: break-word;
-}
-.title em,
-.title span,
-.subtitle em,
-.subtitle span {
-  font-weight: inherit;
-}
-.title sub,
-.subtitle sub {
-  font-size: 0.75em;
-}
-.title sup,
-.subtitle sup {
-  font-size: 0.75em;
-}
-.title .tag,
-.subtitle .tag {
-  vertical-align: middle;
-}
+  word-break: break-word; }
+  .title em,
+  .title span,
+  .subtitle em,
+  .subtitle span {
+    font-weight: inherit; }
+  .title sub,
+  .subtitle sub {
+    font-size: 0.75em; }
+  .title sup,
+  .subtitle sup {
+    font-size: 0.75em; }
+  .title .tag,
+  .subtitle .tag {
+    vertical-align: middle; }
 
 .title {
   color: #3A3D4E;
   font-size: 2rem;
   font-weight: 600;
-  line-height: 1.125;
-}
-.title strong {
-  color: inherit;
-  font-weight: inherit;
-}
-.title:not(.is-spaced) + .subtitle {
-  margin-top: -1.25rem;
-}
-.title.is-1 {
-  font-size: 3rem;
-}
-.title.is-2 {
-  font-size: 2.5rem;
-}
-.title.is-3 {
-  font-size: 2rem;
-}
-.title.is-4 {
-  font-size: 1.5rem;
-}
-.title.is-5 {
-  font-size: 1.25rem;
-}
-.title.is-6 {
-  font-size: 1rem;
-}
-.title.is-7 {
-  font-size: 0.75rem;
-}
+  line-height: 1.125; }
+  .title strong {
+    color: inherit;
+    font-weight: inherit; }
+  .title:not(.is-spaced) + .subtitle {
+    margin-top: -1.25rem; }
+  .title.is-1 {
+    font-size: 3rem; }
+  .title.is-2 {
+    font-size: 2.5rem; }
+  .title.is-3 {
+    font-size: 2rem; }
+  .title.is-4 {
+    font-size: 1.5rem; }
+  .title.is-5 {
+    font-size: 1.25rem; }
+  .title.is-6 {
+    font-size: 1rem; }
+  .title.is-7 {
+    font-size: 0.75rem; }
 
 .subtitle {
   color: #83858D;
   font-size: 1.25rem;
   font-weight: 400;
-  line-height: 1.25;
-}
-.subtitle strong {
-  color: #3A3D4E;
-  font-weight: 600;
-}
-.subtitle:not(.is-spaced) + .title {
-  margin-top: -1.25rem;
-}
-.subtitle.is-1 {
-  font-size: 3rem;
-}
-.subtitle.is-2 {
-  font-size: 2.5rem;
-}
-.subtitle.is-3 {
-  font-size: 2rem;
-}
-.subtitle.is-4 {
-  font-size: 1.5rem;
-}
-.subtitle.is-5 {
-  font-size: 1.25rem;
-}
-.subtitle.is-6 {
-  font-size: 1rem;
-}
-.subtitle.is-7 {
-  font-size: 0.75rem;
-}
+  line-height: 1.25; }
+  .subtitle strong {
+    color: #3A3D4E;
+    font-weight: 600; }
+  .subtitle:not(.is-spaced) + .title {
+    margin-top: -1.25rem; }
+  .subtitle.is-1 {
+    font-size: 3rem; }
+  .subtitle.is-2 {
+    font-size: 2.5rem; }
+  .subtitle.is-3 {
+    font-size: 2rem; }
+  .subtitle.is-4 {
+    font-size: 1.5rem; }
+  .subtitle.is-5 {
+    font-size: 1.25rem; }
+  .subtitle.is-6 {
+    font-size: 1rem; }
+  .subtitle.is-7 {
+    font-size: 0.75rem; }
 
 /* Bulma Form */
-.select select, .textarea, .input {
+.input, .textarea, .select select {
   background-color: #fafafa;
   border-color: #e5e5e5;
   border-radius: 4px;
-  color: #3A3D4E;
-}
-.select select::-moz-placeholder, .textarea::-moz-placeholder, .input::-moz-placeholder {
-  color: rgba(58, 61, 78, 0.3);
-}
-.select select::-webkit-input-placeholder, .textarea::-webkit-input-placeholder, .input::-webkit-input-placeholder {
-  color: rgba(58, 61, 78, 0.3);
-}
-.select select:-moz-placeholder, .textarea:-moz-placeholder, .input:-moz-placeholder {
-  color: rgba(58, 61, 78, 0.3);
-}
-.select select:-ms-input-placeholder, .textarea:-ms-input-placeholder, .input:-ms-input-placeholder {
-  color: rgba(58, 61, 78, 0.3);
-}
-.select select:hover, .textarea:hover, .input:hover, .select select.is-hovered, .is-hovered.textarea, .is-hovered.input {
-  border-color: #d8d8d8;
-}
-.select select:focus, .textarea:focus, .input:focus, .select select.is-focused, .is-focused.textarea, .is-focused.input, .select select:active, .textarea:active, .input:active, .select select.is-active, .is-active.textarea, .is-active.input {
-  border-color: #004FB3;
-  box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25);
-}
-.select select[disabled], [disabled].textarea, [disabled].input, fieldset[disabled] .select select, .select fieldset[disabled] select, fieldset[disabled] .textarea, fieldset[disabled] .input {
-  background-color: #f5f5f5;
-  border-color: #f5f5f5;
-  box-shadow: none;
-  color: #cccccc;
-}
-.select select[disabled]::-moz-placeholder, [disabled].textarea::-moz-placeholder, [disabled].input::-moz-placeholder, fieldset[disabled] .select select::-moz-placeholder, .select fieldset[disabled] select::-moz-placeholder, fieldset[disabled] .textarea::-moz-placeholder, fieldset[disabled] .input::-moz-placeholder {
-  color: rgba(204, 204, 204, 0.3);
-}
-.select select[disabled]::-webkit-input-placeholder, [disabled].textarea::-webkit-input-placeholder, [disabled].input::-webkit-input-placeholder, fieldset[disabled] .select select::-webkit-input-placeholder, .select fieldset[disabled] select::-webkit-input-placeholder, fieldset[disabled] .textarea::-webkit-input-placeholder, fieldset[disabled] .input::-webkit-input-placeholder {
-  color: rgba(204, 204, 204, 0.3);
-}
-.select select[disabled]:-moz-placeholder, [disabled].textarea:-moz-placeholder, [disabled].input:-moz-placeholder, fieldset[disabled] .select select:-moz-placeholder, .select fieldset[disabled] select:-moz-placeholder, fieldset[disabled] .textarea:-moz-placeholder, fieldset[disabled] .input:-moz-placeholder {
-  color: rgba(204, 204, 204, 0.3);
-}
-.select select[disabled]:-ms-input-placeholder, [disabled].textarea:-ms-input-placeholder, [disabled].input:-ms-input-placeholder, fieldset[disabled] .select select:-ms-input-placeholder, .select fieldset[disabled] select:-ms-input-placeholder, fieldset[disabled] .textarea:-ms-input-placeholder, fieldset[disabled] .input:-ms-input-placeholder {
-  color: rgba(204, 204, 204, 0.3);
-}
+  color: #3A3D4E; }
+  .input::-moz-placeholder, .textarea::-moz-placeholder, .select select::-moz-placeholder {
+    color: rgba(58, 61, 78, 0.3); }
+  .input::-webkit-input-placeholder, .textarea::-webkit-input-placeholder, .select select::-webkit-input-placeholder {
+    color: rgba(58, 61, 78, 0.3); }
+  .input:-moz-placeholder, .textarea:-moz-placeholder, .select select:-moz-placeholder {
+    color: rgba(58, 61, 78, 0.3); }
+  .input:-ms-input-placeholder, .textarea:-ms-input-placeholder, .select select:-ms-input-placeholder {
+    color: rgba(58, 61, 78, 0.3); }
+  .input:hover, .textarea:hover, .select select:hover, .is-hovered.input, .is-hovered.textarea, .select select.is-hovered {
+    border-color: #d8d8d8; }
+  .input:focus, .textarea:focus, .select select:focus, .is-focused.input, .is-focused.textarea, .select select.is-focused, .input:active, .textarea:active, .select select:active, .is-active.input, .is-active.textarea, .select select.is-active {
+    border-color: #004FB3;
+    box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25); }
+  [disabled].input, [disabled].textarea, .select select[disabled], fieldset[disabled] .input, fieldset[disabled] .textarea, fieldset[disabled] .select select, .select fieldset[disabled] select {
+    background-color: #f5f5f5;
+    border-color: #f5f5f5;
+    box-shadow: none;
+    color: #cccccc; }
+    [disabled].input::-moz-placeholder, [disabled].textarea::-moz-placeholder, .select select[disabled]::-moz-placeholder, fieldset[disabled] .input::-moz-placeholder, fieldset[disabled] .textarea::-moz-placeholder, fieldset[disabled] .select select::-moz-placeholder, .select fieldset[disabled] select::-moz-placeholder {
+      color: rgba(204, 204, 204, 0.3); }
+    [disabled].input::-webkit-input-placeholder, [disabled].textarea::-webkit-input-placeholder, .select select[disabled]::-webkit-input-placeholder, fieldset[disabled] .input::-webkit-input-placeholder, fieldset[disabled] .textarea::-webkit-input-placeholder, fieldset[disabled] .select select::-webkit-input-placeholder, .select fieldset[disabled] select::-webkit-input-placeholder {
+      color: rgba(204, 204, 204, 0.3); }
+    [disabled].input:-moz-placeholder, [disabled].textarea:-moz-placeholder, .select select[disabled]:-moz-placeholder, fieldset[disabled] .input:-moz-placeholder, fieldset[disabled] .textarea:-moz-placeholder, fieldset[disabled] .select select:-moz-placeholder, .select fieldset[disabled] select:-moz-placeholder {
+      color: rgba(204, 204, 204, 0.3); }
+    [disabled].input:-ms-input-placeholder, [disabled].textarea:-ms-input-placeholder, .select select[disabled]:-ms-input-placeholder, fieldset[disabled] .input:-ms-input-placeholder, fieldset[disabled] .textarea:-ms-input-placeholder, fieldset[disabled] .select select:-ms-input-placeholder, .select fieldset[disabled] select:-ms-input-placeholder {
+      color: rgba(204, 204, 204, 0.3); }
 
-.textarea, .input {
+.input, .textarea {
   box-shadow: inset 0 0.0625em 0.125em rgba(3, 3, 3, 0.05);
   max-width: 100%;
-  width: 100%;
-}
-[readonly].textarea, [readonly].input {
-  box-shadow: none;
-}
-.is-white.textarea, .is-white.input {
-  border-color: #fafafa;
-}
-.is-white.textarea:focus, .is-white.input:focus, .is-white.is-focused.textarea, .is-white.is-focused.input, .is-white.textarea:active, .is-white.input:active, .is-white.is-active.textarea, .is-white.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(250, 250, 250, 0.25);
-}
-.is-black.textarea, .is-black.input {
-  border-color: #030303;
-}
-.is-black.textarea:focus, .is-black.input:focus, .is-black.is-focused.textarea, .is-black.is-focused.input, .is-black.textarea:active, .is-black.input:active, .is-black.is-active.textarea, .is-black.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(3, 3, 3, 0.25);
-}
-.is-light.textarea, .is-light.input {
-  border-color: #f5f5f5;
-}
-.is-light.textarea:focus, .is-light.input:focus, .is-light.is-focused.textarea, .is-light.is-focused.input, .is-light.textarea:active, .is-light.input:active, .is-light.is-active.textarea, .is-light.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
-}
-.is-dark.textarea, .is-dark.input {
-  border-color: #3A3D4E;
-}
-.is-dark.textarea:focus, .is-dark.input:focus, .is-dark.is-focused.textarea, .is-dark.is-focused.input, .is-dark.textarea:active, .is-dark.input:active, .is-dark.is-active.textarea, .is-dark.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(58, 61, 78, 0.25);
-}
-.is-primary.textarea, .is-primary.input {
-  border-color: #005C43;
-}
-.is-primary.textarea:focus, .is-primary.input:focus, .is-primary.is-focused.textarea, .is-primary.is-focused.input, .is-primary.textarea:active, .is-primary.input:active, .is-primary.is-active.textarea, .is-primary.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(0, 92, 67, 0.25);
-}
-.is-link.textarea, .is-link.input {
-  border-color: #004FB3;
-}
-.is-link.textarea:focus, .is-link.input:focus, .is-link.is-focused.textarea, .is-link.is-focused.input, .is-link.textarea:active, .is-link.input:active, .is-link.is-active.textarea, .is-link.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25);
-}
-.is-info.textarea, .is-info.input {
-  border-color: hsl(204deg, 71%, 53%);
-}
-.is-info.textarea:focus, .is-info.input:focus, .is-info.is-focused.textarea, .is-info.is-focused.input, .is-info.textarea:active, .is-info.input:active, .is-info.is-active.textarea, .is-info.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(50, 152, 220, 0.25);
-}
-.is-success.textarea, .is-success.input {
-  border-color: #1C6301;
-}
-.is-success.textarea:focus, .is-success.input:focus, .is-success.is-focused.textarea, .is-success.is-focused.input, .is-success.textarea:active, .is-success.input:active, .is-success.is-active.textarea, .is-success.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(28, 99, 1, 0.25);
-}
-.is-warning.textarea, .is-warning.input {
-  border-color: #EED891;
-}
-.is-warning.textarea:focus, .is-warning.input:focus, .is-warning.is-focused.textarea, .is-warning.is-focused.input, .is-warning.textarea:active, .is-warning.input:active, .is-warning.is-active.textarea, .is-warning.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(238, 216, 145, 0.25);
-}
-.is-danger.textarea, .is-danger.input {
-  border-color: #A30031;
-}
-.is-danger.textarea:focus, .is-danger.input:focus, .is-danger.is-focused.textarea, .is-danger.is-focused.input, .is-danger.textarea:active, .is-danger.input:active, .is-danger.is-active.textarea, .is-danger.is-active.input {
-  box-shadow: 0 0 0 0.125em rgba(163, 0, 49, 0.25);
-}
-.is-small.textarea, .is-small.input {
-  border-radius: 2px;
-  font-size: 0.75rem;
-}
-.is-medium.textarea, .is-medium.input {
-  font-size: 1.25rem;
-}
-.is-large.textarea, .is-large.input {
-  font-size: 1.5rem;
-}
-.is-fullwidth.textarea, .is-fullwidth.input {
-  display: block;
-  width: 100%;
-}
-.is-inline.textarea, .is-inline.input {
-  display: inline;
-  width: auto;
-}
+  width: 100%; }
+  [readonly].input, [readonly].textarea {
+    box-shadow: none; }
+  .is-white.input, .is-white.textarea {
+    border-color: #fafafa; }
+    .is-white.input:focus, .is-white.textarea:focus, .is-white.is-focused.input, .is-white.is-focused.textarea, .is-white.input:active, .is-white.textarea:active, .is-white.is-active.input, .is-white.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(250, 250, 250, 0.25); }
+  .is-black.input, .is-black.textarea {
+    border-color: #030303; }
+    .is-black.input:focus, .is-black.textarea:focus, .is-black.is-focused.input, .is-black.is-focused.textarea, .is-black.input:active, .is-black.textarea:active, .is-black.is-active.input, .is-black.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(3, 3, 3, 0.25); }
+  .is-light.input, .is-light.textarea {
+    border-color: #f5f5f5; }
+    .is-light.input:focus, .is-light.textarea:focus, .is-light.is-focused.input, .is-light.is-focused.textarea, .is-light.input:active, .is-light.textarea:active, .is-light.is-active.input, .is-light.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25); }
+  .is-dark.input, .is-dark.textarea {
+    border-color: #3A3D4E; }
+    .is-dark.input:focus, .is-dark.textarea:focus, .is-dark.is-focused.input, .is-dark.is-focused.textarea, .is-dark.input:active, .is-dark.textarea:active, .is-dark.is-active.input, .is-dark.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(58, 61, 78, 0.25); }
+  .is-primary.input, .is-primary.textarea {
+    border-color: #005C43; }
+    .is-primary.input:focus, .is-primary.textarea:focus, .is-primary.is-focused.input, .is-primary.is-focused.textarea, .is-primary.input:active, .is-primary.textarea:active, .is-primary.is-active.input, .is-primary.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(0, 92, 67, 0.25); }
+  .is-link.input, .is-link.textarea {
+    border-color: #004FB3; }
+    .is-link.input:focus, .is-link.textarea:focus, .is-link.is-focused.input, .is-link.is-focused.textarea, .is-link.input:active, .is-link.textarea:active, .is-link.is-active.input, .is-link.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25); }
+  .is-info.input, .is-info.textarea {
+    border-color: #3298dc; }
+    .is-info.input:focus, .is-info.textarea:focus, .is-info.is-focused.input, .is-info.is-focused.textarea, .is-info.input:active, .is-info.textarea:active, .is-info.is-active.input, .is-info.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(50, 152, 220, 0.25); }
+  .is-success.input, .is-success.textarea {
+    border-color: #1C6301; }
+    .is-success.input:focus, .is-success.textarea:focus, .is-success.is-focused.input, .is-success.is-focused.textarea, .is-success.input:active, .is-success.textarea:active, .is-success.is-active.input, .is-success.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(28, 99, 1, 0.25); }
+  .is-warning.input, .is-warning.textarea {
+    border-color: #EED891; }
+    .is-warning.input:focus, .is-warning.textarea:focus, .is-warning.is-focused.input, .is-warning.is-focused.textarea, .is-warning.input:active, .is-warning.textarea:active, .is-warning.is-active.input, .is-warning.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(238, 216, 145, 0.25); }
+  .is-danger.input, .is-danger.textarea {
+    border-color: #A30031; }
+    .is-danger.input:focus, .is-danger.textarea:focus, .is-danger.is-focused.input, .is-danger.is-focused.textarea, .is-danger.input:active, .is-danger.textarea:active, .is-danger.is-active.input, .is-danger.is-active.textarea {
+      box-shadow: 0 0 0 0.125em rgba(163, 0, 49, 0.25); }
+  .is-small.input, .is-small.textarea {
+    border-radius: 2px;
+    font-size: 0.75rem; }
+  .is-medium.input, .is-medium.textarea {
+    font-size: 1.25rem; }
+  .is-large.input, .is-large.textarea {
+    font-size: 1.5rem; }
+  .is-fullwidth.input, .is-fullwidth.textarea {
+    display: block;
+    width: 100%; }
+  .is-inline.input, .is-inline.textarea {
+    display: inline;
+    width: auto; }
 
 .input.is-rounded {
   border-radius: 9999px;
   padding-left: calc(calc(0.75em - 1px) + 0.375em);
-  padding-right: calc(calc(0.75em - 1px) + 0.375em);
-}
+  padding-right: calc(calc(0.75em - 1px) + 0.375em); }
 .input.is-static {
   background-color: transparent;
   border-color: transparent;
   box-shadow: none;
   padding-left: 0;
-  padding-right: 0;
-}
+  padding-right: 0; }
 
 .textarea {
   display: block;
   max-width: 100%;
   min-width: 100%;
   padding: calc(0.75em - 1px);
-  resize: vertical;
-}
-.textarea:not([rows]) {
-  max-height: 40em;
-  min-height: 8em;
-}
-.textarea[rows] {
-  height: initial;
-}
-.textarea.has-fixed-size {
-  resize: none;
-}
+  resize: vertical; }
+  .textarea:not([rows]) {
+    max-height: 40em;
+    min-height: 8em; }
+  .textarea[rows] {
+    height: initial; }
+  .textarea.has-fixed-size {
+    resize: none; }
 
-.radio, .checkbox {
+.checkbox, .radio {
   cursor: pointer;
   display: inline-block;
   line-height: 1.25;
-  position: relative;
-}
-.radio input, .checkbox input {
-  cursor: pointer;
-}
-.radio:hover, .checkbox:hover {
-  color: #3A3D4E;
-}
-[disabled].radio, [disabled].checkbox, fieldset[disabled] .radio, fieldset[disabled] .checkbox,
-.radio input[disabled],
-.checkbox input[disabled] {
-  color: #cccccc;
-  cursor: not-allowed;
-}
+  position: relative; }
+  .checkbox input, .radio input {
+    cursor: pointer; }
+  .checkbox:hover, .radio:hover {
+    color: #3A3D4E; }
+  [disabled].checkbox, [disabled].radio, fieldset[disabled] .checkbox, fieldset[disabled] .radio,
+  .checkbox input[disabled],
+  .radio input[disabled] {
+    color: #cccccc;
+    cursor: not-allowed; }
 
 .radio + .radio {
-  margin-left: 0.5em;
-}
+  margin-left: 0.5em; }
 
 .select {
   display: inline-block;
   max-width: 100%;
   position: relative;
-  vertical-align: top;
-}
-.select:not(.is-multiple) {
-  height: 2.5em;
-}
-.select:not(.is-multiple):not(.is-loading)::after {
-  border-color: #004FB3;
-  right: 1.125em;
-  z-index: 4;
-}
-.select.is-rounded select {
-  border-radius: 9999px;
-  padding-left: 1em;
-}
-.select select {
-  cursor: pointer;
-  display: block;
-  font-size: 1em;
-  max-width: 100%;
-  outline: none;
-}
-.select select::-ms-expand {
-  display: none;
-}
-.select select[disabled]:hover, fieldset[disabled] .select select:hover {
-  border-color: #f5f5f5;
-}
-.select select:not([multiple]) {
-  padding-right: 2.5em;
-}
-.select select[multiple] {
-  height: auto;
-  padding: 0;
-}
-.select select[multiple] option {
-  padding: 0.5em 1em;
-}
-.select:not(.is-multiple):not(.is-loading):hover::after {
-  border-color: #3A3D4E;
-}
-.select.is-white:not(:hover)::after {
-  border-color: #fafafa;
-}
-.select.is-white select {
-  border-color: #fafafa;
-}
-.select.is-white select:hover, .select.is-white select.is-hovered {
-  border-color: #ededed;
-}
-.select.is-white select:focus, .select.is-white select.is-focused, .select.is-white select:active, .select.is-white select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(250, 250, 250, 0.25);
-}
-.select.is-black:not(:hover)::after {
-  border-color: #030303;
-}
-.select.is-black select {
-  border-color: #030303;
-}
-.select.is-black select:hover, .select.is-black select.is-hovered {
-  border-color: black;
-}
-.select.is-black select:focus, .select.is-black select.is-focused, .select.is-black select:active, .select.is-black select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(3, 3, 3, 0.25);
-}
-.select.is-light:not(:hover)::after {
-  border-color: #f5f5f5;
-}
-.select.is-light select {
-  border-color: #f5f5f5;
-}
-.select.is-light select:hover, .select.is-light select.is-hovered {
-  border-color: #e8e8e8;
-}
-.select.is-light select:focus, .select.is-light select.is-focused, .select.is-light select:active, .select.is-light select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
-}
-.select.is-dark:not(:hover)::after {
-  border-color: #3A3D4E;
-}
-.select.is-dark select {
-  border-color: #3A3D4E;
-}
-.select.is-dark select:hover, .select.is-dark select.is-hovered {
-  border-color: #2f323f;
-}
-.select.is-dark select:focus, .select.is-dark select.is-focused, .select.is-dark select:active, .select.is-dark select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(58, 61, 78, 0.25);
-}
-.select.is-primary:not(:hover)::after {
-  border-color: #005C43;
-}
-.select.is-primary select {
-  border-color: #005C43;
-}
-.select.is-primary select:hover, .select.is-primary select.is-hovered {
-  border-color: #004330;
-}
-.select.is-primary select:focus, .select.is-primary select.is-focused, .select.is-primary select:active, .select.is-primary select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(0, 92, 67, 0.25);
-}
-.select.is-link:not(:hover)::after {
-  border-color: #004FB3;
-}
-.select.is-link select {
-  border-color: #004FB3;
-}
-.select.is-link select:hover, .select.is-link select.is-hovered {
-  border-color: #00449a;
-}
-.select.is-link select:focus, .select.is-link select.is-focused, .select.is-link select:active, .select.is-link select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25);
-}
-.select.is-info:not(:hover)::after {
-  border-color: hsl(204deg, 71%, 53%);
-}
-.select.is-info select {
-  border-color: hsl(204deg, 71%, 53%);
-}
-.select.is-info select:hover, .select.is-info select.is-hovered {
-  border-color: #238cd1;
-}
-.select.is-info select:focus, .select.is-info select.is-focused, .select.is-info select:active, .select.is-info select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(50, 152, 220, 0.25);
-}
-.select.is-success:not(:hover)::after {
-  border-color: #1C6301;
-}
-.select.is-success select {
-  border-color: #1C6301;
-}
-.select.is-success select:hover, .select.is-success select.is-hovered {
-  border-color: #154a01;
-}
-.select.is-success select:focus, .select.is-success select.is-focused, .select.is-success select:active, .select.is-success select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(28, 99, 1, 0.25);
-}
-.select.is-warning:not(:hover)::after {
-  border-color: #EED891;
-}
-.select.is-warning select {
-  border-color: #EED891;
-}
-.select.is-warning select:hover, .select.is-warning select.is-hovered {
-  border-color: #ebd07b;
-}
-.select.is-warning select:focus, .select.is-warning select.is-focused, .select.is-warning select:active, .select.is-warning select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(238, 216, 145, 0.25);
-}
-.select.is-danger:not(:hover)::after {
-  border-color: #A30031;
-}
-.select.is-danger select {
-  border-color: #A30031;
-}
-.select.is-danger select:hover, .select.is-danger select.is-hovered {
-  border-color: #8a0029;
-}
-.select.is-danger select:focus, .select.is-danger select.is-focused, .select.is-danger select:active, .select.is-danger select.is-active {
-  box-shadow: 0 0 0 0.125em rgba(163, 0, 49, 0.25);
-}
-.select.is-small {
-  border-radius: 2px;
-  font-size: 0.75rem;
-}
-.select.is-medium {
-  font-size: 1.25rem;
-}
-.select.is-large {
-  font-size: 1.5rem;
-}
-.select.is-disabled::after {
-  border-color: #cccccc !important;
-  opacity: 0.5;
-}
-.select.is-fullwidth {
-  width: 100%;
-}
-.select.is-fullwidth select {
-  width: 100%;
-}
-.select.is-loading::after {
-  margin-top: 0;
-  position: absolute;
-  right: 0.625em;
-  top: 0.625em;
-  transform: none;
-}
-.select.is-loading.is-small:after {
-  font-size: 0.75rem;
-}
-.select.is-loading.is-medium:after {
-  font-size: 1.25rem;
-}
-.select.is-loading.is-large:after {
-  font-size: 1.5rem;
-}
+  vertical-align: top; }
+  .select:not(.is-multiple) {
+    height: 2.5em; }
+  .select:not(.is-multiple):not(.is-loading)::after {
+    border-color: #004FB3;
+    right: 1.125em;
+    z-index: 4; }
+  .select.is-rounded select {
+    border-radius: 9999px;
+    padding-left: 1em; }
+  .select select {
+    cursor: pointer;
+    display: block;
+    font-size: 1em;
+    max-width: 100%;
+    outline: none; }
+    .select select::-ms-expand {
+      display: none; }
+    .select select[disabled]:hover, fieldset[disabled] .select select:hover {
+      border-color: #f5f5f5; }
+    .select select:not([multiple]) {
+      padding-right: 2.5em; }
+    .select select[multiple] {
+      height: auto;
+      padding: 0; }
+      .select select[multiple] option {
+        padding: 0.5em 1em; }
+  .select:not(.is-multiple):not(.is-loading):hover::after {
+    border-color: #3A3D4E; }
+  .select.is-white:not(:hover)::after {
+    border-color: #fafafa; }
+  .select.is-white select {
+    border-color: #fafafa; }
+    .select.is-white select:hover, .select.is-white select.is-hovered {
+      border-color: #ededed; }
+    .select.is-white select:focus, .select.is-white select.is-focused, .select.is-white select:active, .select.is-white select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(250, 250, 250, 0.25); }
+  .select.is-black:not(:hover)::after {
+    border-color: #030303; }
+  .select.is-black select {
+    border-color: #030303; }
+    .select.is-black select:hover, .select.is-black select.is-hovered {
+      border-color: black; }
+    .select.is-black select:focus, .select.is-black select.is-focused, .select.is-black select:active, .select.is-black select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(3, 3, 3, 0.25); }
+  .select.is-light:not(:hover)::after {
+    border-color: #f5f5f5; }
+  .select.is-light select {
+    border-color: #f5f5f5; }
+    .select.is-light select:hover, .select.is-light select.is-hovered {
+      border-color: #e8e8e8; }
+    .select.is-light select:focus, .select.is-light select.is-focused, .select.is-light select:active, .select.is-light select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25); }
+  .select.is-dark:not(:hover)::after {
+    border-color: #3A3D4E; }
+  .select.is-dark select {
+    border-color: #3A3D4E; }
+    .select.is-dark select:hover, .select.is-dark select.is-hovered {
+      border-color: #2f323f; }
+    .select.is-dark select:focus, .select.is-dark select.is-focused, .select.is-dark select:active, .select.is-dark select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(58, 61, 78, 0.25); }
+  .select.is-primary:not(:hover)::after {
+    border-color: #005C43; }
+  .select.is-primary select {
+    border-color: #005C43; }
+    .select.is-primary select:hover, .select.is-primary select.is-hovered {
+      border-color: #004330; }
+    .select.is-primary select:focus, .select.is-primary select.is-focused, .select.is-primary select:active, .select.is-primary select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(0, 92, 67, 0.25); }
+  .select.is-link:not(:hover)::after {
+    border-color: #004FB3; }
+  .select.is-link select {
+    border-color: #004FB3; }
+    .select.is-link select:hover, .select.is-link select.is-hovered {
+      border-color: #00449a; }
+    .select.is-link select:focus, .select.is-link select.is-focused, .select.is-link select:active, .select.is-link select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(0, 79, 179, 0.25); }
+  .select.is-info:not(:hover)::after {
+    border-color: #3298dc; }
+  .select.is-info select {
+    border-color: #3298dc; }
+    .select.is-info select:hover, .select.is-info select.is-hovered {
+      border-color: #238cd1; }
+    .select.is-info select:focus, .select.is-info select.is-focused, .select.is-info select:active, .select.is-info select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(50, 152, 220, 0.25); }
+  .select.is-success:not(:hover)::after {
+    border-color: #1C6301; }
+  .select.is-success select {
+    border-color: #1C6301; }
+    .select.is-success select:hover, .select.is-success select.is-hovered {
+      border-color: #154a01; }
+    .select.is-success select:focus, .select.is-success select.is-focused, .select.is-success select:active, .select.is-success select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(28, 99, 1, 0.25); }
+  .select.is-warning:not(:hover)::after {
+    border-color: #EED891; }
+  .select.is-warning select {
+    border-color: #EED891; }
+    .select.is-warning select:hover, .select.is-warning select.is-hovered {
+      border-color: #ebd07b; }
+    .select.is-warning select:focus, .select.is-warning select.is-focused, .select.is-warning select:active, .select.is-warning select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(238, 216, 145, 0.25); }
+  .select.is-danger:not(:hover)::after {
+    border-color: #A30031; }
+  .select.is-danger select {
+    border-color: #A30031; }
+    .select.is-danger select:hover, .select.is-danger select.is-hovered {
+      border-color: #8a0029; }
+    .select.is-danger select:focus, .select.is-danger select.is-focused, .select.is-danger select:active, .select.is-danger select.is-active {
+      box-shadow: 0 0 0 0.125em rgba(163, 0, 49, 0.25); }
+  .select.is-small {
+    border-radius: 2px;
+    font-size: 0.75rem; }
+  .select.is-medium {
+    font-size: 1.25rem; }
+  .select.is-large {
+    font-size: 1.5rem; }
+  .select.is-disabled::after {
+    border-color: #cccccc !important;
+    opacity: 0.5; }
+  .select.is-fullwidth {
+    width: 100%; }
+    .select.is-fullwidth select {
+      width: 100%; }
+  .select.is-loading::after {
+    margin-top: 0;
+    position: absolute;
+    right: 0.625em;
+    top: 0.625em;
+    transform: none; }
+  .select.is-loading.is-small:after {
+    font-size: 0.75rem; }
+  .select.is-loading.is-medium:after {
+    font-size: 1.25rem; }
+  .select.is-loading.is-large:after {
+    font-size: 1.5rem; }
 
 .file {
   align-items: stretch;
   display: flex;
   justify-content: flex-start;
-  position: relative;
-}
-.file.is-white .file-cta {
-  background-color: #fafafa;
-  border-color: transparent;
-  color: #030303;
-}
-.file.is-white:hover .file-cta, .file.is-white.is-hovered .file-cta {
-  background-color: #f4f4f4;
-  border-color: transparent;
-  color: #030303;
-}
-.file.is-white:focus .file-cta, .file.is-white.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(250, 250, 250, 0.25);
-  color: #030303;
-}
-.file.is-white:active .file-cta, .file.is-white.is-active .file-cta {
-  background-color: #ededed;
-  border-color: transparent;
-  color: #030303;
-}
-.file.is-black .file-cta {
-  background-color: #030303;
-  border-color: transparent;
-  color: #fafafa;
-}
-.file.is-black:hover .file-cta, .file.is-black.is-hovered .file-cta {
-  background-color: black;
-  border-color: transparent;
-  color: #fafafa;
-}
-.file.is-black:focus .file-cta, .file.is-black.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(3, 3, 3, 0.25);
-  color: #fafafa;
-}
-.file.is-black:active .file-cta, .file.is-black.is-active .file-cta {
-  background-color: black;
-  border-color: transparent;
-  color: #fafafa;
-}
-.file.is-light .file-cta {
-  background-color: #f5f5f5;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.file.is-light:hover .file-cta, .file.is-light.is-hovered .file-cta {
-  background-color: #efefef;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.file.is-light:focus .file-cta, .file.is-light.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(245, 245, 245, 0.25);
-  color: rgba(0, 0, 0, 0.7);
-}
-.file.is-light:active .file-cta, .file.is-light.is-active .file-cta {
-  background-color: #e8e8e8;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.file.is-dark .file-cta {
-  background-color: #3A3D4E;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-dark:hover .file-cta, .file.is-dark.is-hovered .file-cta {
-  background-color: #353747;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-dark:focus .file-cta, .file.is-dark.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(58, 61, 78, 0.25);
-  color: #fff;
-}
-.file.is-dark:active .file-cta, .file.is-dark.is-active .file-cta {
-  background-color: #2f323f;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-primary .file-cta {
-  background-color: #005C43;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-primary:hover .file-cta, .file.is-primary.is-hovered .file-cta {
-  background-color: #004f3a;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-primary:focus .file-cta, .file.is-primary.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(0, 92, 67, 0.25);
-  color: #fff;
-}
-.file.is-primary:active .file-cta, .file.is-primary.is-active .file-cta {
-  background-color: #004330;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-link .file-cta {
-  background-color: #004FB3;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-link:hover .file-cta, .file.is-link.is-hovered .file-cta {
-  background-color: #0049a6;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-link:focus .file-cta, .file.is-link.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(0, 79, 179, 0.25);
-  color: #fff;
-}
-.file.is-link:active .file-cta, .file.is-link.is-active .file-cta {
-  background-color: #00449a;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-info .file-cta {
-  background-color: hsl(204deg, 71%, 53%);
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-info:hover .file-cta, .file.is-info.is-hovered .file-cta {
-  background-color: #2793da;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-info:focus .file-cta, .file.is-info.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(50, 152, 220, 0.25);
-  color: #fff;
-}
-.file.is-info:active .file-cta, .file.is-info.is-active .file-cta {
-  background-color: #238cd1;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-success .file-cta {
-  background-color: #1C6301;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-success:hover .file-cta, .file.is-success.is-hovered .file-cta {
-  background-color: #185601;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-success:focus .file-cta, .file.is-success.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(28, 99, 1, 0.25);
-  color: #fff;
-}
-.file.is-success:active .file-cta, .file.is-success.is-active .file-cta {
-  background-color: #154a01;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-warning .file-cta {
-  background-color: #EED891;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.file.is-warning:hover .file-cta, .file.is-warning.is-hovered .file-cta {
-  background-color: #ecd486;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.file.is-warning:focus .file-cta, .file.is-warning.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(238, 216, 145, 0.25);
-  color: rgba(0, 0, 0, 0.7);
-}
-.file.is-warning:active .file-cta, .file.is-warning.is-active .file-cta {
-  background-color: #ebd07b;
-  border-color: transparent;
-  color: rgba(0, 0, 0, 0.7);
-}
-.file.is-danger .file-cta {
-  background-color: #A30031;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-danger:hover .file-cta, .file.is-danger.is-hovered .file-cta {
-  background-color: #96002d;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-danger:focus .file-cta, .file.is-danger.is-focused .file-cta {
-  border-color: transparent;
-  box-shadow: 0 0 0.5em rgba(163, 0, 49, 0.25);
-  color: #fff;
-}
-.file.is-danger:active .file-cta, .file.is-danger.is-active .file-cta {
-  background-color: #8a0029;
-  border-color: transparent;
-  color: #fff;
-}
-.file.is-small {
-  font-size: 0.75rem;
-}
-.file.is-normal {
-  font-size: 1rem;
-}
-.file.is-medium {
-  font-size: 1.25rem;
-}
-.file.is-medium .file-icon .fa {
-  font-size: 21px;
-}
-.file.is-large {
-  font-size: 1.5rem;
-}
-.file.is-large .file-icon .fa {
-  font-size: 28px;
-}
-.file.has-name .file-cta {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-}
-.file.has-name .file-name {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
-.file.has-name.is-empty .file-cta {
-  border-radius: 4px;
-}
-.file.has-name.is-empty .file-name {
-  display: none;
-}
-.file.is-boxed .file-label {
-  flex-direction: column;
-}
-.file.is-boxed .file-cta {
-  flex-direction: column;
-  height: auto;
-  padding: 1em 3em;
-}
-.file.is-boxed .file-name {
-  border-width: 0 1px 1px;
-}
-.file.is-boxed .file-icon {
-  height: 1.5em;
-  width: 1.5em;
-}
-.file.is-boxed .file-icon .fa {
-  font-size: 21px;
-}
-.file.is-boxed.is-small .file-icon .fa {
-  font-size: 14px;
-}
-.file.is-boxed.is-medium .file-icon .fa {
-  font-size: 28px;
-}
-.file.is-boxed.is-large .file-icon .fa {
-  font-size: 35px;
-}
-.file.is-boxed.has-name .file-cta {
-  border-radius: 4px 4px 0 0;
-}
-.file.is-boxed.has-name .file-name {
-  border-radius: 0 0 4px 4px;
-  border-width: 0 1px 1px;
-}
-.file.is-centered {
-  justify-content: center;
-}
-.file.is-fullwidth .file-label {
-  width: 100%;
-}
-.file.is-fullwidth .file-name {
-  flex-grow: 1;
-  max-width: none;
-}
-.file.is-right {
-  justify-content: flex-end;
-}
-.file.is-right .file-cta {
-  border-radius: 0 4px 4px 0;
-}
-.file.is-right .file-name {
-  border-radius: 4px 0 0 4px;
-  border-width: 1px 0 1px 1px;
-  order: -1;
-}
+  position: relative; }
+  .file.is-white .file-cta {
+    background-color: #fafafa;
+    border-color: transparent;
+    color: #030303; }
+  .file.is-white:hover .file-cta, .file.is-white.is-hovered .file-cta {
+    background-color: #f4f4f4;
+    border-color: transparent;
+    color: #030303; }
+  .file.is-white:focus .file-cta, .file.is-white.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(250, 250, 250, 0.25);
+    color: #030303; }
+  .file.is-white:active .file-cta, .file.is-white.is-active .file-cta {
+    background-color: #ededed;
+    border-color: transparent;
+    color: #030303; }
+  .file.is-black .file-cta {
+    background-color: #030303;
+    border-color: transparent;
+    color: #fafafa; }
+  .file.is-black:hover .file-cta, .file.is-black.is-hovered .file-cta {
+    background-color: black;
+    border-color: transparent;
+    color: #fafafa; }
+  .file.is-black:focus .file-cta, .file.is-black.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(3, 3, 3, 0.25);
+    color: #fafafa; }
+  .file.is-black:active .file-cta, .file.is-black.is-active .file-cta {
+    background-color: black;
+    border-color: transparent;
+    color: #fafafa; }
+  .file.is-light .file-cta {
+    background-color: #f5f5f5;
+    border-color: transparent;
+    color: rgba(0, 0, 0, 0.7); }
+  .file.is-light:hover .file-cta, .file.is-light.is-hovered .file-cta {
+    background-color: #efefef;
+    border-color: transparent;
+    color: rgba(0, 0, 0, 0.7); }
+  .file.is-light:focus .file-cta, .file.is-light.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(245, 245, 245, 0.25);
+    color: rgba(0, 0, 0, 0.7); }
+  .file.is-light:active .file-cta, .file.is-light.is-active .file-cta {
+    background-color: #e8e8e8;
+    border-color: transparent;
+    color: rgba(0, 0, 0, 0.7); }
+  .file.is-dark .file-cta {
+    background-color: #3A3D4E;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-dark:hover .file-cta, .file.is-dark.is-hovered .file-cta {
+    background-color: #353747;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-dark:focus .file-cta, .file.is-dark.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(58, 61, 78, 0.25);
+    color: #fff; }
+  .file.is-dark:active .file-cta, .file.is-dark.is-active .file-cta {
+    background-color: #2f323f;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-primary .file-cta {
+    background-color: #005C43;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-primary:hover .file-cta, .file.is-primary.is-hovered .file-cta {
+    background-color: #004f3a;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-primary:focus .file-cta, .file.is-primary.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(0, 92, 67, 0.25);
+    color: #fff; }
+  .file.is-primary:active .file-cta, .file.is-primary.is-active .file-cta {
+    background-color: #004330;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-link .file-cta {
+    background-color: #004FB3;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-link:hover .file-cta, .file.is-link.is-hovered .file-cta {
+    background-color: #0049a6;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-link:focus .file-cta, .file.is-link.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(0, 79, 179, 0.25);
+    color: #fff; }
+  .file.is-link:active .file-cta, .file.is-link.is-active .file-cta {
+    background-color: #00449a;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-info .file-cta {
+    background-color: #3298dc;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-info:hover .file-cta, .file.is-info.is-hovered .file-cta {
+    background-color: #2793da;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-info:focus .file-cta, .file.is-info.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(50, 152, 220, 0.25);
+    color: #fff; }
+  .file.is-info:active .file-cta, .file.is-info.is-active .file-cta {
+    background-color: #238cd1;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-success .file-cta {
+    background-color: #1C6301;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-success:hover .file-cta, .file.is-success.is-hovered .file-cta {
+    background-color: #185601;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-success:focus .file-cta, .file.is-success.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(28, 99, 1, 0.25);
+    color: #fff; }
+  .file.is-success:active .file-cta, .file.is-success.is-active .file-cta {
+    background-color: #154a01;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-warning .file-cta {
+    background-color: #EED891;
+    border-color: transparent;
+    color: rgba(0, 0, 0, 0.7); }
+  .file.is-warning:hover .file-cta, .file.is-warning.is-hovered .file-cta {
+    background-color: #ecd486;
+    border-color: transparent;
+    color: rgba(0, 0, 0, 0.7); }
+  .file.is-warning:focus .file-cta, .file.is-warning.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(238, 216, 145, 0.25);
+    color: rgba(0, 0, 0, 0.7); }
+  .file.is-warning:active .file-cta, .file.is-warning.is-active .file-cta {
+    background-color: #ebd07b;
+    border-color: transparent;
+    color: rgba(0, 0, 0, 0.7); }
+  .file.is-danger .file-cta {
+    background-color: #A30031;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-danger:hover .file-cta, .file.is-danger.is-hovered .file-cta {
+    background-color: #96002d;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-danger:focus .file-cta, .file.is-danger.is-focused .file-cta {
+    border-color: transparent;
+    box-shadow: 0 0 0.5em rgba(163, 0, 49, 0.25);
+    color: #fff; }
+  .file.is-danger:active .file-cta, .file.is-danger.is-active .file-cta {
+    background-color: #8a0029;
+    border-color: transparent;
+    color: #fff; }
+  .file.is-small {
+    font-size: 0.75rem; }
+  .file.is-normal {
+    font-size: 1rem; }
+  .file.is-medium {
+    font-size: 1.25rem; }
+    .file.is-medium .file-icon .fa {
+      font-size: 21px; }
+  .file.is-large {
+    font-size: 1.5rem; }
+    .file.is-large .file-icon .fa {
+      font-size: 28px; }
+  .file.has-name .file-cta {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0; }
+  .file.has-name .file-name {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0; }
+  .file.has-name.is-empty .file-cta {
+    border-radius: 4px; }
+  .file.has-name.is-empty .file-name {
+    display: none; }
+  .file.is-boxed .file-label {
+    flex-direction: column; }
+  .file.is-boxed .file-cta {
+    flex-direction: column;
+    height: auto;
+    padding: 1em 3em; }
+  .file.is-boxed .file-name {
+    border-width: 0 1px 1px; }
+  .file.is-boxed .file-icon {
+    height: 1.5em;
+    width: 1.5em; }
+    .file.is-boxed .file-icon .fa {
+      font-size: 21px; }
+  .file.is-boxed.is-small .file-icon .fa {
+    font-size: 14px; }
+  .file.is-boxed.is-medium .file-icon .fa {
+    font-size: 28px; }
+  .file.is-boxed.is-large .file-icon .fa {
+    font-size: 35px; }
+  .file.is-boxed.has-name .file-cta {
+    border-radius: 4px 4px 0 0; }
+  .file.is-boxed.has-name .file-name {
+    border-radius: 0 0 4px 4px;
+    border-width: 0 1px 1px; }
+  .file.is-centered {
+    justify-content: center; }
+  .file.is-fullwidth .file-label {
+    width: 100%; }
+  .file.is-fullwidth .file-name {
+    flex-grow: 1;
+    max-width: none; }
+  .file.is-right {
+    justify-content: flex-end; }
+    .file.is-right .file-cta {
+      border-radius: 0 4px 4px 0; }
+    .file.is-right .file-name {
+      border-radius: 4px 0 0 4px;
+      border-width: 1px 0 1px 1px;
+      order: -1; }
 
 .file-label {
   align-items: stretch;
@@ -4943,22 +3900,17 @@ div.icon-text {
   cursor: pointer;
   justify-content: flex-start;
   overflow: hidden;
-  position: relative;
-}
-.file-label:hover .file-cta {
-  background-color: #efefef;
-  color: #3A3D4E;
-}
-.file-label:hover .file-name {
-  border-color: #dfdfdf;
-}
-.file-label:active .file-cta {
-  background-color: #e8e8e8;
-  color: #3A3D4E;
-}
-.file-label:active .file-name {
-  border-color: #d8d8d8;
-}
+  position: relative; }
+  .file-label:hover .file-cta {
+    background-color: #efefef;
+    color: #3A3D4E; }
+  .file-label:hover .file-name {
+    border-color: #dfdfdf; }
+  .file-label:active .file-cta {
+    background-color: #e8e8e8;
+    color: #3A3D4E; }
+  .file-label:active .file-name {
+    border-color: #d8d8d8; }
 
 .file-input {
   height: 100%;
@@ -4967,8 +3919,7 @@ div.icon-text {
   outline: none;
   position: absolute;
   top: 0;
-  width: 100%;
-}
+  width: 100%; }
 
 .file-cta,
 .file-name {
@@ -4977,13 +3928,11 @@ div.icon-text {
   font-size: 1em;
   padding-left: 1em;
   padding-right: 1em;
-  white-space: nowrap;
-}
+  white-space: nowrap; }
 
 .file-cta {
   background-color: #f5f5f5;
-  color: #83858D;
-}
+  color: #83858D; }
 
 .file-name {
   border-color: #e5e5e5;
@@ -4993,8 +3942,7 @@ div.icon-text {
   max-width: 16em;
   overflow: hidden;
   text-align: inherit;
-  text-overflow: ellipsis;
-}
+  text-overflow: ellipsis; }
 
 .file-icon {
   align-items: center;
@@ -5002,3416 +3950,2496 @@ div.icon-text {
   height: 1em;
   justify-content: center;
   margin-right: 0.5em;
-  width: 1em;
-}
-.file-icon .fa {
-  font-size: 14px;
-}
+  width: 1em; }
+  .file-icon .fa {
+    font-size: 14px; }
 
 .label {
   color: #3A3D4E;
   display: block;
   font-size: 1rem;
-  font-weight: 700;
-}
-.label:not(:last-child) {
-  margin-bottom: 0.5em;
-}
-.label.is-small {
-  font-size: 0.75rem;
-}
-.label.is-medium {
-  font-size: 1.25rem;
-}
-.label.is-large {
-  font-size: 1.5rem;
-}
+  font-weight: 700; }
+  .label:not(:last-child) {
+    margin-bottom: 0.5em; }
+  .label.is-small {
+    font-size: 0.75rem; }
+  .label.is-medium {
+    font-size: 1.25rem; }
+  .label.is-large {
+    font-size: 1.5rem; }
 
 .help {
   display: block;
   font-size: 0.75rem;
-  margin-top: 0.25rem;
-}
-.help.is-white {
-  color: #fafafa;
-}
-.help.is-black {
-  color: #030303;
-}
-.help.is-light {
-  color: #f5f5f5;
-}
-.help.is-dark {
-  color: #3A3D4E;
-}
-.help.is-primary {
-  color: #005C43;
-}
-.help.is-link {
-  color: #004FB3;
-}
-.help.is-info {
-  color: hsl(204deg, 71%, 53%);
-}
-.help.is-success {
-  color: #1C6301;
-}
-.help.is-warning {
-  color: #EED891;
-}
-.help.is-danger {
-  color: #A30031;
-}
+  margin-top: 0.25rem; }
+  .help.is-white {
+    color: #fafafa; }
+  .help.is-black {
+    color: #030303; }
+  .help.is-light {
+    color: #f5f5f5; }
+  .help.is-dark {
+    color: #3A3D4E; }
+  .help.is-primary {
+    color: #005C43; }
+  .help.is-link {
+    color: #004FB3; }
+  .help.is-info {
+    color: #3298dc; }
+  .help.is-success {
+    color: #1C6301; }
+  .help.is-warning {
+    color: #EED891; }
+  .help.is-danger {
+    color: #A30031; }
 
 .field:not(:last-child) {
-  margin-bottom: 0.75rem;
-}
+  margin-bottom: 0.75rem; }
 .field.has-addons {
   display: flex;
-  justify-content: flex-start;
-}
-.field.has-addons .control:not(:last-child) {
-  margin-right: -1px;
-}
-.field.has-addons .control:not(:first-child):not(:last-child) .button,
-.field.has-addons .control:not(:first-child):not(:last-child) .input,
-.field.has-addons .control:not(:first-child):not(:last-child) .select select {
-  border-radius: 0;
-}
-.field.has-addons .control:first-child:not(:only-child) .button,
-.field.has-addons .control:first-child:not(:only-child) .input,
-.field.has-addons .control:first-child:not(:only-child) .select select {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-}
-.field.has-addons .control:last-child:not(:only-child) .button,
-.field.has-addons .control:last-child:not(:only-child) .input,
-.field.has-addons .control:last-child:not(:only-child) .select select {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-}
-.field.has-addons .control .button:not([disabled]):hover, .field.has-addons .control .button:not([disabled]).is-hovered,
-.field.has-addons .control .input:not([disabled]):hover,
-.field.has-addons .control .input:not([disabled]).is-hovered,
-.field.has-addons .control .select select:not([disabled]):hover,
-.field.has-addons .control .select select:not([disabled]).is-hovered {
-  z-index: 2;
-}
-.field.has-addons .control .button:not([disabled]):focus, .field.has-addons .control .button:not([disabled]).is-focused, .field.has-addons .control .button:not([disabled]):active, .field.has-addons .control .button:not([disabled]).is-active,
-.field.has-addons .control .input:not([disabled]):focus,
-.field.has-addons .control .input:not([disabled]).is-focused,
-.field.has-addons .control .input:not([disabled]):active,
-.field.has-addons .control .input:not([disabled]).is-active,
-.field.has-addons .control .select select:not([disabled]):focus,
-.field.has-addons .control .select select:not([disabled]).is-focused,
-.field.has-addons .control .select select:not([disabled]):active,
-.field.has-addons .control .select select:not([disabled]).is-active {
-  z-index: 3;
-}
-.field.has-addons .control .button:not([disabled]):focus:hover, .field.has-addons .control .button:not([disabled]).is-focused:hover, .field.has-addons .control .button:not([disabled]):active:hover, .field.has-addons .control .button:not([disabled]).is-active:hover,
-.field.has-addons .control .input:not([disabled]):focus:hover,
-.field.has-addons .control .input:not([disabled]).is-focused:hover,
-.field.has-addons .control .input:not([disabled]):active:hover,
-.field.has-addons .control .input:not([disabled]).is-active:hover,
-.field.has-addons .control .select select:not([disabled]):focus:hover,
-.field.has-addons .control .select select:not([disabled]).is-focused:hover,
-.field.has-addons .control .select select:not([disabled]):active:hover,
-.field.has-addons .control .select select:not([disabled]).is-active:hover {
-  z-index: 4;
-}
-.field.has-addons .control.is-expanded {
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-.field.has-addons.has-addons-centered {
-  justify-content: center;
-}
-.field.has-addons.has-addons-right {
-  justify-content: flex-end;
-}
-.field.has-addons.has-addons-fullwidth .control {
-  flex-grow: 1;
-  flex-shrink: 0;
-}
+  justify-content: flex-start; }
+  .field.has-addons .control:not(:last-child) {
+    margin-right: -1px; }
+  .field.has-addons .control:not(:first-child):not(:last-child) .button,
+  .field.has-addons .control:not(:first-child):not(:last-child) .input,
+  .field.has-addons .control:not(:first-child):not(:last-child) .select select {
+    border-radius: 0; }
+  .field.has-addons .control:first-child:not(:only-child) .button,
+  .field.has-addons .control:first-child:not(:only-child) .input,
+  .field.has-addons .control:first-child:not(:only-child) .select select {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0; }
+  .field.has-addons .control:last-child:not(:only-child) .button,
+  .field.has-addons .control:last-child:not(:only-child) .input,
+  .field.has-addons .control:last-child:not(:only-child) .select select {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0; }
+  .field.has-addons .control .button:not([disabled]):hover, .field.has-addons .control .button:not([disabled]).is-hovered,
+  .field.has-addons .control .input:not([disabled]):hover,
+  .field.has-addons .control .input:not([disabled]).is-hovered,
+  .field.has-addons .control .select select:not([disabled]):hover,
+  .field.has-addons .control .select select:not([disabled]).is-hovered {
+    z-index: 2; }
+  .field.has-addons .control .button:not([disabled]):focus, .field.has-addons .control .button:not([disabled]).is-focused, .field.has-addons .control .button:not([disabled]):active, .field.has-addons .control .button:not([disabled]).is-active,
+  .field.has-addons .control .input:not([disabled]):focus,
+  .field.has-addons .control .input:not([disabled]).is-focused,
+  .field.has-addons .control .input:not([disabled]):active,
+  .field.has-addons .control .input:not([disabled]).is-active,
+  .field.has-addons .control .select select:not([disabled]):focus,
+  .field.has-addons .control .select select:not([disabled]).is-focused,
+  .field.has-addons .control .select select:not([disabled]):active,
+  .field.has-addons .control .select select:not([disabled]).is-active {
+    z-index: 3; }
+    .field.has-addons .control .button:not([disabled]):focus:hover, .field.has-addons .control .button:not([disabled]).is-focused:hover, .field.has-addons .control .button:not([disabled]):active:hover, .field.has-addons .control .button:not([disabled]).is-active:hover,
+    .field.has-addons .control .input:not([disabled]):focus:hover,
+    .field.has-addons .control .input:not([disabled]).is-focused:hover,
+    .field.has-addons .control .input:not([disabled]):active:hover,
+    .field.has-addons .control .input:not([disabled]).is-active:hover,
+    .field.has-addons .control .select select:not([disabled]):focus:hover,
+    .field.has-addons .control .select select:not([disabled]).is-focused:hover,
+    .field.has-addons .control .select select:not([disabled]):active:hover,
+    .field.has-addons .control .select select:not([disabled]).is-active:hover {
+      z-index: 4; }
+  .field.has-addons .control.is-expanded {
+    flex-grow: 1;
+    flex-shrink: 1; }
+  .field.has-addons.has-addons-centered {
+    justify-content: center; }
+  .field.has-addons.has-addons-right {
+    justify-content: flex-end; }
+  .field.has-addons.has-addons-fullwidth .control {
+    flex-grow: 1;
+    flex-shrink: 0; }
 .field.is-grouped {
   display: flex;
-  justify-content: flex-start;
-}
-.field.is-grouped > .control {
-  flex-shrink: 0;
-}
-.field.is-grouped > .control:not(:last-child) {
-  margin-bottom: 0;
-  margin-right: 0.75rem;
-}
-.field.is-grouped > .control.is-expanded {
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-.field.is-grouped.is-grouped-centered {
-  justify-content: center;
-}
-.field.is-grouped.is-grouped-right {
-  justify-content: flex-end;
-}
-.field.is-grouped.is-grouped-multiline {
-  flex-wrap: wrap;
-}
-.field.is-grouped.is-grouped-multiline > .control:last-child, .field.is-grouped.is-grouped-multiline > .control:not(:last-child) {
-  margin-bottom: 0.75rem;
-}
-.field.is-grouped.is-grouped-multiline:last-child {
-  margin-bottom: -0.75rem;
-}
-.field.is-grouped.is-grouped-multiline:not(:last-child) {
-  margin-bottom: 0;
-}
+  justify-content: flex-start; }
+  .field.is-grouped > .control {
+    flex-shrink: 0; }
+    .field.is-grouped > .control:not(:last-child) {
+      margin-bottom: 0;
+      margin-right: 0.75rem; }
+    .field.is-grouped > .control.is-expanded {
+      flex-grow: 1;
+      flex-shrink: 1; }
+  .field.is-grouped.is-grouped-centered {
+    justify-content: center; }
+  .field.is-grouped.is-grouped-right {
+    justify-content: flex-end; }
+  .field.is-grouped.is-grouped-multiline {
+    flex-wrap: wrap; }
+    .field.is-grouped.is-grouped-multiline > .control:last-child, .field.is-grouped.is-grouped-multiline > .control:not(:last-child) {
+      margin-bottom: 0.75rem; }
+    .field.is-grouped.is-grouped-multiline:last-child {
+      margin-bottom: -0.75rem; }
+    .field.is-grouped.is-grouped-multiline:not(:last-child) {
+      margin-bottom: 0; }
 @media screen and (min-width: 769px), print {
   .field.is-horizontal {
-    display: flex;
-  }
-}
+    display: flex; } }
 
 .field-label .label {
-  font-size: inherit;
-}
+  font-size: inherit; }
 @media screen and (max-width: 768px) {
   .field-label {
-    margin-bottom: 0.5rem;
-  }
-}
+    margin-bottom: 0.5rem; } }
 @media screen and (min-width: 769px), print {
   .field-label {
     flex-basis: 0;
     flex-grow: 1;
     flex-shrink: 0;
     margin-right: 1.5rem;
-    text-align: right;
-  }
-  .field-label.is-small {
-    font-size: 0.75rem;
-    padding-top: 0.375em;
-  }
-  .field-label.is-normal {
-    padding-top: 0.375em;
-  }
-  .field-label.is-medium {
-    font-size: 1.25rem;
-    padding-top: 0.375em;
-  }
-  .field-label.is-large {
-    font-size: 1.5rem;
-    padding-top: 0.375em;
-  }
-}
+    text-align: right; }
+    .field-label.is-small {
+      font-size: 0.75rem;
+      padding-top: 0.375em; }
+    .field-label.is-normal {
+      padding-top: 0.375em; }
+    .field-label.is-medium {
+      font-size: 1.25rem;
+      padding-top: 0.375em; }
+    .field-label.is-large {
+      font-size: 1.5rem;
+      padding-top: 0.375em; } }
 
 .field-body .field .field {
-  margin-bottom: 0;
-}
+  margin-bottom: 0; }
 @media screen and (min-width: 769px), print {
   .field-body {
     display: flex;
     flex-basis: 0;
     flex-grow: 5;
-    flex-shrink: 1;
-  }
-  .field-body .field {
-    margin-bottom: 0;
-  }
-  .field-body > .field {
-    flex-shrink: 1;
-  }
-  .field-body > .field:not(.is-narrow) {
-    flex-grow: 1;
-  }
-  .field-body > .field:not(:last-child) {
-    margin-right: 0.75rem;
-  }
-}
+    flex-shrink: 1; }
+    .field-body .field {
+      margin-bottom: 0; }
+    .field-body > .field {
+      flex-shrink: 1; }
+      .field-body > .field:not(.is-narrow) {
+        flex-grow: 1; }
+      .field-body > .field:not(:last-child) {
+        margin-right: 0.75rem; } }
 
 .control {
   box-sizing: border-box;
   clear: both;
   font-size: 1rem;
   position: relative;
-  text-align: inherit;
-}
-.control.has-icons-left .input:focus ~ .icon,
-.control.has-icons-left .select:focus ~ .icon, .control.has-icons-right .input:focus ~ .icon,
-.control.has-icons-right .select:focus ~ .icon {
-  color: #83858D;
-}
-.control.has-icons-left .input.is-small ~ .icon,
-.control.has-icons-left .select.is-small ~ .icon, .control.has-icons-right .input.is-small ~ .icon,
-.control.has-icons-right .select.is-small ~ .icon {
-  font-size: 0.75rem;
-}
-.control.has-icons-left .input.is-medium ~ .icon,
-.control.has-icons-left .select.is-medium ~ .icon, .control.has-icons-right .input.is-medium ~ .icon,
-.control.has-icons-right .select.is-medium ~ .icon {
-  font-size: 1.25rem;
-}
-.control.has-icons-left .input.is-large ~ .icon,
-.control.has-icons-left .select.is-large ~ .icon, .control.has-icons-right .input.is-large ~ .icon,
-.control.has-icons-right .select.is-large ~ .icon {
-  font-size: 1.5rem;
-}
-.control.has-icons-left .icon, .control.has-icons-right .icon {
-  color: #e5e5e5;
-  height: 2.5em;
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  width: 2.5em;
-  z-index: 4;
-}
-.control.has-icons-left .input,
-.control.has-icons-left .select select {
-  padding-left: 2.5em;
-}
-.control.has-icons-left .icon.is-left {
-  left: 0;
-}
-.control.has-icons-right .input,
-.control.has-icons-right .select select {
-  padding-right: 2.5em;
-}
-.control.has-icons-right .icon.is-right {
-  right: 0;
-}
-.control.is-loading::after {
-  position: absolute !important;
-  right: 0.625em;
-  top: 0.625em;
-  z-index: 4;
-}
-.control.is-loading.is-small:after {
-  font-size: 0.75rem;
-}
-.control.is-loading.is-medium:after {
-  font-size: 1.25rem;
-}
-.control.is-loading.is-large:after {
-  font-size: 1.5rem;
-}
+  text-align: inherit; }
+  .control.has-icons-left .input:focus ~ .icon,
+  .control.has-icons-left .select:focus ~ .icon, .control.has-icons-right .input:focus ~ .icon,
+  .control.has-icons-right .select:focus ~ .icon {
+    color: #83858D; }
+  .control.has-icons-left .input.is-small ~ .icon,
+  .control.has-icons-left .select.is-small ~ .icon, .control.has-icons-right .input.is-small ~ .icon,
+  .control.has-icons-right .select.is-small ~ .icon {
+    font-size: 0.75rem; }
+  .control.has-icons-left .input.is-medium ~ .icon,
+  .control.has-icons-left .select.is-medium ~ .icon, .control.has-icons-right .input.is-medium ~ .icon,
+  .control.has-icons-right .select.is-medium ~ .icon {
+    font-size: 1.25rem; }
+  .control.has-icons-left .input.is-large ~ .icon,
+  .control.has-icons-left .select.is-large ~ .icon, .control.has-icons-right .input.is-large ~ .icon,
+  .control.has-icons-right .select.is-large ~ .icon {
+    font-size: 1.5rem; }
+  .control.has-icons-left .icon, .control.has-icons-right .icon {
+    color: #e5e5e5;
+    height: 2.5em;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 2.5em;
+    z-index: 4; }
+  .control.has-icons-left .input,
+  .control.has-icons-left .select select {
+    padding-left: 2.5em; }
+  .control.has-icons-left .icon.is-left {
+    left: 0; }
+  .control.has-icons-right .input,
+  .control.has-icons-right .select select {
+    padding-right: 2.5em; }
+  .control.has-icons-right .icon.is-right {
+    right: 0; }
+  .control.is-loading::after {
+    position: absolute !important;
+    right: 0.625em;
+    top: 0.625em;
+    z-index: 4; }
+  .control.is-loading.is-small:after {
+    font-size: 0.75rem; }
+  .control.is-loading.is-medium:after {
+    font-size: 1.25rem; }
+  .control.is-loading.is-large:after {
+    font-size: 1.5rem; }
 
 .column {
   display: block;
   flex-basis: 0;
   flex-grow: 1;
   flex-shrink: 1;
-  padding: 0.75rem;
-}
-.columns.is-mobile > .column.is-narrow {
-  flex: none;
-  width: unset;
-}
-.columns.is-mobile > .column.is-full {
-  flex: none;
-  width: 100%;
-}
-.columns.is-mobile > .column.is-three-quarters {
-  flex: none;
-  width: 75%;
-}
-.columns.is-mobile > .column.is-two-thirds {
-  flex: none;
-  width: 66.6666%;
-}
-.columns.is-mobile > .column.is-half {
-  flex: none;
-  width: 50%;
-}
-.columns.is-mobile > .column.is-one-third {
-  flex: none;
-  width: 33.3333%;
-}
-.columns.is-mobile > .column.is-one-quarter {
-  flex: none;
-  width: 25%;
-}
-.columns.is-mobile > .column.is-one-fifth {
-  flex: none;
-  width: 20%;
-}
-.columns.is-mobile > .column.is-two-fifths {
-  flex: none;
-  width: 40%;
-}
-.columns.is-mobile > .column.is-three-fifths {
-  flex: none;
-  width: 60%;
-}
-.columns.is-mobile > .column.is-four-fifths {
-  flex: none;
-  width: 80%;
-}
-.columns.is-mobile > .column.is-offset-three-quarters {
-  margin-left: 75%;
-}
-.columns.is-mobile > .column.is-offset-two-thirds {
-  margin-left: 66.6666%;
-}
-.columns.is-mobile > .column.is-offset-half {
-  margin-left: 50%;
-}
-.columns.is-mobile > .column.is-offset-one-third {
-  margin-left: 33.3333%;
-}
-.columns.is-mobile > .column.is-offset-one-quarter {
-  margin-left: 25%;
-}
-.columns.is-mobile > .column.is-offset-one-fifth {
-  margin-left: 20%;
-}
-.columns.is-mobile > .column.is-offset-two-fifths {
-  margin-left: 40%;
-}
-.columns.is-mobile > .column.is-offset-three-fifths {
-  margin-left: 60%;
-}
-.columns.is-mobile > .column.is-offset-four-fifths {
-  margin-left: 80%;
-}
-.columns.is-mobile > .column.is-0 {
-  flex: none;
-  width: 0%;
-}
-.columns.is-mobile > .column.is-offset-0 {
-  margin-left: 0%;
-}
-.columns.is-mobile > .column.is-1 {
-  flex: none;
-  width: 8.33333337%;
-}
-.columns.is-mobile > .column.is-offset-1 {
-  margin-left: 8.33333337%;
-}
-.columns.is-mobile > .column.is-2 {
-  flex: none;
-  width: 16.66666674%;
-}
-.columns.is-mobile > .column.is-offset-2 {
-  margin-left: 16.66666674%;
-}
-.columns.is-mobile > .column.is-3 {
-  flex: none;
-  width: 25%;
-}
-.columns.is-mobile > .column.is-offset-3 {
-  margin-left: 25%;
-}
-.columns.is-mobile > .column.is-4 {
-  flex: none;
-  width: 33.33333337%;
-}
-.columns.is-mobile > .column.is-offset-4 {
-  margin-left: 33.33333337%;
-}
-.columns.is-mobile > .column.is-5 {
-  flex: none;
-  width: 41.66666674%;
-}
-.columns.is-mobile > .column.is-offset-5 {
-  margin-left: 41.66666674%;
-}
-.columns.is-mobile > .column.is-6 {
-  flex: none;
-  width: 50%;
-}
-.columns.is-mobile > .column.is-offset-6 {
-  margin-left: 50%;
-}
-.columns.is-mobile > .column.is-7 {
-  flex: none;
-  width: 58.33333337%;
-}
-.columns.is-mobile > .column.is-offset-7 {
-  margin-left: 58.33333337%;
-}
-.columns.is-mobile > .column.is-8 {
-  flex: none;
-  width: 66.66666674%;
-}
-.columns.is-mobile > .column.is-offset-8 {
-  margin-left: 66.66666674%;
-}
-.columns.is-mobile > .column.is-9 {
-  flex: none;
-  width: 75%;
-}
-.columns.is-mobile > .column.is-offset-9 {
-  margin-left: 75%;
-}
-.columns.is-mobile > .column.is-10 {
-  flex: none;
-  width: 83.33333337%;
-}
-.columns.is-mobile > .column.is-offset-10 {
-  margin-left: 83.33333337%;
-}
-.columns.is-mobile > .column.is-11 {
-  flex: none;
-  width: 91.66666674%;
-}
-.columns.is-mobile > .column.is-offset-11 {
-  margin-left: 91.66666674%;
-}
-.columns.is-mobile > .column.is-12 {
-  flex: none;
-  width: 100%;
-}
-.columns.is-mobile > .column.is-offset-12 {
-  margin-left: 100%;
-}
-@media screen and (max-width: 768px) {
-  .column.is-narrow-mobile {
-    flex: none;
-    width: unset;
-  }
-  .column.is-full-mobile {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters-mobile {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds-mobile {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half-mobile {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third-mobile {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter-mobile {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth-mobile {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths-mobile {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths-mobile {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths-mobile {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters-mobile {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds-mobile {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half-mobile {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third-mobile {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter-mobile {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth-mobile {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths-mobile {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths-mobile {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths-mobile {
-    margin-left: 80%;
-  }
-  .column.is-0-mobile {
-    flex: none;
-    width: 0%;
-  }
-  .column.is-offset-0-mobile {
-    margin-left: 0%;
-  }
-  .column.is-1-mobile {
-    flex: none;
-    width: 8.33333337%;
-  }
-  .column.is-offset-1-mobile {
-    margin-left: 8.33333337%;
-  }
-  .column.is-2-mobile {
-    flex: none;
-    width: 16.66666674%;
-  }
-  .column.is-offset-2-mobile {
-    margin-left: 16.66666674%;
-  }
-  .column.is-3-mobile {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3-mobile {
-    margin-left: 25%;
-  }
-  .column.is-4-mobile {
-    flex: none;
-    width: 33.33333337%;
-  }
-  .column.is-offset-4-mobile {
-    margin-left: 33.33333337%;
-  }
-  .column.is-5-mobile {
-    flex: none;
-    width: 41.66666674%;
-  }
-  .column.is-offset-5-mobile {
-    margin-left: 41.66666674%;
-  }
-  .column.is-6-mobile {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6-mobile {
-    margin-left: 50%;
-  }
-  .column.is-7-mobile {
-    flex: none;
-    width: 58.33333337%;
-  }
-  .column.is-offset-7-mobile {
-    margin-left: 58.33333337%;
-  }
-  .column.is-8-mobile {
-    flex: none;
-    width: 66.66666674%;
-  }
-  .column.is-offset-8-mobile {
-    margin-left: 66.66666674%;
-  }
-  .column.is-9-mobile {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9-mobile {
-    margin-left: 75%;
-  }
-  .column.is-10-mobile {
-    flex: none;
-    width: 83.33333337%;
-  }
-  .column.is-offset-10-mobile {
-    margin-left: 83.33333337%;
-  }
-  .column.is-11-mobile {
-    flex: none;
-    width: 91.66666674%;
-  }
-  .column.is-offset-11-mobile {
-    margin-left: 91.66666674%;
-  }
-  .column.is-12-mobile {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12-mobile {
-    margin-left: 100%;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .column.is-narrow, .column.is-narrow-tablet {
-    flex: none;
-    width: unset;
-  }
-  .column.is-full, .column.is-full-tablet {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters, .column.is-three-quarters-tablet {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds, .column.is-two-thirds-tablet {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half, .column.is-half-tablet {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third, .column.is-one-third-tablet {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter, .column.is-one-quarter-tablet {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth, .column.is-one-fifth-tablet {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths, .column.is-two-fifths-tablet {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths, .column.is-three-fifths-tablet {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths, .column.is-four-fifths-tablet {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters, .column.is-offset-three-quarters-tablet {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds, .column.is-offset-two-thirds-tablet {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half, .column.is-offset-half-tablet {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third, .column.is-offset-one-third-tablet {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter, .column.is-offset-one-quarter-tablet {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth, .column.is-offset-one-fifth-tablet {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths, .column.is-offset-two-fifths-tablet {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths, .column.is-offset-three-fifths-tablet {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths, .column.is-offset-four-fifths-tablet {
-    margin-left: 80%;
-  }
-  .column.is-0, .column.is-0-tablet {
-    flex: none;
-    width: 0%;
-  }
-  .column.is-offset-0, .column.is-offset-0-tablet {
-    margin-left: 0%;
-  }
-  .column.is-1, .column.is-1-tablet {
-    flex: none;
-    width: 8.33333337%;
-  }
-  .column.is-offset-1, .column.is-offset-1-tablet {
-    margin-left: 8.33333337%;
-  }
-  .column.is-2, .column.is-2-tablet {
-    flex: none;
-    width: 16.66666674%;
-  }
-  .column.is-offset-2, .column.is-offset-2-tablet {
-    margin-left: 16.66666674%;
-  }
-  .column.is-3, .column.is-3-tablet {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3, .column.is-offset-3-tablet {
-    margin-left: 25%;
-  }
-  .column.is-4, .column.is-4-tablet {
-    flex: none;
-    width: 33.33333337%;
-  }
-  .column.is-offset-4, .column.is-offset-4-tablet {
-    margin-left: 33.33333337%;
-  }
-  .column.is-5, .column.is-5-tablet {
-    flex: none;
-    width: 41.66666674%;
-  }
-  .column.is-offset-5, .column.is-offset-5-tablet {
-    margin-left: 41.66666674%;
-  }
-  .column.is-6, .column.is-6-tablet {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6, .column.is-offset-6-tablet {
-    margin-left: 50%;
-  }
-  .column.is-7, .column.is-7-tablet {
-    flex: none;
-    width: 58.33333337%;
-  }
-  .column.is-offset-7, .column.is-offset-7-tablet {
-    margin-left: 58.33333337%;
-  }
-  .column.is-8, .column.is-8-tablet {
-    flex: none;
-    width: 66.66666674%;
-  }
-  .column.is-offset-8, .column.is-offset-8-tablet {
-    margin-left: 66.66666674%;
-  }
-  .column.is-9, .column.is-9-tablet {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9, .column.is-offset-9-tablet {
-    margin-left: 75%;
-  }
-  .column.is-10, .column.is-10-tablet {
-    flex: none;
-    width: 83.33333337%;
-  }
-  .column.is-offset-10, .column.is-offset-10-tablet {
-    margin-left: 83.33333337%;
-  }
-  .column.is-11, .column.is-11-tablet {
-    flex: none;
-    width: 91.66666674%;
-  }
-  .column.is-offset-11, .column.is-offset-11-tablet {
-    margin-left: 91.66666674%;
-  }
-  .column.is-12, .column.is-12-tablet {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12, .column.is-offset-12-tablet {
-    margin-left: 100%;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .column.is-narrow-touch {
-    flex: none;
-    width: unset;
-  }
-  .column.is-full-touch {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters-touch {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds-touch {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half-touch {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third-touch {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter-touch {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth-touch {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths-touch {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths-touch {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths-touch {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters-touch {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds-touch {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half-touch {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third-touch {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter-touch {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth-touch {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths-touch {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths-touch {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths-touch {
-    margin-left: 80%;
-  }
-  .column.is-0-touch {
-    flex: none;
-    width: 0%;
-  }
-  .column.is-offset-0-touch {
-    margin-left: 0%;
-  }
-  .column.is-1-touch {
-    flex: none;
-    width: 8.33333337%;
-  }
-  .column.is-offset-1-touch {
-    margin-left: 8.33333337%;
-  }
-  .column.is-2-touch {
-    flex: none;
-    width: 16.66666674%;
-  }
-  .column.is-offset-2-touch {
-    margin-left: 16.66666674%;
-  }
-  .column.is-3-touch {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3-touch {
-    margin-left: 25%;
-  }
-  .column.is-4-touch {
-    flex: none;
-    width: 33.33333337%;
-  }
-  .column.is-offset-4-touch {
-    margin-left: 33.33333337%;
-  }
-  .column.is-5-touch {
-    flex: none;
-    width: 41.66666674%;
-  }
-  .column.is-offset-5-touch {
-    margin-left: 41.66666674%;
-  }
-  .column.is-6-touch {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6-touch {
-    margin-left: 50%;
-  }
-  .column.is-7-touch {
-    flex: none;
-    width: 58.33333337%;
-  }
-  .column.is-offset-7-touch {
-    margin-left: 58.33333337%;
-  }
-  .column.is-8-touch {
-    flex: none;
-    width: 66.66666674%;
-  }
-  .column.is-offset-8-touch {
-    margin-left: 66.66666674%;
-  }
-  .column.is-9-touch {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9-touch {
-    margin-left: 75%;
-  }
-  .column.is-10-touch {
-    flex: none;
-    width: 83.33333337%;
-  }
-  .column.is-offset-10-touch {
-    margin-left: 83.33333337%;
-  }
-  .column.is-11-touch {
-    flex: none;
-    width: 91.66666674%;
-  }
-  .column.is-offset-11-touch {
-    margin-left: 91.66666674%;
-  }
-  .column.is-12-touch {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12-touch {
-    margin-left: 100%;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .column.is-narrow-desktop {
-    flex: none;
-    width: unset;
-  }
-  .column.is-full-desktop {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-three-quarters-desktop {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-two-thirds-desktop {
-    flex: none;
-    width: 66.6666%;
-  }
-  .column.is-half-desktop {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-one-third-desktop {
-    flex: none;
-    width: 33.3333%;
-  }
-  .column.is-one-quarter-desktop {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-one-fifth-desktop {
-    flex: none;
-    width: 20%;
-  }
-  .column.is-two-fifths-desktop {
-    flex: none;
-    width: 40%;
-  }
-  .column.is-three-fifths-desktop {
-    flex: none;
-    width: 60%;
-  }
-  .column.is-four-fifths-desktop {
-    flex: none;
-    width: 80%;
-  }
-  .column.is-offset-three-quarters-desktop {
-    margin-left: 75%;
-  }
-  .column.is-offset-two-thirds-desktop {
-    margin-left: 66.6666%;
-  }
-  .column.is-offset-half-desktop {
-    margin-left: 50%;
-  }
-  .column.is-offset-one-third-desktop {
-    margin-left: 33.3333%;
-  }
-  .column.is-offset-one-quarter-desktop {
-    margin-left: 25%;
-  }
-  .column.is-offset-one-fifth-desktop {
-    margin-left: 20%;
-  }
-  .column.is-offset-two-fifths-desktop {
-    margin-left: 40%;
-  }
-  .column.is-offset-three-fifths-desktop {
-    margin-left: 60%;
-  }
-  .column.is-offset-four-fifths-desktop {
-    margin-left: 80%;
-  }
-  .column.is-0-desktop {
-    flex: none;
-    width: 0%;
-  }
-  .column.is-offset-0-desktop {
-    margin-left: 0%;
-  }
-  .column.is-1-desktop {
-    flex: none;
-    width: 8.33333337%;
-  }
-  .column.is-offset-1-desktop {
-    margin-left: 8.33333337%;
-  }
-  .column.is-2-desktop {
-    flex: none;
-    width: 16.66666674%;
-  }
-  .column.is-offset-2-desktop {
-    margin-left: 16.66666674%;
-  }
-  .column.is-3-desktop {
-    flex: none;
-    width: 25%;
-  }
-  .column.is-offset-3-desktop {
-    margin-left: 25%;
-  }
-  .column.is-4-desktop {
-    flex: none;
-    width: 33.33333337%;
-  }
-  .column.is-offset-4-desktop {
-    margin-left: 33.33333337%;
-  }
-  .column.is-5-desktop {
-    flex: none;
-    width: 41.66666674%;
-  }
-  .column.is-offset-5-desktop {
-    margin-left: 41.66666674%;
-  }
-  .column.is-6-desktop {
-    flex: none;
-    width: 50%;
-  }
-  .column.is-offset-6-desktop {
-    margin-left: 50%;
-  }
-  .column.is-7-desktop {
-    flex: none;
-    width: 58.33333337%;
-  }
-  .column.is-offset-7-desktop {
-    margin-left: 58.33333337%;
-  }
-  .column.is-8-desktop {
-    flex: none;
-    width: 66.66666674%;
-  }
-  .column.is-offset-8-desktop {
-    margin-left: 66.66666674%;
-  }
-  .column.is-9-desktop {
-    flex: none;
-    width: 75%;
-  }
-  .column.is-offset-9-desktop {
-    margin-left: 75%;
-  }
-  .column.is-10-desktop {
-    flex: none;
-    width: 83.33333337%;
-  }
-  .column.is-offset-10-desktop {
-    margin-left: 83.33333337%;
-  }
-  .column.is-11-desktop {
-    flex: none;
-    width: 91.66666674%;
-  }
-  .column.is-offset-11-desktop {
-    margin-left: 91.66666674%;
-  }
-  .column.is-12-desktop {
-    flex: none;
-    width: 100%;
-  }
-  .column.is-offset-12-desktop {
-    margin-left: 100%;
-  }
-}
+  padding: 0.75rem; }
+  .columns.is-mobile > .column.is-narrow {
+    flex: none;
+    width: unset; }
+  .columns.is-mobile > .column.is-full {
+    flex: none;
+    width: 100%; }
+  .columns.is-mobile > .column.is-three-quarters {
+    flex: none;
+    width: 75%; }
+  .columns.is-mobile > .column.is-two-thirds {
+    flex: none;
+    width: 66.6666%; }
+  .columns.is-mobile > .column.is-half {
+    flex: none;
+    width: 50%; }
+  .columns.is-mobile > .column.is-one-third {
+    flex: none;
+    width: 33.3333%; }
+  .columns.is-mobile > .column.is-one-quarter {
+    flex: none;
+    width: 25%; }
+  .columns.is-mobile > .column.is-one-fifth {
+    flex: none;
+    width: 20%; }
+  .columns.is-mobile > .column.is-two-fifths {
+    flex: none;
+    width: 40%; }
+  .columns.is-mobile > .column.is-three-fifths {
+    flex: none;
+    width: 60%; }
+  .columns.is-mobile > .column.is-four-fifths {
+    flex: none;
+    width: 80%; }
+  .columns.is-mobile > .column.is-offset-three-quarters {
+    margin-left: 75%; }
+  .columns.is-mobile > .column.is-offset-two-thirds {
+    margin-left: 66.6666%; }
+  .columns.is-mobile > .column.is-offset-half {
+    margin-left: 50%; }
+  .columns.is-mobile > .column.is-offset-one-third {
+    margin-left: 33.3333%; }
+  .columns.is-mobile > .column.is-offset-one-quarter {
+    margin-left: 25%; }
+  .columns.is-mobile > .column.is-offset-one-fifth {
+    margin-left: 20%; }
+  .columns.is-mobile > .column.is-offset-two-fifths {
+    margin-left: 40%; }
+  .columns.is-mobile > .column.is-offset-three-fifths {
+    margin-left: 60%; }
+  .columns.is-mobile > .column.is-offset-four-fifths {
+    margin-left: 80%; }
+  .columns.is-mobile > .column.is-0 {
+    flex: none;
+    width: 0%; }
+  .columns.is-mobile > .column.is-offset-0 {
+    margin-left: 0%; }
+  .columns.is-mobile > .column.is-1 {
+    flex: none;
+    width: 8.33333337%; }
+  .columns.is-mobile > .column.is-offset-1 {
+    margin-left: 8.33333337%; }
+  .columns.is-mobile > .column.is-2 {
+    flex: none;
+    width: 16.66666674%; }
+  .columns.is-mobile > .column.is-offset-2 {
+    margin-left: 16.66666674%; }
+  .columns.is-mobile > .column.is-3 {
+    flex: none;
+    width: 25%; }
+  .columns.is-mobile > .column.is-offset-3 {
+    margin-left: 25%; }
+  .columns.is-mobile > .column.is-4 {
+    flex: none;
+    width: 33.33333337%; }
+  .columns.is-mobile > .column.is-offset-4 {
+    margin-left: 33.33333337%; }
+  .columns.is-mobile > .column.is-5 {
+    flex: none;
+    width: 41.66666674%; }
+  .columns.is-mobile > .column.is-offset-5 {
+    margin-left: 41.66666674%; }
+  .columns.is-mobile > .column.is-6 {
+    flex: none;
+    width: 50%; }
+  .columns.is-mobile > .column.is-offset-6 {
+    margin-left: 50%; }
+  .columns.is-mobile > .column.is-7 {
+    flex: none;
+    width: 58.33333337%; }
+  .columns.is-mobile > .column.is-offset-7 {
+    margin-left: 58.33333337%; }
+  .columns.is-mobile > .column.is-8 {
+    flex: none;
+    width: 66.66666674%; }
+  .columns.is-mobile > .column.is-offset-8 {
+    margin-left: 66.66666674%; }
+  .columns.is-mobile > .column.is-9 {
+    flex: none;
+    width: 75%; }
+  .columns.is-mobile > .column.is-offset-9 {
+    margin-left: 75%; }
+  .columns.is-mobile > .column.is-10 {
+    flex: none;
+    width: 83.33333337%; }
+  .columns.is-mobile > .column.is-offset-10 {
+    margin-left: 83.33333337%; }
+  .columns.is-mobile > .column.is-11 {
+    flex: none;
+    width: 91.66666674%; }
+  .columns.is-mobile > .column.is-offset-11 {
+    margin-left: 91.66666674%; }
+  .columns.is-mobile > .column.is-12 {
+    flex: none;
+    width: 100%; }
+  .columns.is-mobile > .column.is-offset-12 {
+    margin-left: 100%; }
+  @media screen and (max-width: 768px) {
+    .column.is-narrow-mobile {
+      flex: none;
+      width: unset; }
+    .column.is-full-mobile {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-mobile {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-mobile {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-mobile {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-mobile {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-mobile {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-mobile {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-mobile {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-mobile {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-mobile {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-mobile {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-mobile {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-mobile {
+      margin-left: 50%; }
+    .column.is-offset-one-third-mobile {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-mobile {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-mobile {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-mobile {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-mobile {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-mobile {
+      margin-left: 80%; }
+    .column.is-0-mobile {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0-mobile {
+      margin-left: 0%; }
+    .column.is-1-mobile {
+      flex: none;
+      width: 8.33333337%; }
+    .column.is-offset-1-mobile {
+      margin-left: 8.33333337%; }
+    .column.is-2-mobile {
+      flex: none;
+      width: 16.66666674%; }
+    .column.is-offset-2-mobile {
+      margin-left: 16.66666674%; }
+    .column.is-3-mobile {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-mobile {
+      margin-left: 25%; }
+    .column.is-4-mobile {
+      flex: none;
+      width: 33.33333337%; }
+    .column.is-offset-4-mobile {
+      margin-left: 33.33333337%; }
+    .column.is-5-mobile {
+      flex: none;
+      width: 41.66666674%; }
+    .column.is-offset-5-mobile {
+      margin-left: 41.66666674%; }
+    .column.is-6-mobile {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-mobile {
+      margin-left: 50%; }
+    .column.is-7-mobile {
+      flex: none;
+      width: 58.33333337%; }
+    .column.is-offset-7-mobile {
+      margin-left: 58.33333337%; }
+    .column.is-8-mobile {
+      flex: none;
+      width: 66.66666674%; }
+    .column.is-offset-8-mobile {
+      margin-left: 66.66666674%; }
+    .column.is-9-mobile {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-mobile {
+      margin-left: 75%; }
+    .column.is-10-mobile {
+      flex: none;
+      width: 83.33333337%; }
+    .column.is-offset-10-mobile {
+      margin-left: 83.33333337%; }
+    .column.is-11-mobile {
+      flex: none;
+      width: 91.66666674%; }
+    .column.is-offset-11-mobile {
+      margin-left: 91.66666674%; }
+    .column.is-12-mobile {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-mobile {
+      margin-left: 100%; } }
+  @media screen and (min-width: 769px), print {
+    .column.is-narrow, .column.is-narrow-tablet {
+      flex: none;
+      width: unset; }
+    .column.is-full, .column.is-full-tablet {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters, .column.is-three-quarters-tablet {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds, .column.is-two-thirds-tablet {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half, .column.is-half-tablet {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third, .column.is-one-third-tablet {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter, .column.is-one-quarter-tablet {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth, .column.is-one-fifth-tablet {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths, .column.is-two-fifths-tablet {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths, .column.is-three-fifths-tablet {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths, .column.is-four-fifths-tablet {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters, .column.is-offset-three-quarters-tablet {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds, .column.is-offset-two-thirds-tablet {
+      margin-left: 66.6666%; }
+    .column.is-offset-half, .column.is-offset-half-tablet {
+      margin-left: 50%; }
+    .column.is-offset-one-third, .column.is-offset-one-third-tablet {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter, .column.is-offset-one-quarter-tablet {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth, .column.is-offset-one-fifth-tablet {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths, .column.is-offset-two-fifths-tablet {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths, .column.is-offset-three-fifths-tablet {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths, .column.is-offset-four-fifths-tablet {
+      margin-left: 80%; }
+    .column.is-0, .column.is-0-tablet {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0, .column.is-offset-0-tablet {
+      margin-left: 0%; }
+    .column.is-1, .column.is-1-tablet {
+      flex: none;
+      width: 8.33333337%; }
+    .column.is-offset-1, .column.is-offset-1-tablet {
+      margin-left: 8.33333337%; }
+    .column.is-2, .column.is-2-tablet {
+      flex: none;
+      width: 16.66666674%; }
+    .column.is-offset-2, .column.is-offset-2-tablet {
+      margin-left: 16.66666674%; }
+    .column.is-3, .column.is-3-tablet {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3, .column.is-offset-3-tablet {
+      margin-left: 25%; }
+    .column.is-4, .column.is-4-tablet {
+      flex: none;
+      width: 33.33333337%; }
+    .column.is-offset-4, .column.is-offset-4-tablet {
+      margin-left: 33.33333337%; }
+    .column.is-5, .column.is-5-tablet {
+      flex: none;
+      width: 41.66666674%; }
+    .column.is-offset-5, .column.is-offset-5-tablet {
+      margin-left: 41.66666674%; }
+    .column.is-6, .column.is-6-tablet {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6, .column.is-offset-6-tablet {
+      margin-left: 50%; }
+    .column.is-7, .column.is-7-tablet {
+      flex: none;
+      width: 58.33333337%; }
+    .column.is-offset-7, .column.is-offset-7-tablet {
+      margin-left: 58.33333337%; }
+    .column.is-8, .column.is-8-tablet {
+      flex: none;
+      width: 66.66666674%; }
+    .column.is-offset-8, .column.is-offset-8-tablet {
+      margin-left: 66.66666674%; }
+    .column.is-9, .column.is-9-tablet {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9, .column.is-offset-9-tablet {
+      margin-left: 75%; }
+    .column.is-10, .column.is-10-tablet {
+      flex: none;
+      width: 83.33333337%; }
+    .column.is-offset-10, .column.is-offset-10-tablet {
+      margin-left: 83.33333337%; }
+    .column.is-11, .column.is-11-tablet {
+      flex: none;
+      width: 91.66666674%; }
+    .column.is-offset-11, .column.is-offset-11-tablet {
+      margin-left: 91.66666674%; }
+    .column.is-12, .column.is-12-tablet {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12, .column.is-offset-12-tablet {
+      margin-left: 100%; } }
+  @media screen and (max-width: 1203px) {
+    .column.is-narrow-touch {
+      flex: none;
+      width: unset; }
+    .column.is-full-touch {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-touch {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-touch {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-touch {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-touch {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-touch {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-touch {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-touch {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-touch {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-touch {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-touch {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-touch {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-touch {
+      margin-left: 50%; }
+    .column.is-offset-one-third-touch {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-touch {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-touch {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-touch {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-touch {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-touch {
+      margin-left: 80%; }
+    .column.is-0-touch {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0-touch {
+      margin-left: 0%; }
+    .column.is-1-touch {
+      flex: none;
+      width: 8.33333337%; }
+    .column.is-offset-1-touch {
+      margin-left: 8.33333337%; }
+    .column.is-2-touch {
+      flex: none;
+      width: 16.66666674%; }
+    .column.is-offset-2-touch {
+      margin-left: 16.66666674%; }
+    .column.is-3-touch {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-touch {
+      margin-left: 25%; }
+    .column.is-4-touch {
+      flex: none;
+      width: 33.33333337%; }
+    .column.is-offset-4-touch {
+      margin-left: 33.33333337%; }
+    .column.is-5-touch {
+      flex: none;
+      width: 41.66666674%; }
+    .column.is-offset-5-touch {
+      margin-left: 41.66666674%; }
+    .column.is-6-touch {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-touch {
+      margin-left: 50%; }
+    .column.is-7-touch {
+      flex: none;
+      width: 58.33333337%; }
+    .column.is-offset-7-touch {
+      margin-left: 58.33333337%; }
+    .column.is-8-touch {
+      flex: none;
+      width: 66.66666674%; }
+    .column.is-offset-8-touch {
+      margin-left: 66.66666674%; }
+    .column.is-9-touch {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-touch {
+      margin-left: 75%; }
+    .column.is-10-touch {
+      flex: none;
+      width: 83.33333337%; }
+    .column.is-offset-10-touch {
+      margin-left: 83.33333337%; }
+    .column.is-11-touch {
+      flex: none;
+      width: 91.66666674%; }
+    .column.is-offset-11-touch {
+      margin-left: 91.66666674%; }
+    .column.is-12-touch {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-touch {
+      margin-left: 100%; } }
+  @media screen and (min-width: 1204px) {
+    .column.is-narrow-desktop {
+      flex: none;
+      width: unset; }
+    .column.is-full-desktop {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-desktop {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-desktop {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-desktop {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-desktop {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-desktop {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-desktop {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-desktop {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-desktop {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-desktop {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-desktop {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-desktop {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-desktop {
+      margin-left: 50%; }
+    .column.is-offset-one-third-desktop {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-desktop {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-desktop {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-desktop {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-desktop {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-desktop {
+      margin-left: 80%; }
+    .column.is-0-desktop {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0-desktop {
+      margin-left: 0%; }
+    .column.is-1-desktop {
+      flex: none;
+      width: 8.33333337%; }
+    .column.is-offset-1-desktop {
+      margin-left: 8.33333337%; }
+    .column.is-2-desktop {
+      flex: none;
+      width: 16.66666674%; }
+    .column.is-offset-2-desktop {
+      margin-left: 16.66666674%; }
+    .column.is-3-desktop {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-desktop {
+      margin-left: 25%; }
+    .column.is-4-desktop {
+      flex: none;
+      width: 33.33333337%; }
+    .column.is-offset-4-desktop {
+      margin-left: 33.33333337%; }
+    .column.is-5-desktop {
+      flex: none;
+      width: 41.66666674%; }
+    .column.is-offset-5-desktop {
+      margin-left: 41.66666674%; }
+    .column.is-6-desktop {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-desktop {
+      margin-left: 50%; }
+    .column.is-7-desktop {
+      flex: none;
+      width: 58.33333337%; }
+    .column.is-offset-7-desktop {
+      margin-left: 58.33333337%; }
+    .column.is-8-desktop {
+      flex: none;
+      width: 66.66666674%; }
+    .column.is-offset-8-desktop {
+      margin-left: 66.66666674%; }
+    .column.is-9-desktop {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-desktop {
+      margin-left: 75%; }
+    .column.is-10-desktop {
+      flex: none;
+      width: 83.33333337%; }
+    .column.is-offset-10-desktop {
+      margin-left: 83.33333337%; }
+    .column.is-11-desktop {
+      flex: none;
+      width: 91.66666674%; }
+    .column.is-offset-11-desktop {
+      margin-left: 91.66666674%; }
+    .column.is-12-desktop {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-desktop {
+      margin-left: 100%; } }
 
 .columns {
   margin-left: -0.75rem;
   margin-right: -0.75rem;
-  margin-top: -0.75rem;
-}
-.columns:last-child {
-  margin-bottom: -0.75rem;
-}
-.columns:not(:last-child) {
-  margin-bottom: calc(1.5rem - 0.75rem);
-}
-.columns.is-centered {
-  justify-content: center;
-}
-.columns.is-gapless {
-  margin-left: 0;
-  margin-right: 0;
-  margin-top: 0;
-}
-.columns.is-gapless > .column {
-  margin: 0;
-  padding: 0 !important;
-}
-.columns.is-gapless:not(:last-child) {
-  margin-bottom: 1.5rem;
-}
-.columns.is-gapless:last-child {
-  margin-bottom: 0;
-}
-.columns.is-mobile {
-  display: flex;
-}
-.columns.is-multiline {
-  flex-wrap: wrap;
-}
-.columns.is-vcentered {
-  align-items: center;
-}
-@media screen and (min-width: 769px), print {
-  .columns:not(.is-desktop) {
-    display: flex;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-desktop {
-    display: flex;
-  }
-}
+  margin-top: -0.75rem; }
+  .columns:last-child {
+    margin-bottom: -0.75rem; }
+  .columns:not(:last-child) {
+    margin-bottom: calc(1.5rem - 0.75rem); }
+  .columns.is-centered {
+    justify-content: center; }
+  .columns.is-gapless {
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 0; }
+    .columns.is-gapless > .column {
+      margin: 0;
+      padding: 0 !important; }
+    .columns.is-gapless:not(:last-child) {
+      margin-bottom: 1.5rem; }
+    .columns.is-gapless:last-child {
+      margin-bottom: 0; }
+  .columns.is-mobile {
+    display: flex; }
+  .columns.is-multiline {
+    flex-wrap: wrap; }
+  .columns.is-vcentered {
+    align-items: center; }
+  @media screen and (min-width: 769px), print {
+    .columns:not(.is-desktop) {
+      display: flex; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-desktop {
+      display: flex; } }
 
 .columns.is-variable {
   --columnGap: 0.75rem;
   margin-left: calc(-1 * var(--columnGap));
-  margin-right: calc(-1 * var(--columnGap));
-}
-.columns.is-variable > .column {
-  padding-left: var(--columnGap);
-  padding-right: var(--columnGap);
-}
-.columns.is-variable.is-0 {
-  --columnGap: 0rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-0-mobile {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-0-tablet {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1203px) {
-  .columns.is-variable.is-0-tablet-only {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .columns.is-variable.is-0-touch {
-    --columnGap: 0rem;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-variable.is-0-desktop {
-    --columnGap: 0rem;
-  }
-}
-.columns.is-variable.is-1 {
-  --columnGap: 0.25rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-1-mobile {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-1-tablet {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1203px) {
-  .columns.is-variable.is-1-tablet-only {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .columns.is-variable.is-1-touch {
-    --columnGap: 0.25rem;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-variable.is-1-desktop {
-    --columnGap: 0.25rem;
-  }
-}
-.columns.is-variable.is-2 {
-  --columnGap: 0.5rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-2-mobile {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-2-tablet {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1203px) {
-  .columns.is-variable.is-2-tablet-only {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .columns.is-variable.is-2-touch {
-    --columnGap: 0.5rem;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-variable.is-2-desktop {
-    --columnGap: 0.5rem;
-  }
-}
-.columns.is-variable.is-3 {
-  --columnGap: 0.75rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-3-mobile {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-3-tablet {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1203px) {
-  .columns.is-variable.is-3-tablet-only {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .columns.is-variable.is-3-touch {
-    --columnGap: 0.75rem;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-variable.is-3-desktop {
-    --columnGap: 0.75rem;
-  }
-}
-.columns.is-variable.is-4 {
-  --columnGap: 1rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-4-mobile {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-4-tablet {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1203px) {
-  .columns.is-variable.is-4-tablet-only {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .columns.is-variable.is-4-touch {
-    --columnGap: 1rem;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-variable.is-4-desktop {
-    --columnGap: 1rem;
-  }
-}
-.columns.is-variable.is-5 {
-  --columnGap: 1.25rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-5-mobile {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-5-tablet {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1203px) {
-  .columns.is-variable.is-5-tablet-only {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .columns.is-variable.is-5-touch {
-    --columnGap: 1.25rem;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-variable.is-5-desktop {
-    --columnGap: 1.25rem;
-  }
-}
-.columns.is-variable.is-6 {
-  --columnGap: 1.5rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-6-mobile {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-6-tablet {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1203px) {
-  .columns.is-variable.is-6-tablet-only {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .columns.is-variable.is-6-touch {
-    --columnGap: 1.5rem;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-variable.is-6-desktop {
-    --columnGap: 1.5rem;
-  }
-}
-.columns.is-variable.is-7 {
-  --columnGap: 1.75rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-7-mobile {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-7-tablet {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1203px) {
-  .columns.is-variable.is-7-tablet-only {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .columns.is-variable.is-7-touch {
-    --columnGap: 1.75rem;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-variable.is-7-desktop {
-    --columnGap: 1.75rem;
-  }
-}
-.columns.is-variable.is-8 {
-  --columnGap: 2rem;
-}
-@media screen and (max-width: 768px) {
-  .columns.is-variable.is-8-mobile {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .columns.is-variable.is-8-tablet {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 769px) and (max-width: 1203px) {
-  .columns.is-variable.is-8-tablet-only {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (max-width: 1203px) {
-  .columns.is-variable.is-8-touch {
-    --columnGap: 2rem;
-  }
-}
-@media screen and (min-width: 1204px) {
-  .columns.is-variable.is-8-desktop {
-    --columnGap: 2rem;
-  }
-}
+  margin-right: calc(-1 * var(--columnGap)); }
+  .columns.is-variable > .column {
+    padding-left: var(--columnGap);
+    padding-right: var(--columnGap); }
+  .columns.is-variable.is-0 {
+    --columnGap: 0rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-0-mobile {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-0-tablet {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1203px) {
+    .columns.is-variable.is-0-tablet-only {
+      --columnGap: 0rem; } }
+  @media screen and (max-width: 1203px) {
+    .columns.is-variable.is-0-touch {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-variable.is-0-desktop {
+      --columnGap: 0rem; } }
+  .columns.is-variable.is-1 {
+    --columnGap: 0.25rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-1-mobile {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-1-tablet {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1203px) {
+    .columns.is-variable.is-1-tablet-only {
+      --columnGap: 0.25rem; } }
+  @media screen and (max-width: 1203px) {
+    .columns.is-variable.is-1-touch {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-variable.is-1-desktop {
+      --columnGap: 0.25rem; } }
+  .columns.is-variable.is-2 {
+    --columnGap: 0.5rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-2-mobile {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-2-tablet {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1203px) {
+    .columns.is-variable.is-2-tablet-only {
+      --columnGap: 0.5rem; } }
+  @media screen and (max-width: 1203px) {
+    .columns.is-variable.is-2-touch {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-variable.is-2-desktop {
+      --columnGap: 0.5rem; } }
+  .columns.is-variable.is-3 {
+    --columnGap: 0.75rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-3-mobile {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-3-tablet {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1203px) {
+    .columns.is-variable.is-3-tablet-only {
+      --columnGap: 0.75rem; } }
+  @media screen and (max-width: 1203px) {
+    .columns.is-variable.is-3-touch {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-variable.is-3-desktop {
+      --columnGap: 0.75rem; } }
+  .columns.is-variable.is-4 {
+    --columnGap: 1rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-4-mobile {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-4-tablet {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1203px) {
+    .columns.is-variable.is-4-tablet-only {
+      --columnGap: 1rem; } }
+  @media screen and (max-width: 1203px) {
+    .columns.is-variable.is-4-touch {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-variable.is-4-desktop {
+      --columnGap: 1rem; } }
+  .columns.is-variable.is-5 {
+    --columnGap: 1.25rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-5-mobile {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-5-tablet {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1203px) {
+    .columns.is-variable.is-5-tablet-only {
+      --columnGap: 1.25rem; } }
+  @media screen and (max-width: 1203px) {
+    .columns.is-variable.is-5-touch {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-variable.is-5-desktop {
+      --columnGap: 1.25rem; } }
+  .columns.is-variable.is-6 {
+    --columnGap: 1.5rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-6-mobile {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-6-tablet {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1203px) {
+    .columns.is-variable.is-6-tablet-only {
+      --columnGap: 1.5rem; } }
+  @media screen and (max-width: 1203px) {
+    .columns.is-variable.is-6-touch {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-variable.is-6-desktop {
+      --columnGap: 1.5rem; } }
+  .columns.is-variable.is-7 {
+    --columnGap: 1.75rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-7-mobile {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-7-tablet {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1203px) {
+    .columns.is-variable.is-7-tablet-only {
+      --columnGap: 1.75rem; } }
+  @media screen and (max-width: 1203px) {
+    .columns.is-variable.is-7-touch {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-variable.is-7-desktop {
+      --columnGap: 1.75rem; } }
+  .columns.is-variable.is-8 {
+    --columnGap: 2rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-8-mobile {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-8-tablet {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1203px) {
+    .columns.is-variable.is-8-tablet-only {
+      --columnGap: 2rem; } }
+  @media screen and (max-width: 1203px) {
+    .columns.is-variable.is-8-touch {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1204px) {
+    .columns.is-variable.is-8-desktop {
+      --columnGap: 2rem; } }
 
 .footer {
   background-color: #f7f7f7;
-  padding: 0;
-}
+  padding: 0; }
 
 .hero {
   align-items: stretch;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-}
-.hero .navbar {
-  background: none;
-}
-.hero .tabs ul {
-  border-bottom: none;
-}
-.hero.is-white {
-  background-color: #fafafa;
-  color: #030303;
-}
-.hero.is-white a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-white strong {
-  color: inherit;
-}
-.hero.is-white .title {
-  color: #030303;
-}
-.hero.is-white .subtitle {
-  color: rgba(3, 3, 3, 0.9);
-}
-.hero.is-white .subtitle a:not(.button),
-.hero.is-white .subtitle strong {
-  color: #030303;
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-white .navbar-menu {
+  justify-content: space-between; }
+  .hero .navbar {
+    background: none; }
+  .hero .tabs ul {
+    border-bottom: none; }
+  .hero.is-white {
     background-color: #fafafa;
-  }
-}
-.hero.is-white .navbar-item,
-.hero.is-white .navbar-link {
-  color: rgba(3, 3, 3, 0.7);
-}
-.hero.is-white a.navbar-item:hover, .hero.is-white a.navbar-item.is-active,
-.hero.is-white .navbar-link:hover,
-.hero.is-white .navbar-link.is-active {
-  background-color: #ededed;
-  color: #030303;
-}
-.hero.is-white .tabs a {
-  color: #030303;
-  opacity: 0.9;
-}
-.hero.is-white .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-white .tabs li.is-active a {
-  color: #fafafa !important;
-  opacity: 1;
-}
-.hero.is-white .tabs.is-boxed a, .hero.is-white .tabs.is-toggle a {
-  color: #030303;
-}
-.hero.is-white .tabs.is-boxed a:hover, .hero.is-white .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-white .tabs.is-boxed li.is-active a, .hero.is-white .tabs.is-boxed li.is-active a:hover, .hero.is-white .tabs.is-toggle li.is-active a, .hero.is-white .tabs.is-toggle li.is-active a:hover {
-  background-color: #030303;
-  border-color: #030303;
-  color: #fafafa;
-}
-.hero.is-white.is-bold {
-  background-image: linear-gradient(141deg, #e4ddde 0%, #fafafa 71%, white 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-white.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #e4ddde 0%, #fafafa 71%, white 100%);
-  }
-}
-.hero.is-black {
-  background-color: #030303;
-  color: #fafafa;
-}
-.hero.is-black a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-black strong {
-  color: inherit;
-}
-.hero.is-black .title {
-  color: #fafafa;
-}
-.hero.is-black .subtitle {
-  color: rgba(250, 250, 250, 0.9);
-}
-.hero.is-black .subtitle a:not(.button),
-.hero.is-black .subtitle strong {
-  color: #fafafa;
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-black .navbar-menu {
+    color: #030303; }
+    .hero.is-white a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-white strong {
+      color: inherit; }
+    .hero.is-white .title {
+      color: #030303; }
+    .hero.is-white .subtitle {
+      color: rgba(3, 3, 3, 0.9); }
+      .hero.is-white .subtitle a:not(.button),
+      .hero.is-white .subtitle strong {
+        color: #030303; }
+    @media screen and (max-width: 1203px) {
+      .hero.is-white .navbar-menu {
+        background-color: #fafafa; } }
+    .hero.is-white .navbar-item,
+    .hero.is-white .navbar-link {
+      color: rgba(3, 3, 3, 0.7); }
+    .hero.is-white a.navbar-item:hover, .hero.is-white a.navbar-item.is-active,
+    .hero.is-white .navbar-link:hover,
+    .hero.is-white .navbar-link.is-active {
+      background-color: #ededed;
+      color: #030303; }
+    .hero.is-white .tabs a {
+      color: #030303;
+      opacity: 0.9; }
+      .hero.is-white .tabs a:hover {
+        opacity: 1; }
+    .hero.is-white .tabs li.is-active a {
+      color: #fafafa !important;
+      opacity: 1; }
+    .hero.is-white .tabs.is-boxed a, .hero.is-white .tabs.is-toggle a {
+      color: #030303; }
+      .hero.is-white .tabs.is-boxed a:hover, .hero.is-white .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-white .tabs.is-boxed li.is-active a, .hero.is-white .tabs.is-boxed li.is-active a:hover, .hero.is-white .tabs.is-toggle li.is-active a, .hero.is-white .tabs.is-toggle li.is-active a:hover {
+      background-color: #030303;
+      border-color: #030303;
+      color: #fafafa; }
+    .hero.is-white.is-bold {
+      background-image: linear-gradient(141deg, #e4ddde 0%, #fafafa 71%, white 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-white.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #e4ddde 0%, #fafafa 71%, white 100%); } }
+  .hero.is-black {
     background-color: #030303;
-  }
-}
-.hero.is-black .navbar-item,
-.hero.is-black .navbar-link {
-  color: rgba(250, 250, 250, 0.7);
-}
-.hero.is-black a.navbar-item:hover, .hero.is-black a.navbar-item.is-active,
-.hero.is-black .navbar-link:hover,
-.hero.is-black .navbar-link.is-active {
-  background-color: black;
-  color: #fafafa;
-}
-.hero.is-black .tabs a {
-  color: #fafafa;
-  opacity: 0.9;
-}
-.hero.is-black .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-black .tabs li.is-active a {
-  color: #030303 !important;
-  opacity: 1;
-}
-.hero.is-black .tabs.is-boxed a, .hero.is-black .tabs.is-toggle a {
-  color: #fafafa;
-}
-.hero.is-black .tabs.is-boxed a:hover, .hero.is-black .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-black .tabs.is-boxed li.is-active a, .hero.is-black .tabs.is-boxed li.is-active a:hover, .hero.is-black .tabs.is-toggle li.is-active a, .hero.is-black .tabs.is-toggle li.is-active a:hover {
-  background-color: #fafafa;
-  border-color: #fafafa;
-  color: #030303;
-}
-.hero.is-black.is-bold {
-  background-image: linear-gradient(141deg, black 0%, #030303 71%, #110f0f 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-black.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, black 0%, #030303 71%, #110f0f 100%);
-  }
-}
-.hero.is-light {
-  background-color: #f5f5f5;
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-light a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-light strong {
-  color: inherit;
-}
-.hero.is-light .title {
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-light .subtitle {
-  color: rgba(0, 0, 0, 0.9);
-}
-.hero.is-light .subtitle a:not(.button),
-.hero.is-light .subtitle strong {
-  color: rgba(0, 0, 0, 0.7);
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-light .navbar-menu {
+    color: #fafafa; }
+    .hero.is-black a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-black strong {
+      color: inherit; }
+    .hero.is-black .title {
+      color: #fafafa; }
+    .hero.is-black .subtitle {
+      color: rgba(250, 250, 250, 0.9); }
+      .hero.is-black .subtitle a:not(.button),
+      .hero.is-black .subtitle strong {
+        color: #fafafa; }
+    @media screen and (max-width: 1203px) {
+      .hero.is-black .navbar-menu {
+        background-color: #030303; } }
+    .hero.is-black .navbar-item,
+    .hero.is-black .navbar-link {
+      color: rgba(250, 250, 250, 0.7); }
+    .hero.is-black a.navbar-item:hover, .hero.is-black a.navbar-item.is-active,
+    .hero.is-black .navbar-link:hover,
+    .hero.is-black .navbar-link.is-active {
+      background-color: black;
+      color: #fafafa; }
+    .hero.is-black .tabs a {
+      color: #fafafa;
+      opacity: 0.9; }
+      .hero.is-black .tabs a:hover {
+        opacity: 1; }
+    .hero.is-black .tabs li.is-active a {
+      color: #030303 !important;
+      opacity: 1; }
+    .hero.is-black .tabs.is-boxed a, .hero.is-black .tabs.is-toggle a {
+      color: #fafafa; }
+      .hero.is-black .tabs.is-boxed a:hover, .hero.is-black .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-black .tabs.is-boxed li.is-active a, .hero.is-black .tabs.is-boxed li.is-active a:hover, .hero.is-black .tabs.is-toggle li.is-active a, .hero.is-black .tabs.is-toggle li.is-active a:hover {
+      background-color: #fafafa;
+      border-color: #fafafa;
+      color: #030303; }
+    .hero.is-black.is-bold {
+      background-image: linear-gradient(141deg, black 0%, #030303 71%, #110f0f 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-black.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, black 0%, #030303 71%, #110f0f 100%); } }
+  .hero.is-light {
     background-color: #f5f5f5;
-  }
-}
-.hero.is-light .navbar-item,
-.hero.is-light .navbar-link {
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-light a.navbar-item:hover, .hero.is-light a.navbar-item.is-active,
-.hero.is-light .navbar-link:hover,
-.hero.is-light .navbar-link.is-active {
-  background-color: #e8e8e8;
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-light .tabs a {
-  color: rgba(0, 0, 0, 0.7);
-  opacity: 0.9;
-}
-.hero.is-light .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-light .tabs li.is-active a {
-  color: #f5f5f5 !important;
-  opacity: 1;
-}
-.hero.is-light .tabs.is-boxed a, .hero.is-light .tabs.is-toggle a {
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-light .tabs.is-boxed a:hover, .hero.is-light .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-light .tabs.is-boxed li.is-active a, .hero.is-light .tabs.is-boxed li.is-active a:hover, .hero.is-light .tabs.is-toggle li.is-active a, .hero.is-light .tabs.is-toggle li.is-active a:hover {
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(0, 0, 0, 0.7);
-  color: #f5f5f5;
-}
-.hero.is-light.is-bold {
-  background-image: linear-gradient(141deg, #dfd8d9 0%, #f5f5f5 71%, white 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-light.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #dfd8d9 0%, #f5f5f5 71%, white 100%);
-  }
-}
-.hero.is-dark {
-  background-color: #3A3D4E;
-  color: #fff;
-}
-.hero.is-dark a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-dark strong {
-  color: inherit;
-}
-.hero.is-dark .title {
-  color: #fff;
-}
-.hero.is-dark .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-dark .subtitle a:not(.button),
-.hero.is-dark .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-dark .navbar-menu {
+    color: rgba(0, 0, 0, 0.7); }
+    .hero.is-light a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-light strong {
+      color: inherit; }
+    .hero.is-light .title {
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-light .subtitle {
+      color: rgba(0, 0, 0, 0.9); }
+      .hero.is-light .subtitle a:not(.button),
+      .hero.is-light .subtitle strong {
+        color: rgba(0, 0, 0, 0.7); }
+    @media screen and (max-width: 1203px) {
+      .hero.is-light .navbar-menu {
+        background-color: #f5f5f5; } }
+    .hero.is-light .navbar-item,
+    .hero.is-light .navbar-link {
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-light a.navbar-item:hover, .hero.is-light a.navbar-item.is-active,
+    .hero.is-light .navbar-link:hover,
+    .hero.is-light .navbar-link.is-active {
+      background-color: #e8e8e8;
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-light .tabs a {
+      color: rgba(0, 0, 0, 0.7);
+      opacity: 0.9; }
+      .hero.is-light .tabs a:hover {
+        opacity: 1; }
+    .hero.is-light .tabs li.is-active a {
+      color: #f5f5f5 !important;
+      opacity: 1; }
+    .hero.is-light .tabs.is-boxed a, .hero.is-light .tabs.is-toggle a {
+      color: rgba(0, 0, 0, 0.7); }
+      .hero.is-light .tabs.is-boxed a:hover, .hero.is-light .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-light .tabs.is-boxed li.is-active a, .hero.is-light .tabs.is-boxed li.is-active a:hover, .hero.is-light .tabs.is-toggle li.is-active a, .hero.is-light .tabs.is-toggle li.is-active a:hover {
+      background-color: rgba(0, 0, 0, 0.7);
+      border-color: rgba(0, 0, 0, 0.7);
+      color: #f5f5f5; }
+    .hero.is-light.is-bold {
+      background-image: linear-gradient(141deg, #dfd8d9 0%, #f5f5f5 71%, white 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-light.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #dfd8d9 0%, #f5f5f5 71%, white 100%); } }
+  .hero.is-dark {
     background-color: #3A3D4E;
-  }
-}
-.hero.is-dark .navbar-item,
-.hero.is-dark .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-dark a.navbar-item:hover, .hero.is-dark a.navbar-item.is-active,
-.hero.is-dark .navbar-link:hover,
-.hero.is-dark .navbar-link.is-active {
-  background-color: #2f323f;
-  color: #fff;
-}
-.hero.is-dark .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-dark .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-dark .tabs li.is-active a {
-  color: #3A3D4E !important;
-  opacity: 1;
-}
-.hero.is-dark .tabs.is-boxed a, .hero.is-dark .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-dark .tabs.is-boxed a:hover, .hero.is-dark .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-dark .tabs.is-boxed li.is-active a, .hero.is-dark .tabs.is-boxed li.is-active a:hover, .hero.is-dark .tabs.is-toggle li.is-active a, .hero.is-dark .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #3A3D4E;
-}
-.hero.is-dark.is-bold {
-  background-image: linear-gradient(141deg, #202735 0%, #3A3D4E 71%, #414161 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-dark.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #202735 0%, #3A3D4E 71%, #414161 100%);
-  }
-}
-.hero.is-primary {
-  background-color: #005C43;
-  color: #fff;
-}
-.hero.is-primary a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-primary strong {
-  color: inherit;
-}
-.hero.is-primary .title {
-  color: #fff;
-}
-.hero.is-primary .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-primary .subtitle a:not(.button),
-.hero.is-primary .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-primary .navbar-menu {
+    color: #fff; }
+    .hero.is-dark a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-dark strong {
+      color: inherit; }
+    .hero.is-dark .title {
+      color: #fff; }
+    .hero.is-dark .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-dark .subtitle a:not(.button),
+      .hero.is-dark .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1203px) {
+      .hero.is-dark .navbar-menu {
+        background-color: #3A3D4E; } }
+    .hero.is-dark .navbar-item,
+    .hero.is-dark .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-dark a.navbar-item:hover, .hero.is-dark a.navbar-item.is-active,
+    .hero.is-dark .navbar-link:hover,
+    .hero.is-dark .navbar-link.is-active {
+      background-color: #2f323f;
+      color: #fff; }
+    .hero.is-dark .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-dark .tabs a:hover {
+        opacity: 1; }
+    .hero.is-dark .tabs li.is-active a {
+      color: #3A3D4E !important;
+      opacity: 1; }
+    .hero.is-dark .tabs.is-boxed a, .hero.is-dark .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-dark .tabs.is-boxed a:hover, .hero.is-dark .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-dark .tabs.is-boxed li.is-active a, .hero.is-dark .tabs.is-boxed li.is-active a:hover, .hero.is-dark .tabs.is-toggle li.is-active a, .hero.is-dark .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #3A3D4E; }
+    .hero.is-dark.is-bold {
+      background-image: linear-gradient(141deg, #202735 0%, #3A3D4E 71%, #414161 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-dark.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #202735 0%, #3A3D4E 71%, #414161 100%); } }
+  .hero.is-primary {
     background-color: #005C43;
-  }
-}
-.hero.is-primary .navbar-item,
-.hero.is-primary .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-primary a.navbar-item:hover, .hero.is-primary a.navbar-item.is-active,
-.hero.is-primary .navbar-link:hover,
-.hero.is-primary .navbar-link.is-active {
-  background-color: #004330;
-  color: #fff;
-}
-.hero.is-primary .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-primary .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-primary .tabs li.is-active a {
-  color: #005C43 !important;
-  opacity: 1;
-}
-.hero.is-primary .tabs.is-boxed a, .hero.is-primary .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-primary .tabs.is-boxed a:hover, .hero.is-primary .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-primary .tabs.is-boxed li.is-active a, .hero.is-primary .tabs.is-boxed li.is-active a:hover, .hero.is-primary .tabs.is-toggle li.is-active a, .hero.is-primary .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #005C43;
-}
-.hero.is-primary.is-bold {
-  background-image: linear-gradient(141deg, #002917 0%, #005C43 71%, #007669 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-primary.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #002917 0%, #005C43 71%, #007669 100%);
-  }
-}
-.hero.is-link {
-  background-color: #004FB3;
-  color: #fff;
-}
-.hero.is-link a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-link strong {
-  color: inherit;
-}
-.hero.is-link .title {
-  color: #fff;
-}
-.hero.is-link .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-link .subtitle a:not(.button),
-.hero.is-link .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-link .navbar-menu {
+    color: #fff; }
+    .hero.is-primary a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-primary strong {
+      color: inherit; }
+    .hero.is-primary .title {
+      color: #fff; }
+    .hero.is-primary .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-primary .subtitle a:not(.button),
+      .hero.is-primary .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1203px) {
+      .hero.is-primary .navbar-menu {
+        background-color: #005C43; } }
+    .hero.is-primary .navbar-item,
+    .hero.is-primary .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-primary a.navbar-item:hover, .hero.is-primary a.navbar-item.is-active,
+    .hero.is-primary .navbar-link:hover,
+    .hero.is-primary .navbar-link.is-active {
+      background-color: #004330;
+      color: #fff; }
+    .hero.is-primary .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-primary .tabs a:hover {
+        opacity: 1; }
+    .hero.is-primary .tabs li.is-active a {
+      color: #005C43 !important;
+      opacity: 1; }
+    .hero.is-primary .tabs.is-boxed a, .hero.is-primary .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-primary .tabs.is-boxed a:hover, .hero.is-primary .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-primary .tabs.is-boxed li.is-active a, .hero.is-primary .tabs.is-boxed li.is-active a:hover, .hero.is-primary .tabs.is-toggle li.is-active a, .hero.is-primary .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #005C43; }
+    .hero.is-primary.is-bold {
+      background-image: linear-gradient(141deg, #002917 0%, #005C43 71%, #007669 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-primary.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #002917 0%, #005C43 71%, #007669 100%); } }
+  .hero.is-link {
     background-color: #004FB3;
-  }
-}
-.hero.is-link .navbar-item,
-.hero.is-link .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-link a.navbar-item:hover, .hero.is-link a.navbar-item.is-active,
-.hero.is-link .navbar-link:hover,
-.hero.is-link .navbar-link.is-active {
-  background-color: #00449a;
-  color: #fff;
-}
-.hero.is-link .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-link .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-link .tabs li.is-active a {
-  color: #004FB3 !important;
-  opacity: 1;
-}
-.hero.is-link .tabs.is-boxed a, .hero.is-link .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-link .tabs.is-boxed a:hover, .hero.is-link .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-link .tabs.is-boxed li.is-active a, .hero.is-link .tabs.is-boxed li.is-active a:hover, .hero.is-link .tabs.is-toggle li.is-active a, .hero.is-link .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #004FB3;
-}
-.hero.is-link.is-bold {
-  background-image: linear-gradient(141deg, #004e80 0%, #004FB3 71%, #0038cd 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-link.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #004e80 0%, #004FB3 71%, #0038cd 100%);
-  }
-}
-.hero.is-info {
-  background-color: hsl(204deg, 71%, 53%);
-  color: #fff;
-}
-.hero.is-info a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-info strong {
-  color: inherit;
-}
-.hero.is-info .title {
-  color: #fff;
-}
-.hero.is-info .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-info .subtitle a:not(.button),
-.hero.is-info .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-info .navbar-menu {
-    background-color: hsl(204deg, 71%, 53%);
-  }
-}
-.hero.is-info .navbar-item,
-.hero.is-info .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-info a.navbar-item:hover, .hero.is-info a.navbar-item.is-active,
-.hero.is-info .navbar-link:hover,
-.hero.is-info .navbar-link.is-active {
-  background-color: #238cd1;
-  color: #fff;
-}
-.hero.is-info .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-info .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-info .tabs li.is-active a {
-  color: hsl(204deg, 71%, 53%) !important;
-  opacity: 1;
-}
-.hero.is-info .tabs.is-boxed a, .hero.is-info .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-info .tabs.is-boxed a:hover, .hero.is-info .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-info .tabs.is-boxed li.is-active a, .hero.is-info .tabs.is-boxed li.is-active a:hover, .hero.is-info .tabs.is-toggle li.is-active a, .hero.is-info .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: hsl(204deg, 71%, 53%);
-}
-.hero.is-info.is-bold {
-  background-image: linear-gradient(141deg, #159dc6 0%, hsl(204deg, 71%, 53%) 71%, #4389e5 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-info.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #159dc6 0%, hsl(204deg, 71%, 53%) 71%, #4389e5 100%);
-  }
-}
-.hero.is-success {
-  background-color: #1C6301;
-  color: #fff;
-}
-.hero.is-success a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-success strong {
-  color: inherit;
-}
-.hero.is-success .title {
-  color: #fff;
-}
-.hero.is-success .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-success .subtitle a:not(.button),
-.hero.is-success .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-success .navbar-menu {
+    color: #fff; }
+    .hero.is-link a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-link strong {
+      color: inherit; }
+    .hero.is-link .title {
+      color: #fff; }
+    .hero.is-link .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-link .subtitle a:not(.button),
+      .hero.is-link .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1203px) {
+      .hero.is-link .navbar-menu {
+        background-color: #004FB3; } }
+    .hero.is-link .navbar-item,
+    .hero.is-link .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-link a.navbar-item:hover, .hero.is-link a.navbar-item.is-active,
+    .hero.is-link .navbar-link:hover,
+    .hero.is-link .navbar-link.is-active {
+      background-color: #00449a;
+      color: #fff; }
+    .hero.is-link .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-link .tabs a:hover {
+        opacity: 1; }
+    .hero.is-link .tabs li.is-active a {
+      color: #004FB3 !important;
+      opacity: 1; }
+    .hero.is-link .tabs.is-boxed a, .hero.is-link .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-link .tabs.is-boxed a:hover, .hero.is-link .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-link .tabs.is-boxed li.is-active a, .hero.is-link .tabs.is-boxed li.is-active a:hover, .hero.is-link .tabs.is-toggle li.is-active a, .hero.is-link .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #004FB3; }
+    .hero.is-link.is-bold {
+      background-image: linear-gradient(141deg, #004e80 0%, #004FB3 71%, #0038cd 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-link.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #004e80 0%, #004FB3 71%, #0038cd 100%); } }
+  .hero.is-info {
+    background-color: #3298dc;
+    color: #fff; }
+    .hero.is-info a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-info strong {
+      color: inherit; }
+    .hero.is-info .title {
+      color: #fff; }
+    .hero.is-info .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-info .subtitle a:not(.button),
+      .hero.is-info .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1203px) {
+      .hero.is-info .navbar-menu {
+        background-color: #3298dc; } }
+    .hero.is-info .navbar-item,
+    .hero.is-info .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-info a.navbar-item:hover, .hero.is-info a.navbar-item.is-active,
+    .hero.is-info .navbar-link:hover,
+    .hero.is-info .navbar-link.is-active {
+      background-color: #238cd1;
+      color: #fff; }
+    .hero.is-info .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-info .tabs a:hover {
+        opacity: 1; }
+    .hero.is-info .tabs li.is-active a {
+      color: #3298dc !important;
+      opacity: 1; }
+    .hero.is-info .tabs.is-boxed a, .hero.is-info .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-info .tabs.is-boxed a:hover, .hero.is-info .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-info .tabs.is-boxed li.is-active a, .hero.is-info .tabs.is-boxed li.is-active a:hover, .hero.is-info .tabs.is-toggle li.is-active a, .hero.is-info .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #3298dc; }
+    .hero.is-info.is-bold {
+      background-image: linear-gradient(141deg, #159dc6 0%, #3298dc 71%, #4389e5 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-info.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #159dc6 0%, #3298dc 71%, #4389e5 100%); } }
+  .hero.is-success {
     background-color: #1C6301;
-  }
-}
-.hero.is-success .navbar-item,
-.hero.is-success .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-success a.navbar-item:hover, .hero.is-success a.navbar-item.is-active,
-.hero.is-success .navbar-link:hover,
-.hero.is-success .navbar-link.is-active {
-  background-color: #154a01;
-  color: #fff;
-}
-.hero.is-success .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-success .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-success .tabs li.is-active a {
-  color: #1C6301 !important;
-  opacity: 1;
-}
-.hero.is-success .tabs.is-boxed a, .hero.is-success .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-success .tabs.is-boxed a:hover, .hero.is-success .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-success .tabs.is-boxed li.is-active a, .hero.is-success .tabs.is-boxed li.is-active a:hover, .hero.is-success .tabs.is-toggle li.is-active a, .hero.is-success .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #1C6301;
-}
-.hero.is-success.is-bold {
-  background-image: linear-gradient(141deg, #163100 0%, #1C6301 71%, #0e7e00 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-success.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #163100 0%, #1C6301 71%, #0e7e00 100%);
-  }
-}
-.hero.is-warning {
-  background-color: #EED891;
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-warning a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-warning strong {
-  color: inherit;
-}
-.hero.is-warning .title {
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-warning .subtitle {
-  color: rgba(0, 0, 0, 0.9);
-}
-.hero.is-warning .subtitle a:not(.button),
-.hero.is-warning .subtitle strong {
-  color: rgba(0, 0, 0, 0.7);
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-warning .navbar-menu {
+    color: #fff; }
+    .hero.is-success a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-success strong {
+      color: inherit; }
+    .hero.is-success .title {
+      color: #fff; }
+    .hero.is-success .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-success .subtitle a:not(.button),
+      .hero.is-success .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1203px) {
+      .hero.is-success .navbar-menu {
+        background-color: #1C6301; } }
+    .hero.is-success .navbar-item,
+    .hero.is-success .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-success a.navbar-item:hover, .hero.is-success a.navbar-item.is-active,
+    .hero.is-success .navbar-link:hover,
+    .hero.is-success .navbar-link.is-active {
+      background-color: #154a01;
+      color: #fff; }
+    .hero.is-success .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-success .tabs a:hover {
+        opacity: 1; }
+    .hero.is-success .tabs li.is-active a {
+      color: #1C6301 !important;
+      opacity: 1; }
+    .hero.is-success .tabs.is-boxed a, .hero.is-success .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-success .tabs.is-boxed a:hover, .hero.is-success .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-success .tabs.is-boxed li.is-active a, .hero.is-success .tabs.is-boxed li.is-active a:hover, .hero.is-success .tabs.is-toggle li.is-active a, .hero.is-success .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #1C6301; }
+    .hero.is-success.is-bold {
+      background-image: linear-gradient(141deg, #163100 0%, #1C6301 71%, #0e7e00 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-success.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #163100 0%, #1C6301 71%, #0e7e00 100%); } }
+  .hero.is-warning {
     background-color: #EED891;
-  }
-}
-.hero.is-warning .navbar-item,
-.hero.is-warning .navbar-link {
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-warning a.navbar-item:hover, .hero.is-warning a.navbar-item.is-active,
-.hero.is-warning .navbar-link:hover,
-.hero.is-warning .navbar-link.is-active {
-  background-color: #ebd07b;
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-warning .tabs a {
-  color: rgba(0, 0, 0, 0.7);
-  opacity: 0.9;
-}
-.hero.is-warning .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-warning .tabs li.is-active a {
-  color: #EED891 !important;
-  opacity: 1;
-}
-.hero.is-warning .tabs.is-boxed a, .hero.is-warning .tabs.is-toggle a {
-  color: rgba(0, 0, 0, 0.7);
-}
-.hero.is-warning .tabs.is-boxed a:hover, .hero.is-warning .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-warning .tabs.is-boxed li.is-active a, .hero.is-warning .tabs.is-boxed li.is-active a:hover, .hero.is-warning .tabs.is-toggle li.is-active a, .hero.is-warning .tabs.is-toggle li.is-active a:hover {
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(0, 0, 0, 0.7);
-  color: #EED891;
-}
-.hero.is-warning.is-bold {
-  background-image: linear-gradient(141deg, #f0b45c 0%, #EED891 71%, #f4eea5 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-warning.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #f0b45c 0%, #EED891 71%, #f4eea5 100%);
-  }
-}
-.hero.is-danger {
-  background-color: #A30031;
-  color: #fff;
-}
-.hero.is-danger a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
-.hero.is-danger strong {
-  color: inherit;
-}
-.hero.is-danger .title {
-  color: #fff;
-}
-.hero.is-danger .subtitle {
-  color: rgba(255, 255, 255, 0.9);
-}
-.hero.is-danger .subtitle a:not(.button),
-.hero.is-danger .subtitle strong {
-  color: #fff;
-}
-@media screen and (max-width: 1203px) {
-  .hero.is-danger .navbar-menu {
+    color: rgba(0, 0, 0, 0.7); }
+    .hero.is-warning a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-warning strong {
+      color: inherit; }
+    .hero.is-warning .title {
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-warning .subtitle {
+      color: rgba(0, 0, 0, 0.9); }
+      .hero.is-warning .subtitle a:not(.button),
+      .hero.is-warning .subtitle strong {
+        color: rgba(0, 0, 0, 0.7); }
+    @media screen and (max-width: 1203px) {
+      .hero.is-warning .navbar-menu {
+        background-color: #EED891; } }
+    .hero.is-warning .navbar-item,
+    .hero.is-warning .navbar-link {
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-warning a.navbar-item:hover, .hero.is-warning a.navbar-item.is-active,
+    .hero.is-warning .navbar-link:hover,
+    .hero.is-warning .navbar-link.is-active {
+      background-color: #ebd07b;
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-warning .tabs a {
+      color: rgba(0, 0, 0, 0.7);
+      opacity: 0.9; }
+      .hero.is-warning .tabs a:hover {
+        opacity: 1; }
+    .hero.is-warning .tabs li.is-active a {
+      color: #EED891 !important;
+      opacity: 1; }
+    .hero.is-warning .tabs.is-boxed a, .hero.is-warning .tabs.is-toggle a {
+      color: rgba(0, 0, 0, 0.7); }
+      .hero.is-warning .tabs.is-boxed a:hover, .hero.is-warning .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-warning .tabs.is-boxed li.is-active a, .hero.is-warning .tabs.is-boxed li.is-active a:hover, .hero.is-warning .tabs.is-toggle li.is-active a, .hero.is-warning .tabs.is-toggle li.is-active a:hover {
+      background-color: rgba(0, 0, 0, 0.7);
+      border-color: rgba(0, 0, 0, 0.7);
+      color: #EED891; }
+    .hero.is-warning.is-bold {
+      background-image: linear-gradient(141deg, #f0b45c 0%, #EED891 71%, #f4eea5 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-warning.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #f0b45c 0%, #EED891 71%, #f4eea5 100%); } }
+  .hero.is-danger {
     background-color: #A30031;
-  }
-}
-.hero.is-danger .navbar-item,
-.hero.is-danger .navbar-link {
-  color: rgba(255, 255, 255, 0.7);
-}
-.hero.is-danger a.navbar-item:hover, .hero.is-danger a.navbar-item.is-active,
-.hero.is-danger .navbar-link:hover,
-.hero.is-danger .navbar-link.is-active {
-  background-color: #8a0029;
-  color: #fff;
-}
-.hero.is-danger .tabs a {
-  color: #fff;
-  opacity: 0.9;
-}
-.hero.is-danger .tabs a:hover {
-  opacity: 1;
-}
-.hero.is-danger .tabs li.is-active a {
-  color: #A30031 !important;
-  opacity: 1;
-}
-.hero.is-danger .tabs.is-boxed a, .hero.is-danger .tabs.is-toggle a {
-  color: #fff;
-}
-.hero.is-danger .tabs.is-boxed a:hover, .hero.is-danger .tabs.is-toggle a:hover {
-  background-color: rgba(3, 3, 3, 0.1);
-}
-.hero.is-danger .tabs.is-boxed li.is-active a, .hero.is-danger .tabs.is-boxed li.is-active a:hover, .hero.is-danger .tabs.is-toggle li.is-active a, .hero.is-danger .tabs.is-toggle li.is-active a:hover {
-  background-color: #fff;
-  border-color: #fff;
-  color: #A30031;
-}
-.hero.is-danger.is-bold {
-  background-image: linear-gradient(141deg, #700034 0%, #A30031 71%, #bd0019 100%);
-}
-@media screen and (max-width: 768px) {
-  .hero.is-danger.is-bold .navbar-menu {
-    background-image: linear-gradient(141deg, #700034 0%, #A30031 71%, #bd0019 100%);
-  }
-}
-.hero.is-small .hero-body {
-  padding: 1.5rem;
-}
-@media screen and (min-width: 769px), print {
-  .hero.is-medium .hero-body {
-    padding: 6rem 0.5rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .hero.is-large .hero-body {
-    padding: 18rem 6rem;
-  }
-}
-.hero.is-halfheight .hero-body, .hero.is-fullheight .hero-body, .hero.is-fullheight-with-navbar .hero-body {
-  align-items: center;
-  display: flex;
-}
-.hero.is-halfheight .hero-body > .container, .hero.is-fullheight .hero-body > .container, .hero.is-fullheight-with-navbar .hero-body > .container {
-  flex-grow: 1;
-  flex-shrink: 1;
-}
-.hero.is-halfheight {
-  min-height: 50vh;
-}
-.hero.is-fullheight {
-  min-height: 100vh;
-}
+    color: #fff; }
+    .hero.is-danger a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-danger strong {
+      color: inherit; }
+    .hero.is-danger .title {
+      color: #fff; }
+    .hero.is-danger .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-danger .subtitle a:not(.button),
+      .hero.is-danger .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1203px) {
+      .hero.is-danger .navbar-menu {
+        background-color: #A30031; } }
+    .hero.is-danger .navbar-item,
+    .hero.is-danger .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-danger a.navbar-item:hover, .hero.is-danger a.navbar-item.is-active,
+    .hero.is-danger .navbar-link:hover,
+    .hero.is-danger .navbar-link.is-active {
+      background-color: #8a0029;
+      color: #fff; }
+    .hero.is-danger .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-danger .tabs a:hover {
+        opacity: 1; }
+    .hero.is-danger .tabs li.is-active a {
+      color: #A30031 !important;
+      opacity: 1; }
+    .hero.is-danger .tabs.is-boxed a, .hero.is-danger .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-danger .tabs.is-boxed a:hover, .hero.is-danger .tabs.is-toggle a:hover {
+        background-color: rgba(3, 3, 3, 0.1); }
+    .hero.is-danger .tabs.is-boxed li.is-active a, .hero.is-danger .tabs.is-boxed li.is-active a:hover, .hero.is-danger .tabs.is-toggle li.is-active a, .hero.is-danger .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #A30031; }
+    .hero.is-danger.is-bold {
+      background-image: linear-gradient(141deg, #700034 0%, #A30031 71%, #bd0019 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-danger.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #700034 0%, #A30031 71%, #bd0019 100%); } }
+  .hero.is-small .hero-body {
+    padding: 1.5rem; }
+  @media screen and (min-width: 769px), print {
+    .hero.is-medium .hero-body {
+      padding: 6rem 0.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .hero.is-large .hero-body {
+      padding: 18rem 6rem; } }
+  .hero.is-halfheight .hero-body, .hero.is-fullheight .hero-body, .hero.is-fullheight-with-navbar .hero-body {
+    align-items: center;
+    display: flex; }
+    .hero.is-halfheight .hero-body > .container, .hero.is-fullheight .hero-body > .container, .hero.is-fullheight-with-navbar .hero-body > .container {
+      flex-grow: 1;
+      flex-shrink: 1; }
+  .hero.is-halfheight {
+    min-height: 50vh; }
+  .hero.is-fullheight {
+    min-height: 100vh; }
 
 .hero-video {
-  overflow: hidden;
-}
-.hero-video video {
-  left: 50%;
-  min-height: 100%;
-  min-width: 100%;
-  position: absolute;
-  top: 50%;
-  transform: translate3d(-50%, -50%, 0);
-}
-.hero-video.is-transparent {
-  opacity: 0.3;
-}
-@media screen and (max-width: 768px) {
-  .hero-video {
-    display: none;
-  }
-}
+  overflow: hidden; }
+  .hero-video video {
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    position: absolute;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0); }
+  .hero-video.is-transparent {
+    opacity: 0.3; }
+  @media screen and (max-width: 768px) {
+    .hero-video {
+      display: none; } }
 
 .hero-buttons {
-  margin-top: 1.5rem;
-}
-@media screen and (max-width: 768px) {
-  .hero-buttons .button {
-    display: flex;
-  }
-  .hero-buttons .button:not(:last-child) {
-    margin-bottom: 0.75rem;
-  }
-}
-@media screen and (min-width: 769px), print {
-  .hero-buttons {
-    display: flex;
-    justify-content: center;
-  }
-  .hero-buttons .button:not(:last-child) {
-    margin-right: 1.5rem;
-  }
-}
+  margin-top: 1.5rem; }
+  @media screen and (max-width: 768px) {
+    .hero-buttons .button {
+      display: flex; }
+      .hero-buttons .button:not(:last-child) {
+        margin-bottom: 0.75rem; } }
+  @media screen and (min-width: 769px), print {
+    .hero-buttons {
+      display: flex;
+      justify-content: center; }
+      .hero-buttons .button:not(:last-child) {
+        margin-right: 1.5rem; } }
 
 .hero-head,
 .hero-foot {
   flex-grow: 0;
-  flex-shrink: 0;
-}
+  flex-shrink: 0; }
 
 .hero-body {
   flex-grow: 1;
   flex-shrink: 0;
-  padding: 3rem 1.5rem;
-}
-@media screen and (min-width: 769px), print {
-  .hero-body {
-    padding: 3rem 3rem;
-  }
-}
+  padding: 3rem 1.5rem; }
+  @media screen and (min-width: 769px), print {
+    .hero-body {
+      padding: 3rem 3rem; } }
 
 .section {
-  padding: 1.5rem 1.5rem;
-}
-@media screen and (min-width: 1204px) {
-  .section {
-    padding: 3rem 3rem;
-  }
-  .section.is-medium {
-    padding: 9rem 4.5rem;
-  }
-  .section.is-large {
-    padding: 18rem 6rem;
-  }
-}
+  padding: 1.5rem 1.5rem; }
+  @media screen and (min-width: 1204px) {
+    .section {
+      padding: 3rem 3rem; }
+      .section.is-medium {
+        padding: 9rem 4.5rem; }
+      .section.is-large {
+        padding: 18rem 6rem; } }
 
 .is-size-1 {
-  font-size: 3rem !important;
-}
+  font-size: 3rem !important; }
 
 .is-size-2 {
-  font-size: 2.5rem !important;
-}
+  font-size: 2.5rem !important; }
 
 .is-size-3 {
-  font-size: 2rem !important;
-}
+  font-size: 2rem !important; }
 
 .is-size-4 {
-  font-size: 1.5rem !important;
-}
+  font-size: 1.5rem !important; }
 
 .is-size-5 {
-  font-size: 1.25rem !important;
-}
+  font-size: 1.25rem !important; }
 
 .is-size-6 {
-  font-size: 1rem !important;
-}
+  font-size: 1rem !important; }
 
 .is-size-7 {
-  font-size: 0.75rem !important;
-}
+  font-size: 0.75rem !important; }
 
 @media screen and (max-width: 768px) {
   .is-size-1-mobile {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
+
   .is-size-2-mobile {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
+
   .is-size-3-mobile {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
+
   .is-size-4-mobile {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
+
   .is-size-5-mobile {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
+
   .is-size-6-mobile {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
+
   .is-size-7-mobile {
-    font-size: 0.75rem !important;
-  }
-}
+    font-size: 0.75rem !important; } }
 @media screen and (min-width: 769px), print {
   .is-size-1-tablet {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
+
   .is-size-2-tablet {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
+
   .is-size-3-tablet {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
+
   .is-size-4-tablet {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
+
   .is-size-5-tablet {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
+
   .is-size-6-tablet {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
+
   .is-size-7-tablet {
-    font-size: 0.75rem !important;
-  }
-}
+    font-size: 0.75rem !important; } }
 @media screen and (max-width: 1203px) {
   .is-size-1-touch {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
+
   .is-size-2-touch {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
+
   .is-size-3-touch {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
+
   .is-size-4-touch {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
+
   .is-size-5-touch {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
+
   .is-size-6-touch {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
+
   .is-size-7-touch {
-    font-size: 0.75rem !important;
-  }
-}
+    font-size: 0.75rem !important; } }
 @media screen and (min-width: 1204px) {
   .is-size-1-desktop {
-    font-size: 3rem !important;
-  }
+    font-size: 3rem !important; }
+
   .is-size-2-desktop {
-    font-size: 2.5rem !important;
-  }
+    font-size: 2.5rem !important; }
+
   .is-size-3-desktop {
-    font-size: 2rem !important;
-  }
+    font-size: 2rem !important; }
+
   .is-size-4-desktop {
-    font-size: 1.5rem !important;
-  }
+    font-size: 1.5rem !important; }
+
   .is-size-5-desktop {
-    font-size: 1.25rem !important;
-  }
+    font-size: 1.25rem !important; }
+
   .is-size-6-desktop {
-    font-size: 1rem !important;
-  }
+    font-size: 1rem !important; }
+
   .is-size-7-desktop {
-    font-size: 0.75rem !important;
-  }
-}
+    font-size: 0.75rem !important; } }
 .has-text-centered {
-  text-align: center !important;
-}
+  text-align: center !important; }
 
 .has-text-justified {
-  text-align: justify !important;
-}
+  text-align: justify !important; }
 
 .has-text-left {
-  text-align: left !important;
-}
+  text-align: left !important; }
 
 .has-text-right {
-  text-align: right !important;
-}
+  text-align: right !important; }
 
 @media screen and (max-width: 768px) {
   .has-text-centered-mobile {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
 @media screen and (min-width: 769px), print {
   .has-text-centered-tablet {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
 @media screen and (min-width: 769px) and (max-width: 1203px) {
   .has-text-centered-tablet-only {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
 @media screen and (max-width: 1203px) {
   .has-text-centered-touch {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
 @media screen and (min-width: 1204px) {
   .has-text-centered-desktop {
-    text-align: center !important;
-  }
-}
+    text-align: center !important; } }
 @media screen and (max-width: 768px) {
   .has-text-justified-mobile {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
 @media screen and (min-width: 769px), print {
   .has-text-justified-tablet {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
 @media screen and (min-width: 769px) and (max-width: 1203px) {
   .has-text-justified-tablet-only {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
 @media screen and (max-width: 1203px) {
   .has-text-justified-touch {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
 @media screen and (min-width: 1204px) {
   .has-text-justified-desktop {
-    text-align: justify !important;
-  }
-}
+    text-align: justify !important; } }
 @media screen and (max-width: 768px) {
   .has-text-left-mobile {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
 @media screen and (min-width: 769px), print {
   .has-text-left-tablet {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
 @media screen and (min-width: 769px) and (max-width: 1203px) {
   .has-text-left-tablet-only {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
 @media screen and (max-width: 1203px) {
   .has-text-left-touch {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
 @media screen and (min-width: 1204px) {
   .has-text-left-desktop {
-    text-align: left !important;
-  }
-}
+    text-align: left !important; } }
 @media screen and (max-width: 768px) {
   .has-text-right-mobile {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
 @media screen and (min-width: 769px), print {
   .has-text-right-tablet {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
 @media screen and (min-width: 769px) and (max-width: 1203px) {
   .has-text-right-tablet-only {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
 @media screen and (max-width: 1203px) {
   .has-text-right-touch {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
 @media screen and (min-width: 1204px) {
   .has-text-right-desktop {
-    text-align: right !important;
-  }
-}
+    text-align: right !important; } }
 .is-capitalized {
-  text-transform: capitalize !important;
-}
+  text-transform: capitalize !important; }
 
 .is-lowercase {
-  text-transform: lowercase !important;
-}
+  text-transform: lowercase !important; }
 
 .is-uppercase {
-  text-transform: uppercase !important;
-}
+  text-transform: uppercase !important; }
 
 .is-italic {
-  font-style: italic !important;
-}
+  font-style: italic !important; }
 
 .is-underlined {
-  text-decoration: underline !important;
-}
+  text-decoration: underline !important; }
 
 .has-text-weight-light {
-  font-weight: 300 !important;
-}
+  font-weight: 300 !important; }
 
 .has-text-weight-normal {
-  font-weight: 400 !important;
-}
+  font-weight: 400 !important; }
 
 .has-text-weight-medium {
-  font-weight: 500 !important;
-}
+  font-weight: 500 !important; }
 
 .has-text-weight-semibold {
-  font-weight: 600 !important;
-}
+  font-weight: 600 !important; }
 
 .has-text-weight-bold {
-  font-weight: 700 !important;
-}
+  font-weight: 700 !important; }
 
 .is-family-primary {
-  font-family: "Inter", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
-}
+  font-family: "Inter", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important; }
 
 .is-family-secondary {
-  font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
-}
+  font-family: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important; }
 
 .is-family-sans-serif {
-  font-family: "Inter", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
-}
+  font-family: "Inter", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important; }
 
 .is-family-monospace {
-  font-family: monospace !important;
-}
+  font-family: monospace !important; }
 
 .is-family-code {
-  font-family: monospace !important;
-}
+  font-family: monospace !important; }
 
 .has-text-white {
-  color: #fafafa !important;
-}
+  color: #fafafa !important; }
 
 a.has-text-white:hover, a.has-text-white:focus {
-  color: #e1e1e1 !important;
-}
+  color: #e1e1e1 !important; }
 
 .has-background-white {
-  background-color: #fafafa !important;
-}
+  background-color: #fafafa !important; }
 
 .has-text-black {
-  color: #030303 !important;
-}
+  color: #030303 !important; }
 
 a.has-text-black:hover, a.has-text-black:focus {
-  color: black !important;
-}
+  color: black !important; }
 
 .has-background-black {
-  background-color: #030303 !important;
-}
+  background-color: #030303 !important; }
 
 .has-text-light {
-  color: #f5f5f5 !important;
-}
+  color: #f5f5f5 !important; }
 
 a.has-text-light:hover, a.has-text-light:focus {
-  color: gainsboro !important;
-}
+  color: gainsboro !important; }
 
 .has-background-light {
-  background-color: #f5f5f5 !important;
-}
+  background-color: #f5f5f5 !important; }
 
 .has-text-dark {
-  color: #3A3D4E !important;
-}
+  color: #3A3D4E !important; }
 
 a.has-text-dark:hover, a.has-text-dark:focus {
-  color: #242631 !important;
-}
+  color: #242631 !important; }
 
 .has-background-dark {
-  background-color: #3A3D4E !important;
-}
+  background-color: #3A3D4E !important; }
 
 .has-text-primary {
-  color: #005C43 !important;
-}
+  color: #005C43 !important; }
 
 a.has-text-primary:hover, a.has-text-primary:focus {
-  color: #00291e !important;
-}
+  color: #00291e !important; }
 
 .has-background-primary {
-  background-color: #005C43 !important;
-}
+  background-color: #005C43 !important; }
 
 .has-text-primary-light {
-  color: #ebfff9 !important;
-}
+  color: #ebfff9 !important; }
 
 a.has-text-primary-light:hover, a.has-text-primary-light:focus {
-  color: #b8ffec !important;
-}
+  color: #b8ffec !important; }
 
 .has-background-primary-light {
-  background-color: #ebfff9 !important;
-}
+  background-color: #ebfff9 !important; }
 
 .has-text-primary-dark {
-  color: #05ffbb !important;
-}
+  color: #05ffbb !important; }
 
 a.has-text-primary-dark:hover, a.has-text-primary-dark:focus {
-  color: #38ffc9 !important;
-}
+  color: #38ffc9 !important; }
 
 .has-background-primary-dark {
-  background-color: #05ffbb !important;
-}
+  background-color: #05ffbb !important; }
 
 .has-text-link {
-  color: #004FB3 !important;
-}
+  color: #004FB3 !important; }
 
 a.has-text-link:hover, a.has-text-link:focus {
-  color: #003880 !important;
-}
+  color: #003880 !important; }
 
 .has-background-link {
-  background-color: #004FB3 !important;
-}
+  background-color: #004FB3 !important; }
 
 .has-text-link-light {
-  color: #ebf4ff !important;
-}
+  color: #ebf4ff !important; }
 
 a.has-text-link-light:hover, a.has-text-link-light:focus {
-  color: #b8d7ff !important;
-}
+  color: #b8d7ff !important; }
 
 .has-background-link-light {
-  background-color: #ebf4ff !important;
-}
+  background-color: #ebf4ff !important; }
 
 .has-text-link-dark {
-  color: #0573ff !important;
-}
+  color: #0573ff !important; }
 
 a.has-text-link-dark:hover, a.has-text-link-dark:focus {
-  color: #3890ff !important;
-}
+  color: #3890ff !important; }
 
 .has-background-link-dark {
-  background-color: #0573ff !important;
-}
+  background-color: #0573ff !important; }
 
 .has-text-info {
-  color: hsl(204deg, 71%, 53%) !important;
-}
+  color: #3298dc !important; }
 
 a.has-text-info:hover, a.has-text-info:focus {
-  color: #207dbc !important;
-}
+  color: #207dbc !important; }
 
 .has-background-info {
-  background-color: hsl(204deg, 71%, 53%) !important;
-}
+  background-color: #3298dc !important; }
 
 .has-text-info-light {
-  color: #eef6fc !important;
-}
+  color: #eef6fc !important; }
 
 a.has-text-info-light:hover, a.has-text-info-light:focus {
-  color: #c2e0f5 !important;
-}
+  color: #c2e0f5 !important; }
 
 .has-background-info-light {
-  background-color: #eef6fc !important;
-}
+  background-color: #eef6fc !important; }
 
 .has-text-info-dark {
-  color: #1d72aa !important;
-}
+  color: #1d72aa !important; }
 
 a.has-text-info-dark:hover, a.has-text-info-dark:focus {
-  color: #248fd6 !important;
-}
+  color: #248fd6 !important; }
 
 .has-background-info-dark {
-  background-color: #1d72aa !important;
-}
+  background-color: #1d72aa !important; }
 
 .has-text-success {
-  color: #1C6301 !important;
-}
+  color: #1C6301 !important; }
 
 a.has-text-success:hover, a.has-text-success:focus {
-  color: #0e3100 !important;
-}
+  color: #0e3100 !important; }
 
 .has-background-success {
-  background-color: #1C6301 !important;
-}
+  background-color: #1C6301 !important; }
 
 .has-text-success-light {
-  color: #f0ffeb !important;
-}
+  color: #f0ffeb !important; }
 
 a.has-text-success-light:hover, a.has-text-success-light:focus {
-  color: #ccfeb8 !important;
-}
+  color: #ccfeb8 !important; }
 
 .has-background-success-light {
-  background-color: #f0ffeb !important;
-}
+  background-color: #f0ffeb !important; }
 
 .has-text-success-dark {
-  color: #47fc03 !important;
-}
+  color: #47fc03 !important; }
 
 a.has-text-success-dark:hover, a.has-text-success-dark:focus {
-  color: #6cfd35 !important;
-}
+  color: #6cfd35 !important; }
 
 .has-background-success-dark {
-  background-color: #47fc03 !important;
-}
+  background-color: #47fc03 !important; }
 
 .has-text-warning {
-  color: #EED891 !important;
-}
+  color: #EED891 !important; }
 
 a.has-text-warning:hover, a.has-text-warning:focus {
-  color: #e7c865 !important;
-}
+  color: #e7c865 !important; }
 
 .has-background-warning {
-  background-color: #EED891 !important;
-}
+  background-color: #EED891 !important; }
 
 .has-text-warning-light {
-  color: #fcf9ed !important;
-}
+  color: #fcf9ed !important; }
 
 a.has-text-warning-light:hover, a.has-text-warning-light:focus {
-  color: #f5e9c1 !important;
-}
+  color: #f5e9c1 !important; }
 
 .has-background-warning-light {
-  background-color: #fcf9ed !important;
-}
+  background-color: #fcf9ed !important; }
 
 .has-text-warning-dark {
-  color: #806614 !important;
-}
+  color: #806614 !important; }
 
 a.has-text-warning-dark:hover, a.has-text-warning-dark:focus {
-  color: #ac8a1b !important;
-}
+  color: #ac8a1b !important; }
 
 .has-background-warning-dark {
-  background-color: #806614 !important;
-}
+  background-color: #806614 !important; }
 
 .has-text-danger {
-  color: #A30031 !important;
-}
+  color: #A30031 !important; }
 
 a.has-text-danger:hover, a.has-text-danger:focus {
-  color: #700022 !important;
-}
+  color: #700022 !important; }
 
 .has-background-danger {
-  background-color: #A30031 !important;
-}
+  background-color: #A30031 !important; }
 
 .has-text-danger-light {
-  color: #ffebf1 !important;
-}
+  color: #ffebf1 !important; }
 
 a.has-text-danger-light:hover, a.has-text-danger-light:focus {
-  color: #ffb8cd !important;
-}
+  color: #ffb8cd !important; }
 
 .has-background-danger-light {
-  background-color: #ffebf1 !important;
-}
+  background-color: #ffebf1 !important; }
 
 .has-text-danger-dark {
-  color: #ff0a54 !important;
-}
+  color: #ff0a54 !important; }
 
 a.has-text-danger-dark:hover, a.has-text-danger-dark:focus {
-  color: #ff3d77 !important;
-}
+  color: #ff3d77 !important; }
 
 .has-background-danger-dark {
-  background-color: #ff0a54 !important;
-}
+  background-color: #ff0a54 !important; }
 
 .has-text-black-bis {
-  color: #1B1D1E !important;
-}
+  color: #1B1D1E !important; }
 
 .has-background-black-bis {
-  background-color: #1B1D1E !important;
-}
+  background-color: #1B1D1E !important; }
 
 .has-text-black-ter {
-  color: #212426 !important;
-}
+  color: #212426 !important; }
 
 .has-background-black-ter {
-  background-color: #212426 !important;
-}
+  background-color: #212426 !important; }
 
 .has-text-grey-darker {
-  color: #3A3D4E !important;
-}
+  color: #3A3D4E !important; }
 
 .has-background-grey-darker {
-  background-color: #3A3D4E !important;
-}
+  background-color: #3A3D4E !important; }
 
 .has-text-grey-dark {
-  color: #83858D !important;
-}
+  color: #83858D !important; }
 
 .has-background-grey-dark {
-  background-color: #83858D !important;
-}
+  background-color: #83858D !important; }
 
 .has-text-grey {
-  color: #cccccc !important;
-}
+  color: #cccccc !important; }
 
 .has-background-grey {
-  background-color: #cccccc !important;
-}
+  background-color: #cccccc !important; }
 
 .has-text-grey-light {
-  color: #d8d8d8 !important;
-}
+  color: #d8d8d8 !important; }
 
 .has-background-grey-light {
-  background-color: #d8d8d8 !important;
-}
+  background-color: #d8d8d8 !important; }
 
 .has-text-grey-lighter {
-  color: #e5e5e5 !important;
-}
+  color: #e5e5e5 !important; }
 
 .has-background-grey-lighter {
-  background-color: #e5e5e5 !important;
-}
+  background-color: #e5e5e5 !important; }
 
 .has-text-white-ter {
-  color: #f5f5f5 !important;
-}
+  color: #f5f5f5 !important; }
 
 .has-background-white-ter {
-  background-color: #f5f5f5 !important;
-}
+  background-color: #f5f5f5 !important; }
 
 .has-text-white-bis {
-  color: #f7f7f7 !important;
-}
+  color: #f7f7f7 !important; }
 
 .has-background-white-bis {
-  background-color: #f7f7f7 !important;
-}
+  background-color: #f7f7f7 !important; }
 
 .is-marginless {
-  margin: 0 !important;
-}
+  margin: 0 !important; }
 
 .is-paddingless {
-  padding: 0 !important;
-}
+  padding: 0 !important; }
 
 .m-0 {
-  margin: 0 !important;
-}
+  margin: 0 !important; }
 
 .mt-0 {
-  margin-top: 0 !important;
-}
+  margin-top: 0 !important; }
 
 .mr-0 {
-  margin-right: 0 !important;
-}
+  margin-right: 0 !important; }
 
 .mb-0 {
-  margin-bottom: 0 !important;
-}
+  margin-bottom: 0 !important; }
 
 .ml-0 {
-  margin-left: 0 !important;
-}
+  margin-left: 0 !important; }
 
 .mx-0 {
   margin-left: 0 !important;
-  margin-right: 0 !important;
-}
+  margin-right: 0 !important; }
 
 .my-0 {
   margin-top: 0 !important;
-  margin-bottom: 0 !important;
-}
+  margin-bottom: 0 !important; }
 
 .m-1 {
-  margin: 0.25rem !important;
-}
+  margin: 0.25rem !important; }
 
 .mt-1 {
-  margin-top: 0.25rem !important;
-}
+  margin-top: 0.25rem !important; }
 
 .mr-1 {
-  margin-right: 0.25rem !important;
-}
+  margin-right: 0.25rem !important; }
 
 .mb-1 {
-  margin-bottom: 0.25rem !important;
-}
+  margin-bottom: 0.25rem !important; }
 
 .ml-1 {
-  margin-left: 0.25rem !important;
-}
+  margin-left: 0.25rem !important; }
 
 .mx-1 {
   margin-left: 0.25rem !important;
-  margin-right: 0.25rem !important;
-}
+  margin-right: 0.25rem !important; }
 
 .my-1 {
   margin-top: 0.25rem !important;
-  margin-bottom: 0.25rem !important;
-}
+  margin-bottom: 0.25rem !important; }
 
 .m-2 {
-  margin: 0.5rem !important;
-}
+  margin: 0.5rem !important; }
 
 .mt-2 {
-  margin-top: 0.5rem !important;
-}
+  margin-top: 0.5rem !important; }
 
 .mr-2 {
-  margin-right: 0.5rem !important;
-}
+  margin-right: 0.5rem !important; }
 
 .mb-2 {
-  margin-bottom: 0.5rem !important;
-}
+  margin-bottom: 0.5rem !important; }
 
 .ml-2 {
-  margin-left: 0.5rem !important;
-}
+  margin-left: 0.5rem !important; }
 
 .mx-2 {
   margin-left: 0.5rem !important;
-  margin-right: 0.5rem !important;
-}
+  margin-right: 0.5rem !important; }
 
 .my-2 {
   margin-top: 0.5rem !important;
-  margin-bottom: 0.5rem !important;
-}
+  margin-bottom: 0.5rem !important; }
 
 .m-3 {
-  margin: 0.75rem !important;
-}
+  margin: 0.75rem !important; }
 
 .mt-3 {
-  margin-top: 0.75rem !important;
-}
+  margin-top: 0.75rem !important; }
 
 .mr-3 {
-  margin-right: 0.75rem !important;
-}
+  margin-right: 0.75rem !important; }
 
 .mb-3 {
-  margin-bottom: 0.75rem !important;
-}
+  margin-bottom: 0.75rem !important; }
 
 .ml-3 {
-  margin-left: 0.75rem !important;
-}
+  margin-left: 0.75rem !important; }
 
 .mx-3 {
   margin-left: 0.75rem !important;
-  margin-right: 0.75rem !important;
-}
+  margin-right: 0.75rem !important; }
 
 .my-3 {
   margin-top: 0.75rem !important;
-  margin-bottom: 0.75rem !important;
-}
+  margin-bottom: 0.75rem !important; }
 
 .m-4 {
-  margin: 1rem !important;
-}
+  margin: 1rem !important; }
 
 .mt-4 {
-  margin-top: 1rem !important;
-}
+  margin-top: 1rem !important; }
 
 .mr-4 {
-  margin-right: 1rem !important;
-}
+  margin-right: 1rem !important; }
 
 .mb-4 {
-  margin-bottom: 1rem !important;
-}
+  margin-bottom: 1rem !important; }
 
 .ml-4 {
-  margin-left: 1rem !important;
-}
+  margin-left: 1rem !important; }
 
 .mx-4 {
   margin-left: 1rem !important;
-  margin-right: 1rem !important;
-}
+  margin-right: 1rem !important; }
 
 .my-4 {
   margin-top: 1rem !important;
-  margin-bottom: 1rem !important;
-}
+  margin-bottom: 1rem !important; }
 
 .m-5 {
-  margin: 1.5rem !important;
-}
+  margin: 1.5rem !important; }
 
 .mt-5 {
-  margin-top: 1.5rem !important;
-}
+  margin-top: 1.5rem !important; }
 
 .mr-5 {
-  margin-right: 1.5rem !important;
-}
+  margin-right: 1.5rem !important; }
 
 .mb-5 {
-  margin-bottom: 1.5rem !important;
-}
+  margin-bottom: 1.5rem !important; }
 
 .ml-5 {
-  margin-left: 1.5rem !important;
-}
+  margin-left: 1.5rem !important; }
 
 .mx-5 {
   margin-left: 1.5rem !important;
-  margin-right: 1.5rem !important;
-}
+  margin-right: 1.5rem !important; }
 
 .my-5 {
   margin-top: 1.5rem !important;
-  margin-bottom: 1.5rem !important;
-}
+  margin-bottom: 1.5rem !important; }
 
 .m-6 {
-  margin: 3rem !important;
-}
+  margin: 3rem !important; }
 
 .mt-6 {
-  margin-top: 3rem !important;
-}
+  margin-top: 3rem !important; }
 
 .mr-6 {
-  margin-right: 3rem !important;
-}
+  margin-right: 3rem !important; }
 
 .mb-6 {
-  margin-bottom: 3rem !important;
-}
+  margin-bottom: 3rem !important; }
 
 .ml-6 {
-  margin-left: 3rem !important;
-}
+  margin-left: 3rem !important; }
 
 .mx-6 {
   margin-left: 3rem !important;
-  margin-right: 3rem !important;
-}
+  margin-right: 3rem !important; }
 
 .my-6 {
   margin-top: 3rem !important;
-  margin-bottom: 3rem !important;
-}
+  margin-bottom: 3rem !important; }
 
 .m-auto {
-  margin: auto !important;
-}
+  margin: auto !important; }
 
 .mt-auto {
-  margin-top: auto !important;
-}
+  margin-top: auto !important; }
 
 .mr-auto {
-  margin-right: auto !important;
-}
+  margin-right: auto !important; }
 
 .mb-auto {
-  margin-bottom: auto !important;
-}
+  margin-bottom: auto !important; }
 
 .ml-auto {
-  margin-left: auto !important;
-}
+  margin-left: auto !important; }
 
 .mx-auto {
   margin-left: auto !important;
-  margin-right: auto !important;
-}
+  margin-right: auto !important; }
 
 .my-auto {
   margin-top: auto !important;
-  margin-bottom: auto !important;
-}
+  margin-bottom: auto !important; }
 
 .p-0 {
-  padding: 0 !important;
-}
+  padding: 0 !important; }
 
 .pt-0 {
-  padding-top: 0 !important;
-}
+  padding-top: 0 !important; }
 
 .pr-0 {
-  padding-right: 0 !important;
-}
+  padding-right: 0 !important; }
 
 .pb-0 {
-  padding-bottom: 0 !important;
-}
+  padding-bottom: 0 !important; }
 
 .pl-0 {
-  padding-left: 0 !important;
-}
+  padding-left: 0 !important; }
 
 .px-0 {
   padding-left: 0 !important;
-  padding-right: 0 !important;
-}
+  padding-right: 0 !important; }
 
 .py-0 {
   padding-top: 0 !important;
-  padding-bottom: 0 !important;
-}
+  padding-bottom: 0 !important; }
 
 .p-1 {
-  padding: 0.25rem !important;
-}
+  padding: 0.25rem !important; }
 
 .pt-1 {
-  padding-top: 0.25rem !important;
-}
+  padding-top: 0.25rem !important; }
 
 .pr-1 {
-  padding-right: 0.25rem !important;
-}
+  padding-right: 0.25rem !important; }
 
 .pb-1 {
-  padding-bottom: 0.25rem !important;
-}
+  padding-bottom: 0.25rem !important; }
 
 .pl-1 {
-  padding-left: 0.25rem !important;
-}
+  padding-left: 0.25rem !important; }
 
 .px-1 {
   padding-left: 0.25rem !important;
-  padding-right: 0.25rem !important;
-}
+  padding-right: 0.25rem !important; }
 
 .py-1 {
   padding-top: 0.25rem !important;
-  padding-bottom: 0.25rem !important;
-}
+  padding-bottom: 0.25rem !important; }
 
 .p-2 {
-  padding: 0.5rem !important;
-}
+  padding: 0.5rem !important; }
 
 .pt-2 {
-  padding-top: 0.5rem !important;
-}
+  padding-top: 0.5rem !important; }
 
 .pr-2 {
-  padding-right: 0.5rem !important;
-}
+  padding-right: 0.5rem !important; }
 
 .pb-2 {
-  padding-bottom: 0.5rem !important;
-}
+  padding-bottom: 0.5rem !important; }
 
 .pl-2 {
-  padding-left: 0.5rem !important;
-}
+  padding-left: 0.5rem !important; }
 
 .px-2 {
   padding-left: 0.5rem !important;
-  padding-right: 0.5rem !important;
-}
+  padding-right: 0.5rem !important; }
 
 .py-2 {
   padding-top: 0.5rem !important;
-  padding-bottom: 0.5rem !important;
-}
+  padding-bottom: 0.5rem !important; }
 
 .p-3 {
-  padding: 0.75rem !important;
-}
+  padding: 0.75rem !important; }
 
 .pt-3 {
-  padding-top: 0.75rem !important;
-}
+  padding-top: 0.75rem !important; }
 
 .pr-3 {
-  padding-right: 0.75rem !important;
-}
+  padding-right: 0.75rem !important; }
 
 .pb-3 {
-  padding-bottom: 0.75rem !important;
-}
+  padding-bottom: 0.75rem !important; }
 
 .pl-3 {
-  padding-left: 0.75rem !important;
-}
+  padding-left: 0.75rem !important; }
 
 .px-3 {
   padding-left: 0.75rem !important;
-  padding-right: 0.75rem !important;
-}
+  padding-right: 0.75rem !important; }
 
 .py-3 {
   padding-top: 0.75rem !important;
-  padding-bottom: 0.75rem !important;
-}
+  padding-bottom: 0.75rem !important; }
 
 .p-4 {
-  padding: 1rem !important;
-}
+  padding: 1rem !important; }
 
 .pt-4 {
-  padding-top: 1rem !important;
-}
+  padding-top: 1rem !important; }
 
 .pr-4 {
-  padding-right: 1rem !important;
-}
+  padding-right: 1rem !important; }
 
 .pb-4 {
-  padding-bottom: 1rem !important;
-}
+  padding-bottom: 1rem !important; }
 
 .pl-4 {
-  padding-left: 1rem !important;
-}
+  padding-left: 1rem !important; }
 
 .px-4 {
   padding-left: 1rem !important;
-  padding-right: 1rem !important;
-}
+  padding-right: 1rem !important; }
 
 .py-4 {
   padding-top: 1rem !important;
-  padding-bottom: 1rem !important;
-}
+  padding-bottom: 1rem !important; }
 
 .p-5 {
-  padding: 1.5rem !important;
-}
+  padding: 1.5rem !important; }
 
 .pt-5 {
-  padding-top: 1.5rem !important;
-}
+  padding-top: 1.5rem !important; }
 
 .pr-5 {
-  padding-right: 1.5rem !important;
-}
+  padding-right: 1.5rem !important; }
 
 .pb-5 {
-  padding-bottom: 1.5rem !important;
-}
+  padding-bottom: 1.5rem !important; }
 
 .pl-5 {
-  padding-left: 1.5rem !important;
-}
+  padding-left: 1.5rem !important; }
 
 .px-5 {
   padding-left: 1.5rem !important;
-  padding-right: 1.5rem !important;
-}
+  padding-right: 1.5rem !important; }
 
 .py-5 {
   padding-top: 1.5rem !important;
-  padding-bottom: 1.5rem !important;
-}
+  padding-bottom: 1.5rem !important; }
 
 .p-6 {
-  padding: 3rem !important;
-}
+  padding: 3rem !important; }
 
 .pt-6 {
-  padding-top: 3rem !important;
-}
+  padding-top: 3rem !important; }
 
 .pr-6 {
-  padding-right: 3rem !important;
-}
+  padding-right: 3rem !important; }
 
 .pb-6 {
-  padding-bottom: 3rem !important;
-}
+  padding-bottom: 3rem !important; }
 
 .pl-6 {
-  padding-left: 3rem !important;
-}
+  padding-left: 3rem !important; }
 
 .px-6 {
   padding-left: 3rem !important;
-  padding-right: 3rem !important;
-}
+  padding-right: 3rem !important; }
 
 .py-6 {
   padding-top: 3rem !important;
-  padding-bottom: 3rem !important;
-}
+  padding-bottom: 3rem !important; }
 
 .p-auto {
-  padding: auto !important;
-}
+  padding: auto !important; }
 
 .pt-auto {
-  padding-top: auto !important;
-}
+  padding-top: auto !important; }
 
 .pr-auto {
-  padding-right: auto !important;
-}
+  padding-right: auto !important; }
 
 .pb-auto {
-  padding-bottom: auto !important;
-}
+  padding-bottom: auto !important; }
 
 .pl-auto {
-  padding-left: auto !important;
-}
+  padding-left: auto !important; }
 
 .px-auto {
   padding-left: auto !important;
-  padding-right: auto !important;
-}
+  padding-right: auto !important; }
 
 .py-auto {
   padding-top: auto !important;
-  padding-bottom: auto !important;
-}
+  padding-bottom: auto !important; }
 
 @media screen and (min-width: 1204px) {
   .navbar-menu .navbar-start:has(~ .navbar-search-wrapper #query:focus) {
-    display: none;
-  }
+    display: none; }
+
   #query {
-    transition: width 0.2s ease-out;
-  }
-  #query:focus {
-    width: 992px;
-  }
-}
+    transition: width 0.2s ease-out; }
+    #query:focus {
+      width: 992px; } }
 @media screen and (max-width: 1203px) {
   .navbar-search-wrapper {
-    top: 12%;
-  }
+    top: 12%; }
+
   .navbar-search-autocomplete {
     top: 42px;
-    left: 10px;
-  }
-}
+    left: 10px; } }
 @media screen and (max-width: 768px) {
   body {
-    overflow-x: hidden;
-  }
+    overflow-x: hidden; }
+
   .section {
-    padding: 1rem 0.75rem;
-  }
+    padding: 1rem 0.75rem; }
+
   .navbar-item span {
     display: block;
     overflow: hidden;
-    padding: 0 5px 0 0;
-  }
+    padding: 0 5px 0 0; }
+
   #query {
-    width: 100%;
-  }
+    width: 100%; }
+
   .navbar-item .field .control:first-child {
-    width: 90%;
-  }
+    width: 90%; }
+
   .navbar-item input {
-    width: 100%;
-  }
+    width: 100%; }
+
   .footer {
     height: auto;
     padding: 1rem;
-    background-color: #f2f2f2;
-  }
+    background-color: #f2f2f2; }
+
   .footer .level {
-    height: auto;
-  }
+    height: auto; }
+
   .raku.page-content {
-    padding: 1rem 0.75rem;
-  }
+    padding: 1rem 0.75rem; }
+
   .tabcontent table td:nth-child(3) {
-    word-break: break-word;
-  }
+    word-break: break-word; }
+
   a.raku-anchor,
-.raku-h1 a.raku-anchor, .raku-h2 a.raku-anchor, .raku-h3 a.raku-anchor, .raku-h4 a.raku-anchor, .raku-h5 a.raku-anchor, .raku-h6 a.raku-anchor {
-    visibility: visible;
-  }
+  .raku-h1 a.raku-anchor, .raku-h2 a.raku-anchor, .raku-h3 a.raku-anchor, .raku-h4 a.raku-anchor, .raku-h5 a.raku-anchor, .raku-h6 a.raku-anchor {
+    visibility: visible; }
+
   .navbar-search-autocomplete {
-    width: calc(100% - 40px);
-  }
+    width: calc(100% - 40px); }
+
   .error-icon {
     position: relative;
-    right: 0;
-  }
-  .error-icon img {
-    display: block;
-    margin: 0 auto;
-  }
+    right: 0; }
+    .error-icon img {
+      display: block;
+      margin: 0 auto; }
+
   .error-icon, error-content {
-    display: block;
-  }
+    display: block; }
+
   .error-title,
-.error-content .subtitle {
-    text-align: center;
-  }
   .error-content .subtitle {
-    max-width: unset;
-  }
+    text-align: center; }
+
+  .error-content .subtitle {
+    max-width: unset; }
+
   .error-content .level {
-    margin: 5rem auto;
-  }
+    margin: 5rem auto; }
+
   .navbar.is-fixed-top .navbar-menu, .navbar.is-fixed-top-touch .navbar-menu {
-    max-height: calc(100vh - 250px);
-  }
+    max-height: calc(100vh - 250px); }
+
   .navbar-search-autocomplete {
     display: block;
-    position: absolute;
-  }
-}
+    position: absolute; } }
 @media only screen and (min-width: 769px) and (max-width: 1204px) {
   #query {
-    width: 500px;
-  }
-}
+    width: 500px; } }
 /* Smartphones (portrait) */
 @media screen and (max-width: 479px) {
   .navbar-search-autocomplete {
     left: 0;
-    width: 100%;
-  }
+    width: 100%; }
+
   .navbar.is-fixed-top .navbar-menu, .navbar.is-fixed-top-touch .navbar-menu {
-    max-height: calc(100vh - 50px);
-  }
+    max-height: calc(100vh - 50px); }
+
   .raku.page-header .page-edit {
-    position: relative;
-  }
+    position: relative; }
+
   .page-generated {
-    padding: 0.75rem;
-  }
+    padding: 0.75rem; }
+
   .footer {
-    padding: 0.75rem 0.5rem;
-  }
-}
+    padding: 0.75rem 0.5rem; } }
+
+/*# sourceMappingURL=main.css.map */

--- a/Website/plugins/ogdenwebb/css/main.css
+++ b/Website/plugins/ogdenwebb/css/main.css
@@ -6441,5 +6441,3 @@ a.has-text-danger-dark:hover, a.has-text-danger-dark:focus {
 
   .footer {
     padding: 0.75rem 0.5rem; } }
-
-/*# sourceMappingURL=main.css.map */

--- a/Website/plugins/ogdenwebb/css/themes/dark.css
+++ b/Website/plugins/ogdenwebb/css/themes/dark.css
@@ -2,493 +2,381 @@ button.button {
   color: #f5f5f5 !important;
   border: 1px solid #3A3D4E !important;
   background-color: #212426 !important;
-  transition: background-color 500ms linear;
-}
+  transition: background-color 500ms linear; }
 
 button.button:hover {
-  background-color: #030303;
-}
+  background-color: #030303; }
 
 div#footer-generated .dropdown-content, div#footer-license .dropdown-content {
   background-color: #212426;
-  border: 1px solid #3A3D4E;
-}
-div#footer-generated .dropdown-content .dropdown-item, div#footer-license .dropdown-content .dropdown-item {
-  color: #f5f5f5 !important;
-}
+  border: 1px solid #3A3D4E; }
+  div#footer-generated .dropdown-content .dropdown-item, div#footer-license .dropdown-content .dropdown-item {
+    color: #f5f5f5 !important; }
 
 a.button strong {
-  color: #282c2e;
-}
+  color: #282c2e; }
 
 a.button.is-primary .icon {
-  color: #282c2e;
-}
+  color: #282c2e; }
 
 /* Collection */
 .raku .container .columns.listing .listf-container {
   border: 1px solid #3A3D4E;
   border-bottom: 5px solid #45485d;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-}
-.raku .container .columns.listing .listf-container .listf-caption {
-  background: #212426;
-  border-bottom: 1px solid #3A3D4E;
-  color: #83858D;
-}
-.raku .container .columns.listing .listf-container .listf-desc:not(:last-of-type) {
-  border-bottom: 1px solid #3A3D4E;
-}
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
+  .raku .container .columns.listing .listf-container .listf-caption {
+    background: #212426;
+    border-bottom: 1px solid #3A3D4E;
+    color: #83858D; }
+  .raku .container .columns.listing .listf-container .listf-desc:not(:last-of-type) {
+    border-bottom: 1px solid #3A3D4E; }
 
 html {
-  background: #1B1D1E;
-}
+  background: #1B1D1E; }
 
 body {
   background: #1B1D1E;
-  color: #f5f5f5;
-}
+  color: #f5f5f5; }
 
 .navbar-logo-tm {
-  color: #e8e8e8;
-}
+  color: #e8e8e8; }
 
 /* Site header */
 .navbar {
   background: #212426;
-  border-bottom: 1px solid #45485d;
-}
+  border-bottom: 1px solid #45485d; }
 
 .navbar a {
-  color: #8DB2EB;
-}
-.navbar a:hover {
-  color: #8DB2EB;
-  text-decoration: none;
-}
-.navbar a:visited {
-  color: #8DB2EB;
-}
+  color: #8DB2EB; }
+  .navbar a:hover {
+    color: #8DB2EB;
+    text-decoration: none; }
+  .navbar a:visited {
+    color: #8DB2EB; }
 
 a.navbar-item:hover {
-  background: #2d3134;
-}
+  background: #2d3134; }
 
 .navbar-item.has-dropdown:focus .navbar-link, .navbar-item.has-dropdown:hover .navbar-link, .navbar-item.has-dropdown.is-active .navbar-link {
-  background-color: #2d3134;
-}
+  background-color: #2d3134; }
 
 .navbar-dropdown {
   background-color: #212426;
-  border-top: 2px solid #3A3D4E;
-}
+  border-top: 2px solid #3A3D4E; }
 
 .navbar-link:not(.is-arrowless)::after {
-  border-color: #8DB2EB;
-}
+  border-color: #8DB2EB; }
 
 .navbar-divider {
-  background-color: #1B1D1E;
-}
+  background-color: #1B1D1E; }
 
 .navbar-menu {
-  background-color: #212426;
-}
+  background-color: #212426; }
 
 .navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover,
 a.navbar-item:focus-within, a.navbar-item.is-active, .navbar-link:focus, .navbar-link:focus-within, .navbar-link:hover, .navbar-link.is-active {
   background-color: #3A3D4E;
-  color: #f5f5f5;
-}
+  color: #f5f5f5; }
 
 #query::placeholder {
-  color: #83858D;
-}
+  color: #83858D; }
 
 .navbar-search-autocomplete {
   color: gainsboro;
   background-color: #282c2e;
   box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07);
-  border: 1px solid #3A3D4E;
-}
-.navbar-search-autocomplete li {
-  padding: 0 5px;
-}
-.navbar-search-autocomplete li.ui-autocomplete-category {
-  color: #f00048;
-  font-weight: 600;
-}
-.navbar-search-autocomplete li:hover, .navbar-search-autocomplete li[aria-selected=true] {
-  cursor: pointer;
-  background-color: #1c1f21;
-}
-.navbar-search-autocomplete li mark {
-  background: transparent;
-  color: rgb(255, 122, 122);
-  font-weight: bold;
-}
-.navbar-search-autocomplete .autocomplete-result-category {
-  color: #EED891;
-}
-.navbar-search-autocomplete .autocomplete-result-category:hover {
-  background-color: unset;
-}
+  border: 1px solid #3A3D4E; }
+  .navbar-search-autocomplete li {
+    padding: 0 5px; }
+    .navbar-search-autocomplete li.ui-autocomplete-category {
+      color: #f00048;
+      font-weight: 600; }
+    .navbar-search-autocomplete li:hover, .navbar-search-autocomplete li[aria-selected="true"] {
+      cursor: pointer;
+      background-color: #1c1f21; }
+    .navbar-search-autocomplete li mark {
+      background: transparent;
+      color: #ff7a7a;
+      font-weight: bold; }
+  .navbar-search-autocomplete .autocomplete-result-category {
+    color: #EED891; }
+    .navbar-search-autocomplete .autocomplete-result-category:hover {
+      background-color: unset; }
 
 a {
-  color: #8DB2EB;
-}
-a:hover {
-  color: #8DB2EB;
-  text-decoration: underline;
-}
-a:visited {
-  color: #8378E8;
-}
+  color: #8DB2EB; }
+  a:hover {
+    color: #8DB2EB;
+    text-decoration: underline; }
+  a:visited {
+    color: #8378E8; }
 
 .button.is-primary {
-  background-color: #8DB2EB !important;
-}
-.button.is-primary:hover {
-  background-color: #4c86e0 !important;
-  text-decoration: none;
-}
+  background-color: #8DB2EB !important; }
+  .button.is-primary:hover {
+    background-color: #4c86e0 !important;
+    text-decoration: none; }
 
 .label {
-  color: #d8d8d8;
-}
+  color: #d8d8d8; }
 
 .input, .textarea, .select select {
   background-color: #2d3134;
   border-color: #3A3D4E;
-  color: #f5f5f5;
-}
+  color: #f5f5f5; }
 
 .input:hover, .textarea:hover, .select select:hover, .is-hovered.input, .is-hovered.textarea, .select select.is-hovered {
-  border-color: #83858D;
-}
+  border-color: #83858D; }
 
 .input:focus, .textarea:focus, .select select:focus, .is-focused.input, .is-focused.textarea, .select select.is-focused, .input:active, .textarea:active, .select select:active, .is-active.input, .is-active.textarea, .select select.is-active {
-  border-color: #8DB2EB;
-}
+  border-color: #8DB2EB; }
 
 .select:not(.is-multiple):not(.is-loading)::after {
-  border-color: #8DB2EB;
-}
+  border-color: #8DB2EB; }
 
 .select:not(.is-multiple):not(.is-loading):hover::after {
-  border-color: #8DB2EB;
-}
+  border-color: #8DB2EB; }
 
 /* Site footer */
 .footer {
   background: #212426;
   border-top: 1px solid #45485d;
-  z-index: 50;
-}
+  z-index: 50; }
 
 .has-text-primary {
-  color: #8DB2EB !important;
-}
+  color: #8DB2EB !important; }
 
 .has-text-dark {
-  color: #3A3D4E !important;
-}
+  color: #3A3D4E !important; }
 
 .has-text-danger {
-  color: #f00048 !important;
-}
+  color: #f00048 !important; }
 
 .has-text-danger:hover {
-  color: #f00048 !important;
-}
+  color: #f00048 !important; }
 
 a.has-text-red, a.has-text-red:hover {
-  color: #f00048;
-}
+  color: #f00048; }
 
 .button.is-link {
-  background-color: #8DB2EB;
-}
+  background-color: #8DB2EB; }
 
 .button.is-link:hover {
-  background-color: #4c86e0;
-}
+  background-color: #4c86e0; }
 
 strong {
-  color: #e8e8e8;
-}
+  color: #e8e8e8; }
 
 .raku.links-block .head {
-  color: #cccccc;
-}
+  color: #cccccc; }
 .raku.links-block a {
-  color: #8DB2EB;
-}
-.raku.links-block a:hover {
-  color: #4c86e0;
-}
+  color: #8DB2EB; }
+  .raku.links-block a:hover {
+    color: #4c86e0; }
 
 /* Hopepage title */
 .hero-body {
   background: linear-gradient(180deg, #030303 0.2%, #170F44 1%, #35229E 82.29%, #271974 100%);
-  mix-blend-mode: normal;
-}
+  mix-blend-mode: normal; }
 
 /* Raku page template */
 .raku.page-title {
-  color: #EED891;
-}
+  color: #EED891; }
 
 .raku.page-header .page-edit {
-  color: #83858D;
-}
-.raku.page-header .page-edit .page-edit-button {
-  background: #282c2e;
-  color: gainsboro;
-  border-color: #3A3D4E;
-}
-.raku.page-header .page-edit .page-edit-button:hover {
-  background: #212426;
-}
+  color: #83858D; }
+  .raku.page-header .page-edit .page-edit-button {
+    background: #282c2e;
+    color: gainsboro;
+    border-color: #3A3D4E; }
+    .raku.page-header .page-edit .page-edit-button:hover {
+      background: #212426; }
 
 /* Raku search page */
 .raku-search .search-category {
   background: #282c2e;
   border: 1px solid #3A3D4E;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  color: #f5f5f5;
-}
+  color: #f5f5f5; }
 .raku-search .search-match {
-  background: #1C6301;
-}
+  background: #1C6301; }
 .raku-search .search-category-title {
   color: #EED891;
-  border-bottom: 1px solid #3A3D4E;
-}
+  border-bottom: 1px solid #3A3D4E; }
 
 /* Categories */
 .raku-category.category-block {
   border: 1px solid #3A3D4E;
   border-bottom: 5px solid #45485d;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-}
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
 
 .raku-category .category-header {
   background: #212426;
   border-bottom: 1px solid #3A3D4E;
-  color: #83858D;
-}
+  color: #83858D; }
 .raku-category .category-item:not(:last-child) {
-  border-bottom: 1px solid #3A3D4E;
-}
+  border-bottom: 1px solid #3A3D4E; }
 
 /* Programs page template */
 .raku-programs .programs-item-title {
-  border-bottom: 1px solid #3A3D4E;
-}
+  border-bottom: 1px solid #3A3D4E; }
 
 /* Raku headings */
 .raku-h1 {
   background: #212426;
   border: 1px solid #3A3D4E;
-  border-bottom: 3px solid #EED891;
-}
+  border-bottom: 3px solid #EED891; }
 
 .raku-h2 {
-  border-bottom: 3px solid #EED891;
-}
+  border-bottom: 3px solid #EED891; }
 
 .raku-h1, .raku-h2, .raku-h3, .raku-h4, .raku-h5, .raku-h6 {
-  colors: #EED891;
-}
-.raku-h1 a, .raku-h2 a, .raku-h3 a, .raku-h4 a, .raku-h5 a, .raku-h6 a {
-  color: #EED891;
-}
-.raku-h1 code, .raku-h2 code, .raku-h3 code, .raku-h4 code, .raku-h5 code, .raku-h6 code {
-  color: unset;
-  background: unset;
-  font-weight: 600;
-}
+  colors: #EED891; }
+  .raku-h1 a, .raku-h2 a, .raku-h3 a, .raku-h4 a, .raku-h5 a, .raku-h6 a {
+    color: #EED891; }
+  .raku-h1 code, .raku-h2 code, .raku-h3 code, .raku-h4 code, .raku-h5 code, .raku-h6 code {
+    color: unset;
+    background: unset;
+    font-weight: 600; }
 
 .raku-h1 a:hover, .raku-h2 a:hover, .raku-h3 a:hover, .raku-h4 a:hover, .raku-h5 a:hover, .raku-h6 a:hover {
   color: #8DB2EB;
-  text-decoration: none;
-}
+  text-decoration: none; }
 
 .raku-anchor {
-  color: #3A3D4E;
-}
+  color: #3A3D4E; }
 
 a.raku-anchor:hover {
-  color: #8DB2EB;
-}
+  color: #8DB2EB; }
 
 a.raku-anchor,
 .raku-h1 a.raku-anchor, .raku-h2 a.raku-anchor, .raku-h3 a.raku-anchor, .raku-h4 a.raku-anchor, .raku-h5 a.raku-anchor, .raku-h6 a.raku-anchor {
-  color: gainsboro;
-}
-a.raku-anchor:hover,
-.raku-h1 a.raku-anchor:hover, .raku-h2 a.raku-anchor:hover, .raku-h3 a.raku-anchor:hover, .raku-h4 a.raku-anchor:hover, .raku-h5 a.raku-anchor:hover, .raku-h6 a.raku-anchor:hover {
-  color: #8DB2EB;
-}
+  color: gainsboro; }
+  a.raku-anchor:hover,
+  .raku-h1 a.raku-anchor:hover, .raku-h2 a.raku-anchor:hover, .raku-h3 a.raku-anchor:hover, .raku-h4 a.raku-anchor:hover, .raku-h5 a.raku-anchor:hover, .raku-h6 a.raku-anchor:hover {
+    color: #8DB2EB; }
 
 .raku-h1:hover a.raku-anchor, .raku-h2:hover a.raku-anchor, .raku-h3:hover a.raku-anchor, .raku-h4:hover a.raku-anchor, .raku-h5:hover a.raku-anchor, .raku-h6:hover a.raku-anchor {
-  visibility: visible;
-}
+  visibility: visible; }
 
 /* Version note */
 .raku.version-note {
   background: #f2f2f2;
   border: 1px solid #3A3D4E;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-}
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
 
 .version-note-header {
-  color: #EED891;
-}
+  color: #EED891; }
 
 .table {
   background-color: #1B1D1E;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  color: #e8e8e8;
-}
+  color: #e8e8e8; }
 
 .table thead td, .table thead th {
-  color: #e8e8e8;
-}
+  color: #e8e8e8; }
 
 .table td, .table th {
-  border: 1px solid #3A3D4E;
-}
+  border: 1px solid #3A3D4E; }
 
 .card {
   color: #f5f5f5;
-  background-color: #1B1D1E;
-}
+  background-color: #1B1D1E; }
 
 .raku-about .card {
   border: 1px solid #e5e5e5;
   border-bottom: 3px solid #e5e5e5;
-  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07);
-}
+  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07); }
 
 .raku.tabs {
   background: #282c2e;
   border: 1px solid #3A3D4E;
   border-bottom: unset;
-  color: #f5f5f5;
-}
-.raku.tabs ul {
-  border-color: #3A3D4E;
-}
-.raku.tabs a {
-  color: #f5f5f5;
-}
-.raku.tabs.is-boxed a:hover {
-  background-color: #3A3D4E;
-  color: #e8e8e8;
-}
-.raku.tabs.is-boxed a {
-  border-right: 1px solid #3A3D4E;
-}
-.raku.tabs.is-boxed li.is-active a {
-  background: #1B1D1E;
-  color: gainsboro;
-  border-top: 1px solid transparent;
-  border-right: 1px solid #3A3D4E;
-  border-bottom: 1px solid #3A3D4E;
-}
+  color: #f5f5f5; }
+  .raku.tabs ul {
+    border-color: #3A3D4E; }
+  .raku.tabs a {
+    color: #f5f5f5; }
+  .raku.tabs.is-boxed a:hover {
+    background-color: #3A3D4E;
+    color: #e8e8e8; }
+  .raku.tabs.is-boxed a {
+    border-right: 1px solid #3A3D4E; }
+  .raku.tabs.is-boxed li.is-active a {
+    background: #1B1D1E;
+    color: gainsboro;
+    border-top: 1px solid transparent;
+    border-right: 1px solid #3A3D4E;
+    border-bottom: 1px solid #3A3D4E; }
 
 p > code {
   background-color: #212426;
-  border: 1px solid #2d3134;
-}
+  border: 1px solid #2d3134; }
 
 .raku-sidebar {
   background-color: #212426;
   border-right: 1px solid #3A3D4E;
-  border-bottom: 3px solid #3A3D4E;
-}
-.raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
-  color: gainsboro;
-}
-.raku-sidebar .menu-list ::marker {
-  color: #EED891;
-}
-.raku-sidebar .menu-list li ul {
-  border-left: 1px solid #3A3D4E;
-}
-.raku-sidebar .menu-list a {
-  color: #f5f5f5;
-}
-.raku-sidebar .menu-list a:hover {
-  background: #3A3D4E;
-  text-decoration: none;
-}
-.raku-sidebar .menu-list a.is-active {
-  color: #212426;
-}
-.raku-sidebar .menu-list a.is-active:hover {
-  background: #8DB2EB;
-}
+  border-bottom: 3px solid #3A3D4E; }
+  .raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
+    color: gainsboro; }
+  .raku-sidebar .menu-list ::marker {
+    color: #EED891; }
+  .raku-sidebar .menu-list li ul {
+    border-left: 1px solid #3A3D4E; }
+  .raku-sidebar .menu-list a {
+    color: #f5f5f5; }
+    .raku-sidebar .menu-list a:hover {
+      background: #3A3D4E;
+      text-decoration: none; }
+    .raku-sidebar .menu-list a.is-active {
+      color: #212426; }
+      .raku-sidebar .menu-list a.is-active:hover {
+        background: #8DB2EB; }
 
 .raku-sidebar.category-sidebar li a.is-active {
   background-color: #2f323f;
-  border-left: 3px solid #8DB2EB;
-}
+  border-left: 3px solid #8DB2EB; }
 .raku-sidebar.category-sidebar a.is-active {
-  color: #f5f5f5;
-}
-.raku-sidebar.category-sidebar a.is-active:hover {
-  background: #2f323f;
-}
+  color: #f5f5f5; }
+  .raku-sidebar.category-sidebar a.is-active:hover {
+    background: #2f323f; }
 
 a > code {
-  color: #8DB2EB;
-}
+  color: #8DB2EB; }
 
 code {
   background-color: #212426;
-  color: #EED891;
-}
+  color: #EED891; }
 
 .raku-code {
   border-bottom: 3px solid #3A3D4E;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  border: 1px solid #3A3D4E;
-}
-.raku-code .code-button {
-  background: #8DB2EB;
-  color: #1B1D1E;
-  border: #3A3D4E;
-}
-.raku-code .code-button:hover {
-  background-color: #4c86e0;
-}
-.raku-code .code-name {
-  color: #EED891;
-}
-.raku-code .code-output {
-  background: #282c2e;
-  border-top: 1px solid #3A3D4E;
-}
-.raku-code .code-output-title {
-  border-bottom: 1px solid #3A3D4E;
-  color: #EED891;
-}
-.raku-code pre {
-  background-color: #212426;
-  color: #f5f5f5;
-}
+  border: 1px solid #3A3D4E; }
+  .raku-code .code-button {
+    background: #8DB2EB;
+    color: #1B1D1E;
+    border: #3A3D4E; }
+    .raku-code .code-button:hover {
+      background-color: #4c86e0; }
+  .raku-code .code-name {
+    color: #EED891; }
+  .raku-code .code-output {
+    background: #282c2e;
+    border-top: 1px solid #3A3D4E; }
+  .raku-code .code-output-title {
+    border-bottom: 1px solid #3A3D4E;
+    color: #EED891; }
+  .raku-code pre {
+    background-color: #212426;
+    color: #f5f5f5; }
 
 .hero.error-page .hero-body {
-  background: #1B1D1E;
-}
+  background: #1B1D1E; }
 
 .error-icon .icon {
-  color: #f5f5f5;
-}
+  color: #f5f5f5; }
 
 .hero .error-title {
-  color: #f00048;
-}
+  color: #f00048; }
+
+/*# sourceMappingURL=dark.css.map */

--- a/Website/plugins/ogdenwebb/css/themes/dark.css
+++ b/Website/plugins/ogdenwebb/css/themes/dark.css
@@ -378,5 +378,3 @@ code {
 
 .hero .error-title {
   color: #f00048; }
-
-/*# sourceMappingURL=dark.css.map */

--- a/Website/plugins/ogdenwebb/css/themes/light.css
+++ b/Website/plugins/ogdenwebb/css/themes/light.css
@@ -363,5 +363,3 @@ code {
 
 .hero .error-title {
   color: #A30031; }
-
-/*# sourceMappingURL=light.css.map */

--- a/Website/plugins/ogdenwebb/css/themes/light.css
+++ b/Website/plugins/ogdenwebb/css/themes/light.css
@@ -1,475 +1,367 @@
 a.button strong {
-  color: #f5f5f5;
-}
+  color: #f5f5f5; }
 
 a.button.is-primary .icon {
-  color: #f5f5f5;
-}
+  color: #f5f5f5; }
 
 /* Collection */
 .raku .container .columns.listing .listf-container {
   border: 1px solid #cccccc;
   border-bottom: 5px solid #d9d9d9;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-}
-.raku .container .columns.listing .listf-container .listf-caption {
-  background: #f2f2f2;
-  border-bottom: 1px solid #cccccc;
-  color: #83858D;
-}
-.raku .container .columns.listing .listf-container .listf-desc:not(:last-of-type) {
-  border-bottom: 1px solid #cccccc;
-}
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
+  .raku .container .columns.listing .listf-container .listf-caption {
+    background: #f2f2f2;
+    border-bottom: 1px solid #cccccc;
+    color: #83858D; }
+  .raku .container .columns.listing .listf-container .listf-desc:not(:last-of-type) {
+    border-bottom: 1px solid #cccccc; }
 
 html {
-  background: #fafafa;
-}
+  background: #fafafa; }
 
 body {
   background: #fafafa;
-  color: #030303;
-}
+  color: #030303; }
 
 .navbar-logo-tm {
-  color: black;
-}
+  color: black; }
 
 /* Site header */
 .navbar {
   background: #f2f2f2;
-  border-bottom: 1px solid #d9d9d9;
-}
+  border-bottom: 1px solid #d9d9d9; }
 
 .navbar a {
-  color: #004FB3;
-}
-.navbar a:hover {
-  color: #004FB3;
-  text-decoration: none;
-}
-.navbar a:visited {
-  color: #004FB3;
-}
+  color: #004FB3; }
+  .navbar a:hover {
+    color: #004FB3;
+    text-decoration: none; }
+  .navbar a:visited {
+    color: #004FB3; }
 
 a.navbar-item:hover {
-  background: #e5e5e5;
-}
+  background: #e5e5e5; }
 
 .navbar-item.has-dropdown:focus .navbar-link, .navbar-item.has-dropdown:hover .navbar-link, .navbar-item.has-dropdown.is-active .navbar-link {
-  background-color: #e5e5e5;
-}
+  background-color: #e5e5e5; }
 
 .navbar-dropdown {
   background-color: #f2f2f2;
-  border-top: 2px solid #cccccc;
-}
+  border-top: 2px solid #cccccc; }
 
 .navbar-link:not(.is-arrowless)::after {
-  border-color: #004FB3;
-}
+  border-color: #004FB3; }
 
 .navbar-divider {
-  background-color: #fafafa;
-}
+  background-color: #fafafa; }
 
 .navbar-menu {
-  background-color: #f2f2f2;
-}
+  background-color: #f2f2f2; }
 
 .navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover,
 a.navbar-item:focus-within, a.navbar-item.is-active, .navbar-link:focus, .navbar-link:focus-within, .navbar-link:hover, .navbar-link.is-active {
   background-color: #e5e5e5;
-  color: #030303;
-}
+  color: #030303; }
 
 #query::placeholder {
-  color: #83858D;
-}
+  color: #83858D; }
 
 .navbar-search-autocomplete {
   color: black;
   background-color: #f5f5f5;
   box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07);
-  border: 1px solid #cccccc;
-}
-.navbar-search-autocomplete li {
-  padding: 0 5px;
-}
-.navbar-search-autocomplete li.ui-autocomplete-category {
-  color: #A30031;
-  font-weight: 600;
-}
-.navbar-search-autocomplete li:hover, .navbar-search-autocomplete li[aria-selected=true] {
-  cursor: pointer;
-  background-color: #e8e8e8;
-}
-.navbar-search-autocomplete li mark {
-  background: transparent;
-  color: rgb(255, 122, 122);
-  font-weight: bold;
-}
-.navbar-search-autocomplete .autocomplete-result-category {
-  color: #A30031;
-}
-.navbar-search-autocomplete .autocomplete-result-category:hover {
-  background-color: unset;
-}
+  border: 1px solid #cccccc; }
+  .navbar-search-autocomplete li {
+    padding: 0 5px; }
+    .navbar-search-autocomplete li.ui-autocomplete-category {
+      color: #A30031;
+      font-weight: 600; }
+    .navbar-search-autocomplete li:hover, .navbar-search-autocomplete li[aria-selected="true"] {
+      cursor: pointer;
+      background-color: #e8e8e8; }
+    .navbar-search-autocomplete li mark {
+      background: transparent;
+      color: #ff7a7a;
+      font-weight: bold; }
+  .navbar-search-autocomplete .autocomplete-result-category {
+    color: #A30031; }
+    .navbar-search-autocomplete .autocomplete-result-category:hover {
+      background-color: unset; }
 
 a {
-  color: #004FB3;
-}
-a:hover {
-  color: #004FB3;
-  text-decoration: underline;
-}
-a:visited {
-  color: #5503B3;
-}
+  color: #004FB3; }
+  a:hover {
+    color: #004FB3;
+    text-decoration: underline; }
+  a:visited {
+    color: #5503B3; }
 
 .button.is-primary {
-  background-color: #004FB3 !important;
-}
-.button.is-primary:hover {
-  background-color: #003880 !important;
-  text-decoration: none;
-}
+  background-color: #004FB3 !important; }
+  .button.is-primary:hover {
+    background-color: #003880 !important;
+    text-decoration: none; }
 
 .label {
-  color: #3A3D4E;
-}
+  color: #3A3D4E; }
 
 .input, .textarea, .select select {
   background-color: #fafafa;
   border-color: #cccccc;
-  color: #030303;
-}
+  color: #030303; }
 
 .input:hover, .textarea:hover, .select select:hover, .is-hovered.input, .is-hovered.textarea, .select select.is-hovered {
-  border-color: #d8d8d8;
-}
+  border-color: #d8d8d8; }
 
 .input:focus, .textarea:focus, .select select:focus, .is-focused.input, .is-focused.textarea, .select select.is-focused, .input:active, .textarea:active, .select select:active, .is-active.input, .is-active.textarea, .select select.is-active {
-  border-color: #004FB3;
-}
+  border-color: #004FB3; }
 
 .select:not(.is-multiple):not(.is-loading)::after {
-  border-color: #004FB3;
-}
+  border-color: #004FB3; }
 
 .select:not(.is-multiple):not(.is-loading):hover::after {
-  border-color: #004FB3;
-}
+  border-color: #004FB3; }
 
 /* Site footer */
 .footer {
   background: #f2f2f2;
   border-top: 1px solid #d9d9d9;
-  z-index: 50;
-}
+  z-index: 50; }
 
 .has-text-primary {
-  color: #004FB3 !important;
-}
+  color: #004FB3 !important; }
 
 .has-text-dark {
-  color: #3A3D4E !important;
-}
+  color: #3A3D4E !important; }
 
 .has-text-danger {
-  color: #A30031 !important;
-}
+  color: #A30031 !important; }
 
 .has-text-danger:hover {
-  color: #A30031 !important;
-}
+  color: #A30031 !important; }
 
 a.has-text-red, a.has-text-red:hover {
-  color: #A30031;
-}
+  color: #A30031; }
 
 .button.is-link {
-  background-color: #004FB3;
-}
+  background-color: #004FB3; }
 
 .button.is-link:hover {
-  background-color: #002d67;
-}
+  background-color: #002d67; }
 
 strong {
-  color: black;
-}
+  color: black; }
 
 .raku.links-block .head {
-  color: #83858D;
-}
+  color: #83858D; }
 .raku.links-block a {
-  color: #004FB3;
-}
-.raku.links-block a:hover {
-  color: #003880;
-}
+  color: #004FB3; }
+  .raku.links-block a:hover {
+    color: #003880; }
 
 /* Hopepage title */
 .hero-body {
   background: linear-gradient(180deg, #051A33 0.2%, #3F103A 1%, #9F0046 82.29%, #B3004F 100%);
-  mix-blend-mode: normal;
-}
+  mix-blend-mode: normal; }
 
 /* Raku page template */
 .raku.page-title {
-  color: #A30031;
-}
+  color: #A30031; }
 
 .raku.page-header .page-edit {
-  color: #83858D;
-}
-.raku.page-header .page-edit .page-edit-button {
-  background: #f5f5f5;
-  color: black;
-  border-color: #cccccc;
-}
-.raku.page-header .page-edit .page-edit-button:hover {
-  background: #f2f2f2;
-}
+  color: #83858D; }
+  .raku.page-header .page-edit .page-edit-button {
+    background: #f5f5f5;
+    color: black;
+    border-color: #cccccc; }
+    .raku.page-header .page-edit .page-edit-button:hover {
+      background: #f2f2f2; }
 
 /* Raku search page */
 .raku-search .search-category {
   background: #f5f5f5;
   border: 1px solid #cccccc;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  color: #030303;
-}
+  color: #030303; }
 .raku-search .search-match {
-  background: #EED891;
-}
+  background: #EED891; }
 .raku-search .search-category-title {
   color: #A30031;
-  border-bottom: 1px solid #cccccc;
-}
+  border-bottom: 1px solid #cccccc; }
 
 /* Categories */
 .raku-category.category-block {
   border: 1px solid #cccccc;
   border-bottom: 5px solid #d9d9d9;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-}
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
 
 .raku-category .category-header {
   background: #f2f2f2;
   border-bottom: 1px solid #cccccc;
-  color: #83858D;
-}
+  color: #83858D; }
 .raku-category .category-item:not(:last-child) {
-  border-bottom: 1px solid #cccccc;
-}
+  border-bottom: 1px solid #cccccc; }
 
 /* Programs page template */
 .raku-programs .programs-item-title {
-  border-bottom: 1px solid #cccccc;
-}
+  border-bottom: 1px solid #cccccc; }
 
 /* Raku headings */
 .raku-h1 {
   background: #f2f2f2;
   border: 1px solid #cccccc;
-  border-bottom: 3px solid #A30031;
-}
+  border-bottom: 3px solid #A30031; }
 
 .raku-h2 {
-  border-bottom: 3px solid #A30031;
-}
+  border-bottom: 3px solid #A30031; }
 
 .raku-h1, .raku-h2, .raku-h3, .raku-h4, .raku-h5, .raku-h6 {
-  colors: #A30031;
-}
-.raku-h1 a, .raku-h2 a, .raku-h3 a, .raku-h4 a, .raku-h5 a, .raku-h6 a {
-  color: #A30031;
-}
-.raku-h1 code, .raku-h2 code, .raku-h3 code, .raku-h4 code, .raku-h5 code, .raku-h6 code {
-  color: unset;
-  background: unset;
-  font-weight: 600;
-}
+  colors: #A30031; }
+  .raku-h1 a, .raku-h2 a, .raku-h3 a, .raku-h4 a, .raku-h5 a, .raku-h6 a {
+    color: #A30031; }
+  .raku-h1 code, .raku-h2 code, .raku-h3 code, .raku-h4 code, .raku-h5 code, .raku-h6 code {
+    color: unset;
+    background: unset;
+    font-weight: 600; }
 
 .raku-h1 a:hover, .raku-h2 a:hover, .raku-h3 a:hover, .raku-h4 a:hover, .raku-h5 a:hover, .raku-h6 a:hover {
   color: #004FB3;
-  text-decoration: none;
-}
+  text-decoration: none; }
 
 .raku-anchor {
-  color: #3A3D4E;
-}
+  color: #3A3D4E; }
 
 a.raku-anchor:hover {
-  color: #004FB3;
-}
+  color: #004FB3; }
 
 a.raku-anchor,
 .raku-h1 a.raku-anchor, .raku-h2 a.raku-anchor, .raku-h3 a.raku-anchor, .raku-h4 a.raku-anchor, .raku-h5 a.raku-anchor, .raku-h6 a.raku-anchor {
-  color: black;
-}
-a.raku-anchor:hover,
-.raku-h1 a.raku-anchor:hover, .raku-h2 a.raku-anchor:hover, .raku-h3 a.raku-anchor:hover, .raku-h4 a.raku-anchor:hover, .raku-h5 a.raku-anchor:hover, .raku-h6 a.raku-anchor:hover {
-  color: #004FB3;
-}
+  color: black; }
+  a.raku-anchor:hover,
+  .raku-h1 a.raku-anchor:hover, .raku-h2 a.raku-anchor:hover, .raku-h3 a.raku-anchor:hover, .raku-h4 a.raku-anchor:hover, .raku-h5 a.raku-anchor:hover, .raku-h6 a.raku-anchor:hover {
+    color: #004FB3; }
 
 .raku-h1:hover a.raku-anchor, .raku-h2:hover a.raku-anchor, .raku-h3:hover a.raku-anchor, .raku-h4:hover a.raku-anchor, .raku-h5:hover a.raku-anchor, .raku-h6:hover a.raku-anchor {
-  visibility: visible;
-}
+  visibility: visible; }
 
 /* Version note */
 .raku.version-note {
   background: #f2f2f2;
   border: 1px solid #cccccc;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-}
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
 
 .version-note-header {
-  color: #A30031;
-}
+  color: #A30031; }
 
 .table {
   background-color: #fafafa;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  color: black;
-}
+  color: black; }
 
 .table thead td, .table thead th {
-  color: #3A3D4E;
-}
+  color: #3A3D4E; }
 
 .table td, .table th {
-  border: 1px solid #cccccc;
-}
+  border: 1px solid #cccccc; }
 
 .card {
   color: #030303;
-  background-color: #fafafa;
-}
+  background-color: #fafafa; }
 
 .raku-about .card {
   border: 1px solid #e5e5e5;
   border-bottom: 3px solid #e5e5e5;
-  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07);
-}
+  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07); }
 
 .raku.tabs {
   background: #f5f5f5;
   border: 1px solid #cccccc;
   border-bottom: unset;
-  color: #030303;
-}
-.raku.tabs ul {
-  border-color: #cccccc;
-}
-.raku.tabs a {
-  color: #030303;
-}
-.raku.tabs.is-boxed a:hover {
-  background-color: #3A3D4E;
-  color: black;
-}
-.raku.tabs.is-boxed a {
-  border-right: 1px solid #cccccc;
-}
-.raku.tabs.is-boxed li.is-active a {
-  background: #fafafa;
-  color: black;
-  border-top: 1px solid transparent;
-  border-right: 1px solid #cccccc;
-  border-bottom: 1px solid #cccccc;
-}
+  color: #030303; }
+  .raku.tabs ul {
+    border-color: #cccccc; }
+  .raku.tabs a {
+    color: #030303; }
+  .raku.tabs.is-boxed a:hover {
+    background-color: #3A3D4E;
+    color: black; }
+  .raku.tabs.is-boxed a {
+    border-right: 1px solid #cccccc; }
+  .raku.tabs.is-boxed li.is-active a {
+    background: #fafafa;
+    color: black;
+    border-top: 1px solid transparent;
+    border-right: 1px solid #cccccc;
+    border-bottom: 1px solid #cccccc; }
 
 p > code {
   background-color: #fafafa;
-  border: 1px solid white;
-}
+  border: 1px solid white; }
 
 .raku-sidebar {
   background-color: #f2f2f2;
   border-right: 1px solid #cccccc;
-  border-bottom: 3px solid #cccccc;
-}
-.raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
-  color: black;
-}
-.raku-sidebar .menu-list ::marker {
-  color: #A30031;
-}
-.raku-sidebar .menu-list li ul {
-  border-left: 1px solid #cccccc;
-}
-.raku-sidebar .menu-list a {
-  color: #030303;
-}
-.raku-sidebar .menu-list a:hover {
-  background: #d8d8d8;
-  text-decoration: none;
-}
-.raku-sidebar .menu-list a.is-active {
-  color: #f7f7f7;
-}
-.raku-sidebar .menu-list a.is-active:hover {
-  background: #004FB3;
-}
+  border-bottom: 3px solid #cccccc; }
+  .raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
+    color: black; }
+  .raku-sidebar .menu-list ::marker {
+    color: #A30031; }
+  .raku-sidebar .menu-list li ul {
+    border-left: 1px solid #cccccc; }
+  .raku-sidebar .menu-list a {
+    color: #030303; }
+    .raku-sidebar .menu-list a:hover {
+      background: #d8d8d8;
+      text-decoration: none; }
+    .raku-sidebar .menu-list a.is-active {
+      color: #f7f7f7; }
+      .raku-sidebar .menu-list a.is-active:hover {
+        background: #004FB3; }
 
 .raku-sidebar.category-sidebar li a.is-active {
   background-color: #d8d8d8;
-  border-left: 3px solid #004FB3;
-}
+  border-left: 3px solid #004FB3; }
 .raku-sidebar.category-sidebar a.is-active {
-  color: #030303;
-}
-.raku-sidebar.category-sidebar a.is-active:hover {
-  background: #d8d8d8;
-}
+  color: #030303; }
+  .raku-sidebar.category-sidebar a.is-active:hover {
+    background: #d8d8d8; }
 
 a > code {
-  color: #004FB3;
-}
+  color: #004FB3; }
 
 code {
   background-color: #f2f2f2;
-  color: #A30031;
-}
+  color: #A30031; }
 
 .raku-code {
   border-bottom: 3px solid #cccccc;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  border: 1px solid #cccccc;
-}
-.raku-code .code-button {
-  background: #004FB3;
-  color: #fafafa;
-  border: #cccccc;
-}
-.raku-code .code-button:hover {
-  background-color: #003880;
-}
-.raku-code .code-name {
-  color: #A30031;
-}
-.raku-code .code-output {
-  background: #f5f5f5;
-  border-top: 1px solid #cccccc;
-}
-.raku-code .code-output-title {
-  border-bottom: 1px solid #cccccc;
-  color: #A30031;
-}
-.raku-code pre {
-  background-color: #fafafa;
-  color: #030303;
-}
+  border: 1px solid #cccccc; }
+  .raku-code .code-button {
+    background: #004FB3;
+    color: #fafafa;
+    border: #cccccc; }
+    .raku-code .code-button:hover {
+      background-color: #003880; }
+  .raku-code .code-name {
+    color: #A30031; }
+  .raku-code .code-output {
+    background: #f5f5f5;
+    border-top: 1px solid #cccccc; }
+  .raku-code .code-output-title {
+    border-bottom: 1px solid #cccccc;
+    color: #A30031; }
+  .raku-code pre {
+    background-color: #fafafa;
+    color: #030303; }
 
 .hero.error-page .hero-body {
-  background: #fafafa;
-}
+  background: #fafafa; }
 
 .error-icon .icon {
-  color: #030303;
-}
+  color: #030303; }
 
 .hero .error-title {
-  color: #A30031;
-}
+  color: #A30031; }
+
+/*# sourceMappingURL=light.css.map */

--- a/Website/plugins/ogdenwebb/scss/code/_highlighting.scss
+++ b/Website/plugins/ogdenwebb/scss/code/_highlighting.scss
@@ -32,4 +32,8 @@
     margin-bottom: 0.5rem;
   }
 
+  .section {
+    /* https://github.com/Raku/doc-website/issues/144 */
+    padding: 0rem;
+  }
 }


### PR DESCRIPTION
`.section` class padding currently interferes with the rendering of examples (see #144).

Explicitly set it to `0rem` within code blocks.

(This should apply to both light and dark themes.)