### PR TITLE
An extra link got added to more (for changes to Raku/Doc).

### DIFF
--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -94,10 +94,6 @@ use v6.d;
                 <a class="navbar-item has-text-red" href="https://github.com/raku/doc-website/issues">
                   Report an issue with this site
                 </a>
-                <hr class="navbar-divider">
-                <a class="navbar-item has-text-red" href="https://github.com/raku/doc/issues">
-                  Report an issue with the documentation content
-                </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
@coke Was the `More->Report content error` link to Raku/Doc approved?
I am afraid I have mistakenly added in the link with another PR, but I see the PR for the More->report content error link is no longer shown as open.
However, docs-dev.raku.org is not showing the link, so I don't know what your final decision was.
This PR removes the link, if the decision was not to have it.