### PR TITLE
Addresses issue #238

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,9 +9,9 @@
   "auth": "zef:raku",
   "depends": [
     "Raku::Pod::Render:ver<4.4.2+>",
-    "Pod::From::Cache:ver<0.4.6+>",
+    "Pod::From::Cache:ver<0.5.0+>",
     "RakuConfig:ver<0.7.3+>",
-    "Collection:ver<0.14.6+>",
+    "Collection:ver<0.15.1+>",
     "Terminal::ANSIColor:ver<0.9+>:auth<zef:lizmat>",
     "Doc::TypeGraph:ver<2.2.1.1+>",
     "Doc::TypeGraph::Viz:ver<2.2.1.1+>",

--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -5,7 +5,7 @@
         :setup<raku-doc-setup>,
         :render<
             font-awesome ogdenwebb camelia simple-extras listfiles images deprecate-span filterlines
-            tablemanager secondaries typegraph
+            tablemanager secondaries typegraph generated
             search-bar link-error-test
             gather-js-jq gather-css
         >,

--- a/Website/plugins/generated/README.rakudoc
+++ b/Website/plugins/generated/README.rakudoc
@@ -1,0 +1,18 @@
+=begin pod
+=TITLE Generated is a plugin for Collection
+
+The plugin is for the C<render> milestone.
+
+The render callable retrieves the last commit id & generation data from the
+ProcessedPod instance and makes the data available for the 'generated' template.
+
+=head1 Custom blocks
+
+GENERATED triggers the template that attaches the commit data and
+adds the build generation date/time
+
+=head1 Templates
+
+generated adds commit data and time for the build after the caption text.
+
+=end pod

--- a/Website/plugins/generated/block.raku
+++ b/Website/plugins/generated/block.raku
@@ -1,0 +1,3 @@
+#!/usr/bin/env raku
+use v6.d;
+<Generated generated>

--- a/Website/plugins/generated/config.raku
+++ b/Website/plugins/generated/config.raku
@@ -1,0 +1,13 @@
+%(
+	:auth<collection>,
+	:authors(
+		"finanalyst",
+	),
+	:custom-raku<block.raku>,
+	:license<Artistic-2.0>,
+	:name<generated>,
+	:render<get-commit-id.raku>,
+	:template-raku<template.raku>,
+	:version<0.1.0>,
+	:css<generated.css>
+)

--- a/Website/plugins/generated/generated.css
+++ b/Website/plugins/generated/generated.css
@@ -1,0 +1,4 @@
+.collection-generated ul {
+	list-style: disclosure-closed;
+	list-style-position: inside;
+}

--- a/Website/plugins/generated/get-commit-id.raku
+++ b/Website/plugins/generated/get-commit-id.raku
@@ -1,0 +1,8 @@
+use v6.d;
+sub ( $pp, %options ) {
+    my %ns := $pp.get-data('generated');
+    for $pp.get-data('generation-data').kv -> $k, $v {
+        %ns{ $k } = $v
+    }
+    []
+}

--- a/Website/plugins/generated/t/05-basic.rakutest
+++ b/Website/plugins/generated/t/05-basic.rakutest
@@ -1,0 +1,5 @@
+use v6.d;
+use Test;
+use Test::CollectionPlugin;
+test-plugin();
+done-testing

--- a/Website/plugins/generated/template.raku
+++ b/Website/plugins/generated/template.raku
@@ -1,0 +1,15 @@
+#!/usr/bin/env raku
+use v6.d;
+%(
+    generated => sub (%prm, %tml) { say %prm.keys;
+        qq[[
+        <div class="collection-generated">
+        { %prm<raw-contents> // '' }
+        <ul>
+            <li>Based on commit { %prm<generated><commit-id>.trim }.</li>
+            <li>Generated on { %prm<generated><g-date> } at { %prm<generated><g-time> } UTC.</li>
+        </ul>
+        </div>
+        ]]
+    }
+)

--- a/Website/structure-sources/about.rakudoc
+++ b/Website/structure-sources/about.rakudoc
@@ -31,4 +31,7 @@ Moritz Lenz L<@moritz | https://github.com/Moritz > and JJ Merelo L<@JJ | https:
 particular. The many other people who have contributed to writing the documentation and tooling
 can be found in this L<Credits file | https://raw.githubusercontent.com/Raku/doc/master/CREDITS>.
 
+=for Generated  :headlevel(0)
+The web site was generated as follows:
+
 =end pod


### PR DESCRIPTION
This PR adds a new plugin `Website/plugins/generated` and bumps minimum versions of `Collection` and `Pod::From::Cache`. `Pod::From::Cache` v0.5.0 has new method to deliver last commit-id for documents. `Collection` v0.15.1 makes the commit-id and date of render available for plugins. `generated` adds these data when the block `=generated` is included in a Rakudoc source. `About.rakudoc` is amended to use `=generated`.
A live version can be seen at [new-raku /About](https://new-raku.finanalyst.org/about)