### PR TITLE
disable git-reflog plugin

### DIFF
--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -2,15 +2,15 @@
     :plugins<plugins>,
     :plugin-format<html>,
     plugins-required => %(
-        :setup<raku-doc-setup git-reflog>,
+        :setup<raku-doc-setup>,
         :render<
             font-awesome ogdenwebb camelia simple-extras listfiles images deprecate-span filterlines
             tablemanager secondaries typegraph
-            search-bar link-error-test git-reflog
+            search-bar link-error-test
             gather-js-jq gather-css
         >,
         :report<link-plugin-assets-report>,
-        :transfer<secondaries gather-js-jq gather-css images search-bar git-reflog>,
+        :transfer<secondaries gather-js-jq gather-css images search-bar >,
         :compilation<secondaries listfiles search-bar link-error-test>,
         :completion<cro-app>,
     ),


### PR DESCRIPTION
disabling the plugin. It was providing information about which reflog the Raku/docs sources were coming from.
The information is low priority. 