### PR TITLE
Assert presence of atom-perl-highlighter on PATH

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,6 +4,7 @@ steps:
   - label: "Build site"
     key: build
     commands:
+      - echo 'Assert highlighting dependency' && command -v atom-perl-highlighter
       - "zef install . --deps-only"
       - "./bin_files/build-site --without-completion --no-status"
       - "./.buildkite/archive.sh"


### PR DESCRIPTION
If we don't have this executable, highlighting doesn't happen.