### PR TITLE
resolves #124 allow format codes in Code blocks

### DIFF
--- a/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
+++ b/Website/plugins/ogdenwebb/ogdenwebb-replacements.raku
@@ -236,7 +236,12 @@ use v6.d;
     },
     #placeholder
     block-code => sub (%prm, %tml) { # previous block-code is set by 02-highlighter
+        my token tag { <?after <-[ B C E I K L N P R T U V X Z ]> > '<' ~ '>' [ '/'? <-[ > ]>+ ] }
+        my @tokens;
+        %prm<contents> .= subst(/ <tag> / , { @tokens.push( ~$/ ); "\xFF\xFF" }, :g );
         my $hl = %tml.prior('block-code').(%prm, %tml);
+        $hl .= subst( / '<pre class="' /, '<pre class="cm-s-ayaya ');
+        $hl .= subst( / "\xFF\xFF" /, { @tokens.shift }, :g );
         $hl .= subst( / '<pre class="' /, '<pre class="cm-s-ayaya ');
         qq[
             <div class="raku-code raku-lang">


### PR DESCRIPTION
Although it only took a change in the Code block template in `Website/plugins/ogdenwebb`, getting it to work with highlighting was not obvious. Basically all HTML tags are replaced with 0xFF chars before highlighting, then put back.