### PR TITLE
add browser theme switching support

### DIFF
--- a/Website/plugins/gather-css/css-collator.raku
+++ b/Website/plugins/gather-css/css-collator.raku
@@ -40,7 +40,8 @@ sub ($pp, %options) {
     }
     else { $template ~= ' "" ' } # Template is describing a subroutine that emits a string, which must be started by css
     for @adds {
-        $template ~= "\n" ~ '~ "\n" ~ ' ~ "'<link rel=\"stylesheet\" href=\"/assets/css/{ $_[1] }\"/>'";
+        my $link-title  = do given $_[1] { when /light/ { ' title="light"' }; when /dark/ { ' title="dark"' }; default { "" }};
+        $template ~= "\n" ~ '~ "\n" ~ ' ~ "'<link rel=\"stylesheet\" href=\"/assets/css/{ $_[1] }\"{ $link-title }/>'";
         @move-dest.push( ('assets/css/' ~ $_[1], $_[0], $_[1], ) )
     }
     for @links {


### PR DESCRIPTION
Refactored how themes work: before it used name matching in js, after the change `gather-css/css-collator.raku` is used to attach theme name.

Js was refactored to only touch `link` tags that have `title` property attached to them, while allowing to add more themes more dynamically.

resolves #151