### PR TITLE
Use consistent font size for highlighted control keywords

### DIFF
--- a/Website/plugins/ogdenwebb/css/main.css
+++ b/Website/plugins/ogdenwebb/css/main.css
@@ -585,6 +585,9 @@ h1.error-title {
   font-family: monospace;
   padding: 0.75rem 1.25rem;
 }
+.raku-code .control {
+  font-size: inherit;
+}
 .raku-code .code-output-title {
   font-size: 1rem;
   font-weight: 500;

--- a/Website/plugins/ogdenwebb/scss/code/_highlighting.scss
+++ b/Website/plugins/ogdenwebb/scss/code/_highlighting.scss
@@ -24,6 +24,10 @@
     padding: $size-7 $size-5;
   }
 
+  .control {
+    font-size: inherit;
+  }
+
   .code-output-title {
     font-size: $size-6;
     font-weight: $weight-medium;


### PR DESCRIPTION
`.control` spans are currently styled with a font-size of `1rem`; in code blocks, inherit the size from `pre` instead.

An example of inconsistent sizing can be found on https://docs.raku.org/language/control.html#for (though it's prevalent across the site).