### PR TITLE
Omit progress bars on CI

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,7 +5,7 @@ steps:
     key: build
     commands:
       - "zef install . --deps-only"
-      - "./bin_files/build-site --without-completion"
+      - "./bin_files/build-site --without-completion --no-status"
       - "./.buildkite/archive.sh"
       - "buildkite-agent artifact upload ./raku-doc-website.tar.gz"
       - rm ./raku-doc-website.tar.gz


### PR DESCRIPTION
In non-interactive scenarios progress bars take up too much log space.
