### PR TITLE
addresses issue #244 adds a copy button to code blocks

### DIFF
--- a/Website/plugins/ogdenwebb/core.js
+++ b/Website/plugins/ogdenwebb/core.js
@@ -130,7 +130,9 @@ $(document).ready( function() {
         });
         $matchingListElements.show();
     });
-    // copy code block to clipboard
+    // copy code block to clipboard adapted from solution at
+    // https://stackoverflow.com/questions/34191780/javascript-copy-string-to-clipboard-as-text-html
+    // if behaviour problems with different browsers add stylesheet code from that solution.
     $('.copy-raku-code').on('click', function(){
         var codeElement = $(this).next();
         var container = document.createElement('div');
@@ -138,19 +140,12 @@ $(document).ready( function() {
         container.style.position = 'fixed';
         container.style.pointerEvents = 'none';
         container.style.opacity = 0;
-        // Detect all style sheets of the page
-        var activeSheets = Array.prototype.slice.call(document.styleSheets)
-          .filter(function (sheet) {
-            return !sheet.disabled;
-          });
         document.body.appendChild(container);
         window.getSelection().removeAllRanges();
         var range = document.createRange();
         range.selectNode(container);
         window.getSelection().addRange(range);
-        //for (var i = 0; i < activeSheets.length; i++) activeSheets[i].disabled = true;
         document.execCommand("copy", false);
-        //for (var i = 0; i < activeSheets.length; i++) activeSheets[i].disabled = false;
         document.body.removeChild(container);
     });
 });

--- a/Website/plugins/ogdenwebb/core.js
+++ b/Website/plugins/ogdenwebb/core.js
@@ -130,5 +130,28 @@ $(document).ready( function() {
         });
         $matchingListElements.show();
     });
+    // copy code block to clipboard
+    $('.copy-raku-code').on('click', function(){
+        var codeElement = $(this).next();
+        var container = document.createElement('div');
+        container.innerHTML = codeElement.html();
+        container.style.position = 'fixed';
+        container.style.pointerEvents = 'none';
+        container.style.opacity = 0;
+        // Detect all style sheets of the page
+        var activeSheets = Array.prototype.slice.call(document.styleSheets)
+          .filter(function (sheet) {
+            return !sheet.disabled;
+          });
+        document.body.appendChild(container);
+        window.getSelection().removeAllRanges();
+        var range = document.createRange();
+        range.selectNode(container);
+        window.getSelection().addRange(range);
+        //for (var i = 0; i < activeSheets.length; i++) activeSheets[i].disabled = true;
+        document.execCommand("copy", false);
+        //for (var i = 0; i < activeSheets.length; i++) activeSheets[i].disabled = false;
+        document.body.removeChild(container);
+    });
 });
 

--- a/Website/plugins/ogdenwebb/css/themes/dark.css
+++ b/Website/plugins/ogdenwebb/css/themes/dark.css
@@ -392,6 +392,7 @@ dl dd {
 
 ul.rakudoc-item {
   list-style: disc;
+  padding: 0 0 0 1.5rem;
 }
 ul.rakudoc-item > ul {
   margin-left: 2em;
@@ -404,4 +405,11 @@ ul.rakudoc-item > ul > ul {
 ul.rakudoc-item > ul > ul > ul {
   margin-left: 2em;
   list-style: disclosure-closed;
+}
+
+button.copy-raku-code {
+  cursor: pointer;
+  opacity: 0.5;
+  padding: 0 0.25rem 0.25rem 0.25rem;
+  position: absolute;
 }

--- a/Website/plugins/ogdenwebb/css/themes/light.css
+++ b/Website/plugins/ogdenwebb/css/themes/light.css
@@ -377,6 +377,7 @@ dl dd {
 
 ul.rakudoc-item {
   list-style: disc;
+  padding: 0 0 0 1.5rem;
 }
 ul.rakudoc-item > ul {
   margin-left: 2em;
@@ -389,4 +390,11 @@ ul.rakudoc-item > ul > ul {
 ul.rakudoc-item > ul > ul > ul {
   margin-left: 2em;
   list-style: disclosure-closed;
+}
+
+button.copy-raku-code {
+  cursor: pointer;
+  opacity: 0.5;
+  padding: 0 0.25rem 0.25rem 0.25rem;
+  position: absolute;
 }

--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -238,9 +238,14 @@ use v6.d;
     block-code => sub (%prm, %tml) { # previous block-code is set by 02-highlighter
         my $hl = %tml.prior('block-code').(%prm, %tml);
         $hl .= subst( / '<pre class="' /, '<pre class="cm-s-ayaya ');
-        '<div class="raku-code raku-lang">'
-            ~ $hl
-            ~ '</div>'
+        qq[
+            <div class="raku-code raku-lang">
+                <button class="copy-raku-code" title="Copy code"><i class="far fa-clipboard"></i></button>
+                <div>
+                    $hl
+                </div>
+            </div>
+        ]
     },
     heading => sub (%prm, %tml) {
         my $txt = %prm<text> // '';

--- a/Website/plugins/ogdenwebb/scss/themes/_themes-template-common.scss
+++ b/Website/plugins/ogdenwebb/scss/themes/_themes-template-common.scss
@@ -573,3 +573,9 @@ ul.rakudoc-item {
         }
     }
 }
+button.copy-raku-code {
+    cursor: pointer;
+    opacity: 0.5;
+    padding: 0 0.25rem 0.25rem 0.25rem;
+    position: absolute;
+}


### PR DESCRIPTION
The patch affect `Website/ogdenwebb` by 
- changing the template for block code to add a button, 
- adding the js code to core.js, and 
- adding CSS for the button (placing on top left of block). 

The JS has been tested for Firefox. Uses `execCommand`, which is deprecated because Firefox does not recognise all of Clipboard API. 

This took a while to get a copy that would remove all HTML but respect whitespace. 

MINOR change to `lists` CSS to align bullets with left margin.