### PR TITLE
Remove debug output left after PR #240

### DIFF
--- a/Website/plugins/generated/template.raku
+++ b/Website/plugins/generated/template.raku
@@ -1,7 +1,7 @@
 #!/usr/bin/env raku
 use v6.d;
 %(
-    generated => sub (%prm, %tml) { say %prm.keys;
+    generated => sub (%prm, %tml) {
         qq[[
         <div class="collection-generated">
         { %prm<raw-contents> // '' }


### PR DESCRIPTION
A debug line was left in `template.raku` in plugin `generated`. The information leaks into the build logs, otherwise is harmless. This PR removes the offending line.