### PR TITLE
Unordered lists and defn lists were not being rendered properly

### DIFF
--- a/Website/plugins/ogdenwebb/css/themes/dark.css
+++ b/Website/plugins/ogdenwebb/css/themes/dark.css
@@ -377,4 +377,31 @@ code {
   color: #f5f5f5; }
 
 .hero .error-title {
-  color: #f00048; }
+  color: #f00048;
+}
+
+dl {
+  margin: 5px;
+}
+dl dt {
+  font-weight: 600;
+}
+dl dd {
+  margin: 5px auto 10px 10px;
+}
+
+ul.rakudoc-item {
+  list-style: disc;
+}
+ul.rakudoc-item > ul {
+  margin-left: 2em;
+  list-style: circle;
+}
+ul.rakudoc-item > ul > ul {
+  margin-left: 2em;
+  list-style: square;
+}
+ul.rakudoc-item > ul > ul > ul {
+  margin-left: 2em;
+  list-style: disclosure-closed;
+}

--- a/Website/plugins/ogdenwebb/css/themes/light.css
+++ b/Website/plugins/ogdenwebb/css/themes/light.css
@@ -362,4 +362,31 @@ code {
   color: #030303; }
 
 .hero .error-title {
-  color: #A30031; }
+  color: #A30031;
+}
+
+dl {
+  margin: 5px;
+}
+dl dt {
+  font-weight: 600;
+}
+dl dd {
+  margin: 5px auto 10px 10px;
+}
+
+ul.rakudoc-item {
+  list-style: disc;
+}
+ul.rakudoc-item > ul {
+  margin-left: 2em;
+  list-style: circle;
+}
+ul.rakudoc-item > ul > ul {
+  margin-left: 2em;
+  list-style: square;
+}
+ul.rakudoc-item > ul > ul > ul {
+  margin-left: 2em;
+  list-style: disclosure-closed;
+}

--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -12,7 +12,6 @@ use v6.d;
         { %tml<header>.(%prm, %tml)  }
         { %tml<sidebar>.(%prm, %tml)  }
         { %tml<wrapper>.(%prm, %tml)  }
-        <div id="raku-repl"></div>
         { %tml<footer>.(%prm, %tml)  }
         { %tml<js-bottom>.({}, {}) }
         </body>
@@ -300,5 +299,22 @@ use v6.d;
             }
         }
         else { '' }
+    },
+    'format-x' => sub (%prm, %tml) {
+        my $indexedheader = %prm<meta>.elems ?? %prm<meta>[0].join(';') !! %prm<text>;
+        qq[
+            <a name="{ %prm<target> // ''}" class="index-entry"
+            data-indexedheader="{ $indexedheader }"></a>
+            { (%prm<text>.defined and %prm<text> ne '') ??
+                '<span class="glossary-entry">' ~ %prm<text> ~ '</span>'
+            !!  '' }
+        ]
+    },
+    'list' => sub (%prm, %tml) {
+        qq[
+        <ul{ %prm<nesting> == 0 ?? ' class="rakudoc-item"' !! ''}>
+           { %prm<items>.join }
+        </ul>
+        ]
     },
 );

--- a/Website/plugins/ogdenwebb/scss/themes/_themes-template-common.scss
+++ b/Website/plugins/ogdenwebb/scss/themes/_themes-template-common.scss
@@ -546,3 +546,30 @@ code {
 .hero .error-title {
   color: $red;
 }
+
+dl {
+    margin: 5px;
+    dt {
+        font-weight: $weight-semibold;
+    }
+    dd {
+        margin: 5px auto 10px 10px
+    }
+}
+
+ul.rakudoc-item {
+    list-style: disc;
+    padding: 0 0 0 $size-4;
+    > ul {
+        margin-left: 2em;
+        list-style: circle;
+        > ul {
+            margin-left: 2em;
+            list-style: square;
+            > ul {
+                margin-left: 2em;
+                list-style: disclosure-closed;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Additions are needed to the CSS, and a change to the list template.

These are relatively minor changes to the CSS and templates. The effect will be seen in `language/pod`, the examples of multi level lists and definition lists.