### PR TITLE
addresses #232 missing typegraphs.

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,7 +11,7 @@
     "Raku::Pod::Render:ver<4.4.2+>",
     "Pod::From::Cache:ver<0.4.6+>",
     "RakuConfig:ver<0.7.3+>",
-    "Collection:ver<0.14.2+>",
+    "Collection:ver<0.14.6+>",
     "Terminal::ANSIColor:ver<0.9+>:auth<zef:lizmat>",
     "Doc::TypeGraph:ver<2.2.1.1+>",
     "Doc::TypeGraph::Viz:ver<2.2.1.1+>",

--- a/Website/plugins/typegraph/add-type-graph.raku
+++ b/Website/plugins/typegraph/add-type-graph.raku
@@ -4,9 +4,11 @@ use Doc::TypeGraph::Viz;
 use Collection::Progress;
 
 sub ($pp, %options) {
-    unless 'typegraphs'.IO ~~ :e & :d
-        and 'type-graph.txt'.IO.modified le 'typegraphs'.IO.modified
-        and +'typegraphs'.IO.dir
+    unless (
+        ('typegraphs'.IO ~~ :e & :d)
+        and ( 'type-graph.txt'.IO.modified le 'typegraphs'.IO.modified )
+        and ( +'typegraphs'.IO.dir > 1 )
+        )
     {
         note 'Generating Typegraphs' unless %options<no-status>;
         mkdir 'typegraphs' unless 'typegraphs'.IO ~~ :e & :d;

--- a/Website/plugins/typegraph/tp-template.raku
+++ b/Website/plugins/typegraph/tp-template.raku
@@ -7,7 +7,6 @@
                 .subst( / [ '.rakudoc' || '.pod6' ] $ /, '')
                 .subst( / '/' /, '', :g )
                 .subst( / \:\: /, '', :g );
-            say $doc;
             with %prm<pod><typegraphs>{ $doc } {
                 my $name =  %prm<config><name>
                     .subst( / ^ 'type/' /, '')


### PR DESCRIPTION
Raku/doc-website is missing the generated svg typegraphs. They should be generated at build time by the plugin `Website/plugins/typegraph`. The original logic was disrupted because a file `.placeholder` was inserted to keep the directory. The logic has been changed. If there are no typegraphs they will be generated in the build environment.