### PR TITLE
addresses issue #228

### DIFF
--- a/Website/plugins/link-error-test/let-templates.raku
+++ b/Website/plugins/link-error-test/let-templates.raku
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
-use PrettyDump;
 %(
+
     linkerrortest => sub (%prm, %tml) {
         my $rv = '';
         if %prm<linkerrortest>:exists and +%prm<linkerrortest>.keys {
@@ -13,7 +13,8 @@ use PrettyDump;
                         'Remote http/s links with bad host or 404';
             for <remote no-target unknown no-file> -> $type {
                 my %object = $data{$type};
-                next if ! %object.elems or ( $type eq 'remote' and %object.elems eq 1 );
+                next if (! %object.elems)
+                    or ( $type eq 'remote' and ! %object<no_test> and %object.elems eq 1 );
                 $rv ~= '<h2 class="raku-h2">' ~ %titles{$type} ~ "</h2>\n";
                 given $type {
                     when 'remote' {
@@ -64,7 +65,7 @@ use PrettyDump;
                 }
                 unless %object<no_test> {
                     for %object.sort.grep( { .value ~~ Positional } ).map(|*.kv) -> $fn, $resp {
-                        $rv ~= '<div class="let-file"><div>' ~ $fn ~ '<a class="let-clickable" href="' ~ $fn ~ '.html" target="_blank" rel="noopener noreferrer">Clickable</a></div>';
+                        $rv ~= '<div class="let-file"><div>' ~ $fn ~ '<a class="let-clickable" href="' ~ $fn ~ '" target="_blank" rel="noopener noreferrer">Clickable</a></div>';
                         when $type eq 'no-file' {
                             for $resp.list -> %info {
                                 $rv ~= '<div class="let-link-text">' ~ %tml<escaped>( %info<link-label> )
@@ -99,7 +100,7 @@ use PrettyDump;
                                 $rv ~= '<div class="let-link-text">' ~ %tml<escaped>( %info<link-label> )
                                     ~ '<div class="let-link-file"><div>'
                                     ~ %tml<escaped>( %info<file> )
-                                    ~ '<a class="let-clickable" href="' ~ %tml<escaped>( %info<file> ) ~ '.html" target="_blank" rel="noopener noreferrer">Clickable</a></div>'
+                                    ~ '<a class="let-clickable" href="' ~ %tml<escaped>( %info<file> ) ~ '" target="_blank" rel="noopener noreferrer">Clickable</a></div>'
                                     ~ %info<targets>.map( {
                                         '<div class="let-link-target">'
                                         ~ %tml<escaped>( $_ )

--- a/Website/plugins/listfiles/listf-templates.raku
+++ b/Website/plugins/listfiles/listf-templates.raku
@@ -59,7 +59,7 @@ my regex select {
                 FIRST
 
         for  @sel-files.sort(*.[0]) -> ($nm, $desc, $path) {
-            $rv ~= '<div class="listf-file"><a class="listf-link" href="' ~ $path ~ '.html">' ~ $nm ~ '</a></div>'
+            $rv ~= '<div class="listf-file"><a class="listf-link" href="' ~ $path ~ '">' ~ $nm ~ '</a></div>'
                     ~ '<div class="listf-desc">' ~ $desc ~ '</div>'
         }
         unless +@sel-files {

--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -210,7 +210,7 @@ use v6.d;
     },
     footer-right => sub (%prm, %tml ) {
         q:to/FRIGHT/
-        <div class="level-left">
+        <div class="level-right">
             <div class="level-item">
               <a href="/license">License</a>
             </div>

--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -63,16 +63,16 @@ use v6.d;
     'head-topbar' => sub ( %prm, %tml ) {
         q:to/BLOCK/
           <div class="navbar-start">
-            <a class="navbar-item" href="/language.html">
+            <a class="navbar-item" href="/language">
                 Language
             </a>
-            <a class="navbar-item" href="/types.html">
+            <a class="navbar-item" href="/types">
                 Types
             </a>
-            <a class="navbar-item" href="/routines.html">
+            <a class="navbar-item" href="/routines">
                 Routines
             </a>
-            <a class="navbar-item" href="/programs.html">
+            <a class="navbar-item" href="/programs">
                 Programs
             </a>
             <a class="navbar-item" href="https://raku.org">
@@ -87,12 +87,16 @@ use v6.d;
               </a>
               <div class="navbar-dropdown">
                 <hr class="navbar-divider">
-                <a class="navbar-item" href="/about.html">
+                <a class="navbar-item" href="/about">
                   About
                 </a>
                 <hr class="navbar-divider">
                 <a class="navbar-item has-text-red" href="https://github.com/raku/doc-website/issues">
                   Report an issue with this site
+                </a>
+                <hr class="navbar-divider">
+                <a class="navbar-item has-text-red" href="https://github.com/raku/doc-website/issues">
+                  Report an issue with the documentation content
                 </a>
               </div>
             </div>
@@ -200,7 +204,7 @@ use v6.d;
         q:to/FLEFT/
         <div class="level-left">
             <div class="level-item">
-              <a href="/about.html">About</a>
+              <a href="/about">About</a>
             </div>
             <div class="level-item">
               <a id="toggle-theme">Toggle theme</a>
@@ -210,10 +214,10 @@ use v6.d;
     },
     footer-right => sub (%prm, %tml ) {
         q:to/FRIGHT/
-        <div class="level-right">
-          <div class="level-item">
-              <a href="/license.html">License</a>
-          </div>
+        <div class="level-left">
+            <div class="level-item">
+              <a href="/license">License</a>
+            </div>
         </div>
         FRIGHT
     },

--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -94,10 +94,6 @@ use v6.d;
                 <a class="navbar-item has-text-red" href="https://github.com/raku/doc-website/issues">
                   Report an issue with this site
                 </a>
-                <hr class="navbar-divider">
-                <a class="navbar-item has-text-red" href="https://github.com/raku/doc-website/issues">
-                  Report an issue with the documentation content
-                </a>
               </div>
             </div>
           </div>

--- a/Website/plugins/search-bar/add-search.raku
+++ b/Website/plugins/search-bar/add-search.raku
@@ -11,9 +11,9 @@ sub ( $pp, %processed, %options ) {
     # eg { "category": "Types", "value": "Distribution::Hash", "url": "/type/Distribution::Hash" }
     # The first three items are supplied for some reason.
     my @entries =
-        %( :category("Syntax"), :value("# single-line comment"), :url("/language/syntax.html#Single-line_comments") ),
-        %( :category("Syntax"), :value("#` multi-line comment"), :url("/language/syntax.html#Multi-line_/_embedded_comments") ),
-        %( :category("Signature"), :value(";; (long name)"), :url("/type/Signature.html#index-entry-Long_Names") )
+        %( :category("Syntax"), :value("# single-line comment"), :url("/language/syntax#Single-line_comments") ),
+        %( :category("Syntax"), :value("#` multi-line comment"), :url("/language/syntax#Multi-line_/_embedded_comments") ),
+        %( :category("Signature"), :value(";; (long name)"), :url("/type/Signature#index-entry-Long_Names") )
     ;
     my $categories = <Syntax Signature Heading Glossary>.SetHash;
     # collect info stored from parsing headers
@@ -41,7 +41,7 @@ sub ( $pp, %processed, %options ) {
                 :$category,
                 :value( escape( %info<name> ) ),
                 :info( ': in <b>' ~ escape-json($fn) ~ '</b>' ),
-                :url( escape-json( "/$fn\.html\#$targ" ) )
+                :url( escape-json( "/$fn\#$targ" ) )
             )
         }
     }
@@ -52,14 +52,14 @@ sub ( $pp, %processed, %options ) {
             :category( $podf.pod-config-data<subkind>.tc ),
             :value( escape-json( $value )),
             :info( ' ' ),
-            :url( escape-json( '/' ~ $fn ~ '.html' ))
+            :url( escape-json( '/' ~ $fn ))
         );
         for $podf.raw-toc.grep({ !(.<is-title>) }) {
             @entries.push: %(
                 :category<Heading>,
                 :value( escape( .<text> ) ),
                 :info( ': section in <b>' ~ escape-json( $podf.title ) ~ '</b>' ),
-                :url( escape-json( '/' ~ $fn ~ '.html#' ~ .<target> ) )
+                :url( escape-json( '/' ~ $fn ~ '#' ~ .<target> ) )
             )
         }
         $categories{ $podf.pod-config-data<kind>.tc }++
@@ -86,7 +86,6 @@ sub ( $pp, %processed, %options ) {
         'var items = '
         ~ to-json( @entries )
         ~ ";\n"
-#        ~ "var searchSite = '$search-site';\n"
         ~ 'search-temp.js'.IO.slurp;
     [
         [ 'assets/scripts/search-bar.js', 'myself', 'search-bar.js' ],

--- a/Website/plugins/secondaries/README.rakudoc
+++ b/Website/plugins/secondaries/README.rakudoc
@@ -20,11 +20,27 @@ During the transfer stage, the secondary files are deleted from the plugin's dir
 
 =head1 Secondary files
 
-Raku documentation contains many C<=head> blocks that define routines (methods, roles, subs etc)
-and syntax (infix postfix etc). These items may be defined and documented separately for different Types.
+Raku documentation contains many C<=head> blocks (called headings below)
+that define routines (methods, roles, subs etc)
+operators, and syntax (infix postfix etc).
+
+Items with the same name (eg., say) may be defined and documented separately for different Types.
 It makes sense to gather the same method name into a separate page.
 
-The headers are analysed when the template is composed.
+As the documentation was written, two types of headings were created:
+=item direct headings, such as C<=head1 sub say>
+=item indirect headings, such as C<=head2 X<Multi-dispatch|Syntax,multi> >
+
+Direct headings are created in the directories C<routine/ and type/>.
+Indirect headings are created in the directories C<syntax/>.
+
+The header blocks are analysed when the template is rendered.
+In order to avoid parsing each source file twice to handle header blocks, the parsing is done
+when the header block is rendered, by which time C<X<>> markup has already been rendered
+into HTML. So to pick up indirect heading definitions, the HTML has to be examined.
+
+Indirect headings will have text starting with an anchor C< <a ...> >, direct headings will have
+ambient text.
 
 The files are generated during the compilation stage.
 

--- a/Website/plugins/secondaries/config.raku
+++ b/Website/plugins/secondaries/config.raku
@@ -10,5 +10,5 @@
 	:render<namespace-check.raku>,
 	:template-raku<header-templates.raku>,
 	:transfer<cleanup.raku>,
-	:version<0.1.16>,
+	:version<0.2.4>,
 )

--- a/Website/plugins/secondaries/gen-secondaries.raku
+++ b/Website/plugins/secondaries/gen-secondaries.raku
@@ -125,7 +125,7 @@ sub ($pp, %processed, %options) {
                 :meta(''),
                 :footnotes(''),
             ), %templates);
-            @transfers.push: ["$fn-name\.html", 'myself', "html/$fn-name.html"]
+            @transfers.push: ["$fn-name\.html", 'myself', "html/$fn-name\.html"]
         }
     }
     my %ns;

--- a/Website/plugins/secondaries/gen-secondaries.raku
+++ b/Website/plugins/secondaries/gen-secondaries.raku
@@ -21,24 +21,26 @@ sub ($pp, %processed, %options) {
         my @goodchars = @badchars
             .map({ '$' ~ .uniname })
             .map({ .subst(' ', '_', :g) });
-        $name = $name.subst(@badchars[0], @goodchars[0], :g);
-        $name = $name.subst(@badchars[1], @goodchars[1], :g);
-
+        # de-HTML-escape name, change bad to good, make _ into %20
+        $name .= trans(qw｢ &lt; &gt; &amp; &quot; ｣ => qw｢ <    >    &   " ｣);
+        $name .= subst(@badchars[0], @goodchars[0], :g);
+        $name .= subst(@badchars[1], @goodchars[1], :g);
+        $name .= subst( / '_' /, '%20', :g );
         # if it contains escaped sequences (like %20) we do not
         # escape %
         if (!($name ~~ /\%<xdigit> ** 2/)) {
-            $name = $name.subst(@badchars[2], @goodchars[2], :g);
+            $name .= subst(@badchars[2], @goodchars[2], :g);
         }
-        return $name;
+        $name;
     }
     my %data = $pp.get-data('heading');
-    #| get the definitions stored after parsing a header
+    #| get the definitions stored after parsing headers
     my %definitions = %data<defs>;
     #| each of the things we want to group in a file
     my %things = %( routine => {}, syntax => {});
     #| templates hash in ProcessedPod instance
     my %templates := $pp.tmpl;
-    #|this is for the triples describing the files to be transferred once created
+    #| container for the triples describing the files to be transferred once created
     my @transfers;
     #| container for tablesearch plugin
     my @routines = [ ['Category', 'Name' , 'Type', 'Where documented'] , ];
@@ -94,7 +96,7 @@ sub ($pp, %processed, %options) {
                 $body ~= %templates<para>.(%(
                    :contents(qq:to/CONT/)
                         See primary documentation
-                        <a href="/{ .<source> }.html#{ .<target> }">in context\</a>
+                        <a href="/{ .<source> }#{ .<target> }">in context\</a>
                         for <b>{ .<target>.subst( / '_' / , ' ', :g ) }</b>
                     CONT
                 ), %templates);
@@ -103,7 +105,7 @@ sub ($pp, %processed, %options) {
                     .<category>.tc,
                     $dn,
                     .<subkind>,
-                    qq[[<a href="/{ .<source> }.html#{ .<target> }">{ .<source> }</a>]]
+                    qq[[<a href="/{ .<source> }#{ .<target> }">{ .<source> }</a>]]
                 ];
             }
             # Construct TOC
@@ -123,7 +125,7 @@ sub ($pp, %processed, %options) {
                 :meta(''),
                 :footnotes(''),
             ), %templates);
-            @transfers.push: ["$fn-name\.html", 'myself', "html/$fn-name\.html"]
+            @transfers.push: ["$fn-name\.html", 'myself', "html/$fn-name.html"]
         }
     }
     my %ns;

--- a/Website/plugins/secondaries/gen-secondaries.raku
+++ b/Website/plugins/secondaries/gen-secondaries.raku
@@ -25,7 +25,6 @@ sub ($pp, %processed, %options) {
         $name .= trans(qw｢ &lt; &gt; &amp; &quot; ｣ => qw｢ <    >    &   " ｣);
         $name .= subst(@badchars[0], @goodchars[0], :g);
         $name .= subst(@badchars[1], @goodchars[1], :g);
-        $name .= subst( / '_' /, '%20', :g );
         # if it contains escaped sequences (like %20) we do not
         # escape %
         if (!($name ~~ /\%<xdigit> ** 2/)) {
@@ -86,6 +85,7 @@ sub ($pp, %processed, %options) {
                 # Construct body
                 @subkind.append: .<subkind>;
                 @category.append: .<category>;
+                $subtitle ~= ' ' ~ .<source>;
                 $body ~= %templates<heading>.(%(
                   :1level,
                   :skip-parse,

--- a/Website/plugins/secondaries/header-templates.raku
+++ b/Website/plugins/secondaries/header-templates.raku
@@ -54,77 +54,45 @@ use v6.d;
     #}
         # get the heading information structure
         my $text = %prm<text> // '';
+        # Normalize text for searching for routines
+        my $n-text = $text
+            .subst(/ '<a' ~ '/a>' .+? / , '', :g)
+            .subst(/ \< ~ \> .+? / , '', :g)
+            .trim;
         my $target = %tml<escaped>(%prm<target>);
+        my $level = %prm<level> // '1';
         my $bookmark = '';
         unless %prm<skip-parse> {
-            my $fn = %prm<config><name>;
-            my $indirect = $text ~~ /
-                ^
-                '<a name="index-entry-Syntax_'
-                ( .+? ) '-' .+?
-                '"></a><span class="glossary-entry">'
-                ( .+? )
-                '</span>'
-            /;
-            if $indirect {
-#                Code in Documentable that's to be reverse engineered.
-#                my $fc = @header.first;
-#                return %() if $fc.type ne "X";
-#
-#                my @meta = $fc.meta[0]:v.flat.cache;
-#                my $name = (@meta > 1) ?? @meta[1]
-#                                    !! textify-pod($fc.contents[0], '');
-#
-#                %attr = name       => $name.trim,
-#                        kind       => Kind::Syntax,
-#                        subkinds   => @meta || (),
-#                        categories => @meta || ();
-
+            my $parsed = $n-text ~~ / <TOP> /;
+            if $parsed {
+                my $kind;
+                my $category;
+                my $name;
+                my $subkind;
+                my $fn = %prm<config><name>;
+                with $parsed<TOP><infix-foo> { $name = .<name>.Str; $subkind = .<subkind>.Str }
+                with $parsed<TOP><the-foo-infix> { $name = .<single-name>.Str ; $subkind = .<subkind>.Str }
+                with $parsed<TOP><infix-foo><subkind><routine> { $kind = 'routine'; $category = .Str }
+                with $parsed<TOP><infix-foo><subkind><syntax> { $kind = 'syntax'; $category = .Str }
+                with $parsed<TOP><infix-foo><subkind><operator> { $kind = 'routine'; $category = 'operator' }
+                with $parsed<TOP><the-foo-infix><subkind><routine> { $kind = 'routine'; $category = .Str }
+                with $parsed<TOP><the-foo-infix><subkind><syntax> { $kind = 'syntax'; $category = .Str }
+                with $parsed<TOP><the-foo-infix><subkind><operator> { $kind = 'routine'; $category = 'operator' }
                 %prm<heading><defs>{ $fn } = {} unless %prm<heading><defs>{ $fn }:exists;
                 %prm<heading><defs>{ $fn }{ $target } = %(
-                    :name( ~ $indirect[0] ),
-                    :kind<syntax>,
-                    :subkind( ~ $indirect[1] ),
-                    :category<Syntax>, # only one category per defn
+                    :$name,
+                    :$kind,
+                    :$subkind,
+                    :$category, # only one category per defn
                 );
-                $bookmark = "\n<!-- defnmark $target -->\n";
-            }
-            else {
-                # Normalize text for searching for routines
-                my $n-text = $text
-                    .subst(/ '<a' ~ '/a>' .+? / , '', :g)
-                    .subst(/ \< ~ \> .+? / , '', :g)
-                    .trim;
-                my $parsed = $n-text ~~ / <TOP> /;
-                if $parsed {
-                    my $kind;
-                    my $category;
-                    my $name;
-                    my $subkind;
-                    with $parsed<TOP><infix-foo> { $name = .<name>.Str; $subkind = .<subkind>.Str }
-                    with $parsed<TOP><the-foo-infix> { $name = .<single-name>.Str ; $subkind = .<subkind>.Str }
-                    with $parsed<TOP><infix-foo><subkind><routine> { $kind = 'routine'; $category = .Str }
-                    with $parsed<TOP><infix-foo><subkind><syntax> { $kind = 'syntax'; $category = .Str }
-                    with $parsed<TOP><infix-foo><subkind><operator> { $kind = 'routine'; $category = 'operator' }
-                    with $parsed<TOP><the-foo-infix><subkind><routine> { $kind = 'routine'; $category = .Str }
-                    with $parsed<TOP><the-foo-infix><subkind><syntax> { $kind = 'syntax'; $category = .Str }
-                    with $parsed<TOP><the-foo-infix><subkind><operator> { $kind = 'routine'; $category = 'operator' }
-                    %prm<heading><defs>{ $fn } = {} unless %prm<heading><defs>{ $fn }:exists;
-                    %prm<heading><defs>{ $fn }{ $target } = %(
-                        :$name,
-                        :$kind,
-                        :$subkind,
-                        :$category, # only one category per defn
-                    );
-                    $bookmark = "\n<!-- defnmark $target -->\n";
-                }
+                $bookmark = "<!-- defnmark $target -->";
             }
         }
-        # now output the header + bookmark
-        # if it exists output the header using the previous header formatting
+        # now output the header + book
+        # if it exists output the header using the previous header formattingmark
         with %tml.prior('heading') {
             $_.( %prm, %tml )
-            ~ $bookmark
+            ~ "\n$bookmark\n"
         }
         else { # no previous header, so here's a generic one in case
             my $index-parse = $text ~~ /
@@ -137,7 +105,6 @@ use v6.d;
                 ~ qq[[<a href="#{ %tml<escaped>.(%prm<top>) }" class="u" title="go to top of document">]]
                 ~ ( $index-parse.so ?? $index-parse[1] !! $text )
                 ~ qq[[</a></$h>\n]]
-            ~ $bookmark
         }
     },
 );

--- a/Website/plugins/typegraph/add-type-graph.raku
+++ b/Website/plugins/typegraph/add-type-graph.raku
@@ -24,7 +24,6 @@ sub ($pp, %options) {
     my @files = 'typegraphs'.IO.dir(test => *.ends-with('.svg'))>>.relative('typegraphs')>>.IO>>.extension('');
     for @files {
         my $s = "typegraphs/$_\.svg".IO.slurp.subst( / ^ .+? <?before '<svg'> /, '');
-        $s ~~ s:g/ 'href=' \" ~ \" (.+?) / href="$0.html" /;
         %ns<typegraphs>{ $_ } = $s;
     }
     if 'pod' ~~ $pp.plugin-datakeys {

--- a/Website/plugins/typegraph/tp-template.raku
+++ b/Website/plugins/typegraph/tp-template.raku
@@ -7,7 +7,6 @@
                 .subst( / [ '.rakudoc' || '.pod6' ] $ /, '')
                 .subst( / '/' /, '', :g )
                 .subst( / \:\: /, '', :g );
-            say $doc;
             with %prm<pod><typegraphs>{ $doc } {
                 my $name =  %prm<config><name>
                     .subst( / ^ 'type/' /, '')

--- a/Website/structure-sources/index.rakudoc
+++ b/Website/structure-sources/index.rakudoc
@@ -7,10 +7,10 @@
         <div class="hero-body">
           <div class="container">
             <h1 class="title is-1 is-size-2-mobile has-text-centered">
-              Raku™ documentation
+              Raku documentation
             </h1>
             <h2 class="subtitle is-4 has-text-centered mt-3">
-              Welcome to the official documentation of the Raku™ programming language!
+              Welcome to the official documentation of the Raku programming language!
             </h2>
           </div>
         </div>
@@ -23,20 +23,20 @@
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
-                    <a href="/language.html">
+                    <a href="/language">
                       <span class="icon is-large has-text-primary">
                         <svg class="svg-inline--fa fa-graduation-cap fa-w-20 icon-large" aria-hidden="true" data-prefix="fas" data-icon="graduation-cap" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" data-fa-i2svg=""><path fill="currentColor" d="M622.34 153.2L343.4 67.5c-15.2-4.67-31.6-4.67-46.79 0L17.66 153.2c-23.54 7.23-23.54 38.36 0 45.59l48.63 14.94c-10.67 13.19-17.23 29.28-17.88 46.9C38.78 266.15 32 276.11 32 288c0 10.78 5.68 19.85 13.86 25.65L20.33 428.53C18.11 438.52 25.71 448 35.94 448h56.11c10.24 0 17.84-9.48 15.62-19.47L82.14 313.65C90.32 307.85 96 298.78 96 288c0-11.57-6.47-21.25-15.66-26.87.76-15.02 8.44-28.3 20.69-36.72L296.6 284.5c9.06 2.78 26.44 6.25 46.79 0l278.95-85.7c23.55-7.24 23.55-38.36 0-45.6zM352.79 315.09c-28.53 8.76-52.84 3.92-65.59 0l-145.02-44.55L128 384c0 35.35 85.96 64 192 64s192-28.65 192-64l-14.18-113.47-145.03 44.56z"></path></svg><!-- <i class="fas fa-graduation-cap icon-large"></i> -->
                       </span>
                     </a>
                   </div>
                   <div class="content has-text-centered">
-                    <p class="title is-5 has-text-primary"><a href="/language.html">Language Reference &amp; Tutorials</a></p>
+                    <p class="title is-5 has-text-primary"><a href="/language">Language Reference &amp; Tutorials</a></p>
                   </div>
                   <div class="content has-text-centered">
                     Documents explaining the various conceptual parts of the language.
                   </div>
                   <div class="has-text-centered">
-                    <a class="button is-primary" href="/language.html">
+                    <a class="button is-primary" href="/language">
                       <strong>Learn more</strong>
                     </a>
                   </div>
@@ -47,20 +47,20 @@
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
-                    <a href="/types.html">
+                    <a href="/type">
                       <span class="icon is-large has-text-primary">
                         <svg class="svg-inline--fa fa-layer-group fa-w-16 icon-large" aria-hidden="true" data-prefix="fas" data-icon="layer-group" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M12.41 148.02l232.94 105.67c6.8 3.09 14.49 3.09 21.29 0l232.94-105.67c16.55-7.51 16.55-32.52 0-40.03L266.65 2.31a25.607 25.607 0 0 0-21.29 0L12.41 107.98c-16.55 7.51-16.55 32.53 0 40.04zm487.18 88.28l-58.09-26.33-161.64 73.27c-7.56 3.43-15.59 5.17-23.86 5.17s-16.29-1.74-23.86-5.17L70.51 209.97l-58.1 26.33c-16.55 7.5-16.55 32.5 0 40l232.94 105.59c6.8 3.08 14.49 3.08 21.29 0L499.59 276.3c16.55-7.5 16.55-32.5 0-40zm0 127.8l-57.87-26.23-161.86 73.37c-7.56 3.43-15.59 5.17-23.86 5.17s-16.29-1.74-23.86-5.17L70.29 337.87 12.41 364.1c-16.55 7.5-16.55 32.5 0 40l232.94 105.59c6.8 3.08 14.49 3.08 21.29 0L499.59 404.1c16.55-7.5 16.55-32.5 0-40z"></path></svg><!-- <i class="fas fa-layer-group icon-large"></i> -->
                       </span>
                     </a>
                   </div>
                   <div class="content has-text-centered">
-                    <p class="title is-5 has-text-primary"><a href="/types.html">Type Reference</a></p>
+                    <p class="title is-5 has-text-primary"><a href="/types">Type Reference</a></p>
                   </div>
                   <div class="content has-text-centered">
                     Index of built-in classes, roles and enums.
                   </div>
                   <div class="has-text-centered">
-                    <a class="button is-primary" href="/types.html">
+                    <a class="button is-primary" href="/types">
                       <strong>Learn more</strong>
                     </a>
                   </div>
@@ -71,20 +71,20 @@
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
-                    <a href="/routines.html">
+                    <a href="/routines">
                       <span class="icon is-large has-text-primary">
                         <svg class="svg-inline--fa fa-paperclip fa-w-14 icon-large" aria-hidden="true" data-prefix="fas" data-icon="paperclip" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M43.246 466.142c-58.43-60.289-57.341-157.511 1.386-217.581L254.392 34c44.316-45.332 116.351-45.336 160.671 0 43.89 44.894 43.943 117.329 0 162.276L232.214 383.128c-29.855 30.537-78.633 30.111-107.982-.998-28.275-29.97-27.368-77.473 1.452-106.953l143.743-146.835c6.182-6.314 16.312-6.422 22.626-.241l22.861 22.379c6.315 6.182 6.422 16.312.241 22.626L171.427 319.927c-4.932 5.045-5.236 13.428-.648 18.292 4.372 4.634 11.245 4.711 15.688.165l182.849-186.851c19.613-20.062 19.613-52.725-.011-72.798-19.189-19.627-49.957-19.637-69.154 0L90.39 293.295c-34.763 35.56-35.299 93.12-1.191 128.313 34.01 35.093 88.985 35.137 123.058.286l172.06-175.999c6.177-6.319 16.307-6.433 22.626-.256l22.877 22.364c6.319 6.177 6.434 16.307.256 22.626l-172.06 175.998c-59.576 60.938-155.943 60.216-214.77-.485z"></path></svg><!-- <i class="fas fa-paperclip icon-large"></i> -->
                       </span>
                     </a>
                   </div>
                   <div class="content has-text-centered">
-                    <p class="title is-5 has-text-primary"><a href="/routines.html">Routine Reference</a></p>
+                    <p class="title is-5 has-text-primary"><a href="/routines">Routine Reference</a></p>
                   </div>
                   <div class="content has-text-centered">
                     Index of built-in subroutines and methods.
                   </div>
                   <div class="has-text-centered">
-                    <a class="button is-primary" href="/routines.html">
+                    <a class="button is-primary" href="/routines">
                       <strong>Learn more</strong>
                     </a>
                   </div>
@@ -95,20 +95,20 @@
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
-                    <a href="/programs.html">
+                    <a href="/programs">
                       <span class="icon is-large has-text-primary">
                         <svg class="svg-inline--fa fa-code fa-w-20 icon-large" aria-hidden="true" data-prefix="fas" data-icon="code" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" data-fa-i2svg=""><path fill="currentColor" d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z"></path></svg><!-- <i class="fas fa-code icon-large"></i> -->
                       </span>
                     </a>
                   </div>
                   <div class="content has-text-centered">
-                    <p class="title is-5 has-text-primary"><a href="/programs.html">Raku Programs</a></p>
+                    <p class="title is-5 has-text-primary"><a href="/programs">Raku Programs</a></p>
                   </div>
                   <div class="content has-text-centered">
                     Documents explaining various topics focused on Raku programs rather than the language itself.
                   </div>
                   <div class="has-text-centered">
-                    <a class="button is-primary" href="/programs.html">
+                    <a class="button is-primary" href="/programs">
                       <strong>Learn more</strong>
                     </a>
                   </div>
@@ -119,20 +119,20 @@
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
-                    <a href="/language/faq.html">
+                    <a href="/language/faq">
                       <span class="icon is-large has-text-primary">
                         <svg class="svg-inline--fa fa-question-circle fa-w-16 icon-large" aria-hidden="true" data-prefix="fas" data-icon="question-circle" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"></path></svg><!-- <i class="fas fa-question-circle icon-large"></i> -->
                       </span>
                     </a>
                   </div>
                   <div class="content has-text-centered">
-                    <p class="title is-5 has-text-primary"><a href="/language/faq.html">FAQs (Frequently Asked Questions)</a></p>
+                    <p class="title is-5 has-text-primary"><a href="/language/faq">FAQs (Frequently Asked Questions)</a></p>
                   </div>
                   <div class="content has-text-centered">
                     A collection of questions that have cropped up often, along with answers.
                   </div>
                   <div class="has-text-centered">
-                    <a class="button is-primary" href="/language/faq.html">
+                    <a class="button is-primary" href="/language/faq">
                       <strong>Learn more</strong>
                     </a>
                   </div>
@@ -143,20 +143,20 @@
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
-                    <a href="/language/community.html">
+                    <a href="/language/community">
                       <span class="icon is-large has-text-primary">
                         <svg class="svg-inline--fa fa-user-friends fa-w-20 icon-large" aria-hidden="true" data-prefix="fas" data-icon="user-friends" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" data-fa-i2svg=""><path fill="currentColor" d="M192 256c61.9 0 112-50.1 112-112S253.9 32 192 32 80 82.1 80 144s50.1 112 112 112zm76.8 32h-8.3c-20.8 10-43.9 16-68.5 16s-47.6-6-68.5-16h-8.3C51.6 288 0 339.6 0 403.2V432c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48v-28.8c0-63.6-51.6-115.2-115.2-115.2zM480 256c53 0 96-43 96-96s-43-96-96-96-96 43-96 96 43 96 96 96zm48 32h-3.8c-13.9 4.8-28.6 8-44.2 8s-30.3-3.2-44.2-8H432c-20.4 0-39.2 5.9-55.7 15.4 24.4 26.3 39.7 61.2 39.7 99.8v38.4c0 2.2-.5 4.3-.6 6.4H592c26.5 0 48-21.5 48-48 0-61.9-50.1-112-112-112z"></path></svg><!-- <i class="fas fa-user-friends icon-large"></i> -->
                       </span>
                     </a>
                   </div>
                   <div class="content has-text-centered">
-                    <p class="title is-5 has-text-primary"><a href="/language/community.html">Community</a></p>
+                    <p class="title is-5 has-text-primary"><a href="/language/community">Community</a></p>
                   </div>
                   <div class="content has-text-centered">
                     Information about the Raku development community, email lists, IRC and IRC bots, and blogs.
                   </div>
                     <div class="has-text-centered">
-                    <a class="button is-primary" href="/language/community.html">
+                    <a class="button is-primary" href="/language/community">
                       <strong>Learn more</strong>
                     </a>
                   </div>
@@ -184,7 +184,7 @@
                 <p class="head">Community</p>
                 <ul>
                   <li><a href="https://www.reddit.com/r/rakulang/">Reddit</a></li>
-                  <li><a href="https://fosstodon.org/@rakulang">Mastodon</a></li>
+                  <li><a href="https://twitter.com/raku_news">Twitter</a></li>
                   <li><a href="https://www.facebook.com/groups/1595443877388632/">Facebook</a></li>
                   <li><a href="https://stackoverflow.com/questions/tagged/raku">Stack Overflow</a></li>
                 </ul>
@@ -200,7 +200,7 @@
               <div class="column">
                 <p class="head">Explore</p>
                 <ul>
-                  <li><a href="https://planet.raku.org/">Raku Blog Aggregator</a></li>
+                  <li><a href="https://pl6anet.org/">Raku Blog Aggregator</a></li>
                   <li><a href="https://rakudoweekly.blog/">Rakudo Weekly</a></li>
                   <li><a href="https://perlweeklychallenge.org/">The Weekly Challenge</a></li>
                   <li><a href="https://raku-advent.blog/">Raku Advent Calendar</a></li>

--- a/Website/structure-sources/index.rakudoc
+++ b/Website/structure-sources/index.rakudoc
@@ -7,10 +7,10 @@
         <div class="hero-body">
           <div class="container">
             <h1 class="title is-1 is-size-2-mobile has-text-centered">
-              Raku documentation
+              Raku™ documentation
             </h1>
             <h2 class="subtitle is-4 has-text-centered mt-3">
-              Welcome to the official documentation of the Raku programming language!
+              Welcome to the official documentation of the Raku™ programming language!
             </h2>
           </div>
         </div>

--- a/Website/structure-sources/index.rakudoc
+++ b/Website/structure-sources/index.rakudoc
@@ -47,7 +47,7 @@
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
-                    <a href="/type">
+                    <a href="/types">
                       <span class="icon is-large has-text-primary">
                         <svg class="svg-inline--fa fa-layer-group fa-w-16 icon-large" aria-hidden="true" data-prefix="fas" data-icon="layer-group" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M12.41 148.02l232.94 105.67c6.8 3.09 14.49 3.09 21.29 0l232.94-105.67c16.55-7.51 16.55-32.52 0-40.03L266.65 2.31a25.607 25.607 0 0 0-21.29 0L12.41 107.98c-16.55 7.51-16.55 32.53 0 40.04zm487.18 88.28l-58.09-26.33-161.64 73.27c-7.56 3.43-15.59 5.17-23.86 5.17s-16.29-1.74-23.86-5.17L70.51 209.97l-58.1 26.33c-16.55 7.5-16.55 32.5 0 40l232.94 105.59c6.8 3.08 14.49 3.08 21.29 0L499.59 276.3c16.55-7.5 16.55-32.5 0-40zm0 127.8l-57.87-26.23-161.86 73.37c-7.56 3.43-15.59 5.17-23.86 5.17s-16.29-1.74-23.86-5.17L70.29 337.87 12.41 364.1c-16.55 7.5-16.55 32.5 0 40l232.94 105.59c6.8 3.08 14.49 3.08 21.29 0L499.59 404.1c16.55-7.5 16.55-32.5 0-40z"></path></svg><!-- <i class="fas fa-layer-group icon-large"></i> -->
                       </span>
@@ -184,7 +184,7 @@
                 <p class="head">Community</p>
                 <ul>
                   <li><a href="https://www.reddit.com/r/rakulang/">Reddit</a></li>
-                  <li><a href="https://twitter.com/raku_news">Twitter</a></li>
+                  <li><a href="https://fosstodon.org/@rakulang">Mastodon</a></li>
                   <li><a href="https://www.facebook.com/groups/1595443877388632/">Facebook</a></li>
                   <li><a href="https://stackoverflow.com/questions/tagged/raku">Stack Overflow</a></li>
                 </ul>
@@ -200,7 +200,7 @@
               <div class="column">
                 <p class="head">Explore</p>
                 <ul>
-                  <li><a href="https://pl6anet.org/">Raku Blog Aggregator</a></li>
+                  <li><a href="https://planet.raku.org/">Raku Blog Aggregator</a></li>
                   <li><a href="https://rakudoweekly.blog/">Rakudo Weekly</a></li>
                   <li><a href="https://perlweeklychallenge.org/">The Weekly Challenge</a></li>
                   <li><a href="https://raku-advent.blog/">Raku Advent Calendar</a></li>


### PR DESCRIPTION
This PR removes all `.html` file extensions from rendered HTML pages (eg, in the header to each page, after the PR the html would be `<a href="/about">About</a>` instead of the current `<a href="/about.html">About<\a>`

tp-template.raku had an extra debug output that might mess up the build logs, but not the build

I have tested this in [new-raku](https://new-raku.finanalyst.org) and it does not break anything.