### PR TITLE
resolves #124 allow format codes in code blocks

### DIFF
--- a/Website/templates/02-highlighter.raku
+++ b/Website/templates/02-highlighter.raku
@@ -52,7 +52,6 @@ sub test-highlighter( Str $hilite-path --> Bool ) {
         my token tag { '<' ~ '>' [ '/'? <-[ > ]>+ ] }
         my @tokens;
         my $rv = &highlight(%prm<contents>.subst(/ <tag> / , { @tokens.push( ~$/ ); "\xFF\xFF" }, :g));
-        say @tokens;
         $rv.subst( / "\xFF\xFF" /, { @tokens.shift }, :g )
     }
 )

--- a/Website/templates/02-highlighter.raku
+++ b/Website/templates/02-highlighter.raku
@@ -49,6 +49,10 @@ sub test-highlighter( Str $hilite-path --> Bool ) {
 
 %(
     'block-code' => sub ( %prm, %tml ) {
-        &highlight( %prm<contents> )
+        my token tag { '<' ~ '>' [ '/'? <-[ > ]>+ ] }
+        my @tokens;
+        my $rv = &highlight(%prm<contents>.subst(/ <tag> / , { @tokens.push( ~$/ ); "\xFF\xFF" }, :g));
+        say @tokens;
+        $rv.subst( / "\xFF\xFF" /, { @tokens.shift }, :g )
     }
 )


### PR DESCRIPTION
This turned out to need a change to the block-code template. Most of the work was already done by Rakudo, but getting the highlighter to work nicely with rendered HTML was more difficult.