### PR TITLE
Adds highlights-js syntax coloring for non-Raku langs

### DIFF
--- a/Website/plugins/ogdenwebb/config.raku
+++ b/Website/plugins/ogdenwebb/config.raku
@@ -12,12 +12,21 @@
 	:template-raku<ogdenwebb-replacements.raku>,
 	:error-report,
 	:!extended-search,
-	:version<0.3.8>,
+	:version<0.3.18>,
+	:css-link(
+		'href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/atom-one-light.min.css" title="light"',
+		'href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/atom-one-dark.min.css" title="dark"',
+	),
+	:js-link(
+		['src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"', 2 ],
+		['src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/bash.min.js"', 2 ],
+	),
 	:add-css<
 		css/main.css
 		css/themes/dark.css css/themes/light.css
 		css/code/dark.css css/code/light.css
 	>, # order of css files is important
 	:jquery( ['core.js', 3], ),
-	:information<add-css jquery>,
-)
+	:information<add-css jquery css-link js-link>,
+);
+

--- a/Website/plugins/ogdenwebb/core.js
+++ b/Website/plugins/ogdenwebb/core.js
@@ -73,6 +73,8 @@ $(document).ready( function() {
 });
 
 $(document).ready( function() {
+    // trigger the highlighter
+    hljs.highlightAll();
     var sidebar_is_shown = localStorage.getItem('sidebarIsShown');;
     if (sidebar_is_shown === null) {
         // If the screen is not wide enough and the sidebar overlaps content -
@@ -133,8 +135,8 @@ $(document).ready( function() {
     // copy code block to clipboard adapted from solution at
     // https://stackoverflow.com/questions/34191780/javascript-copy-string-to-clipboard-as-text-html
     // if behaviour problems with different browsers add stylesheet code from that solution.
-    $('.copy-raku-code').on('click', function(){
-        var codeElement = $(this).next();
+        $('.copy-code').on('click', function(){
+        var codeElement = $(this).next().next(); // skip the label and get the div
         var container = document.createElement('div');
         container.innerHTML = codeElement.html();
         container.style.position = 'fixed';

--- a/Website/plugins/ogdenwebb/css/themes/dark.css
+++ b/Website/plugins/ogdenwebb/css/themes/dark.css
@@ -2,379 +2,501 @@ button.button {
   color: #f5f5f5 !important;
   border: 1px solid #3A3D4E !important;
   background-color: #212426 !important;
-  transition: background-color 500ms linear; }
+  transition: background-color 500ms linear;
+}
 
 button.button:hover {
-  background-color: #030303; }
+  background-color: #030303;
+}
 
 div#footer-generated .dropdown-content, div#footer-license .dropdown-content {
   background-color: #212426;
-  border: 1px solid #3A3D4E; }
-  div#footer-generated .dropdown-content .dropdown-item, div#footer-license .dropdown-content .dropdown-item {
-    color: #f5f5f5 !important; }
+  border: 1px solid #3A3D4E;
+}
+div#footer-generated .dropdown-content .dropdown-item, div#footer-license .dropdown-content .dropdown-item {
+  color: #f5f5f5 !important;
+}
 
 a.button strong {
-  color: #282c2e; }
+  color: #282c2e;
+}
 
 a.button.is-primary .icon {
-  color: #282c2e; }
+  color: #282c2e;
+}
 
 /* Collection */
 .raku .container .columns.listing .listf-container {
   border: 1px solid #3A3D4E;
   border-bottom: 5px solid #45485d;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
-  .raku .container .columns.listing .listf-container .listf-caption {
-    background: #212426;
-    border-bottom: 1px solid #3A3D4E;
-    color: #83858D; }
-  .raku .container .columns.listing .listf-container .listf-desc:not(:last-of-type) {
-    border-bottom: 1px solid #3A3D4E; }
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+}
+.raku .container .columns.listing .listf-container .listf-caption {
+  background: #212426;
+  border-bottom: 1px solid #3A3D4E;
+  color: #83858D;
+}
+.raku .container .columns.listing .listf-container .listf-desc:not(:last-of-type) {
+  border-bottom: 1px solid #3A3D4E;
+}
 
 html {
-  background: #1B1D1E; }
+  background: #1B1D1E;
+}
 
 body {
   background: #1B1D1E;
-  color: #f5f5f5; }
+  color: #f5f5f5;
+}
 
 .navbar-logo-tm {
-  color: #e8e8e8; }
+  color: #e8e8e8;
+}
 
 /* Site header */
 .navbar {
   background: #212426;
-  border-bottom: 1px solid #45485d; }
+  border-bottom: 1px solid #45485d;
+}
 
 .navbar a {
-  color: #8DB2EB; }
-  .navbar a:hover {
-    color: #8DB2EB;
-    text-decoration: none; }
-  .navbar a:visited {
-    color: #8DB2EB; }
+  color: #8DB2EB;
+}
+.navbar a:hover {
+  color: #8DB2EB;
+  text-decoration: none;
+}
+.navbar a:visited {
+  color: #8DB2EB;
+}
 
 a.navbar-item:hover {
-  background: #2d3134; }
+  background: #2d3134;
+}
 
 .navbar-item.has-dropdown:focus .navbar-link, .navbar-item.has-dropdown:hover .navbar-link, .navbar-item.has-dropdown.is-active .navbar-link {
-  background-color: #2d3134; }
+  background-color: #2d3134;
+}
 
 .navbar-dropdown {
   background-color: #212426;
-  border-top: 2px solid #3A3D4E; }
+  border-top: 2px solid #3A3D4E;
+}
 
 .navbar-link:not(.is-arrowless)::after {
-  border-color: #8DB2EB; }
+  border-color: #8DB2EB;
+}
 
 .navbar-divider {
-  background-color: #1B1D1E; }
+  background-color: #1B1D1E;
+}
 
 .navbar-menu {
-  background-color: #212426; }
+  background-color: #212426;
+}
 
 .navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover,
 a.navbar-item:focus-within, a.navbar-item.is-active, .navbar-link:focus, .navbar-link:focus-within, .navbar-link:hover, .navbar-link.is-active {
   background-color: #3A3D4E;
-  color: #f5f5f5; }
+  color: #f5f5f5;
+}
 
 #query::placeholder {
-  color: #83858D; }
+  color: #83858D;
+}
 
 .navbar-search-autocomplete {
   color: gainsboro;
   background-color: #282c2e;
   box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07);
-  border: 1px solid #3A3D4E; }
-  .navbar-search-autocomplete li {
-    padding: 0 5px; }
-    .navbar-search-autocomplete li.ui-autocomplete-category {
-      color: #f00048;
-      font-weight: 600; }
-    .navbar-search-autocomplete li:hover, .navbar-search-autocomplete li[aria-selected="true"] {
-      cursor: pointer;
-      background-color: #1c1f21; }
-    .navbar-search-autocomplete li mark {
-      background: transparent;
-      color: #ff7a7a;
-      font-weight: bold; }
-  .navbar-search-autocomplete .autocomplete-result-category {
-    color: #EED891; }
-    .navbar-search-autocomplete .autocomplete-result-category:hover {
-      background-color: unset; }
+  border: 1px solid #3A3D4E;
+}
+.navbar-search-autocomplete li {
+  padding: 0 5px;
+}
+.navbar-search-autocomplete li.ui-autocomplete-category {
+  color: #f00048;
+  font-weight: 600;
+}
+.navbar-search-autocomplete li:hover, .navbar-search-autocomplete li[aria-selected=true] {
+  cursor: pointer;
+  background-color: #1c1f21;
+}
+.navbar-search-autocomplete li mark {
+  background: transparent;
+  color: rgb(255, 122, 122);
+  font-weight: bold;
+}
+.navbar-search-autocomplete .autocomplete-result-category {
+  color: #EED891;
+}
+.navbar-search-autocomplete .autocomplete-result-category:hover {
+  background-color: unset;
+}
 
 a {
-  color: #8DB2EB; }
-  a:hover {
-    color: #8DB2EB;
-    text-decoration: underline; }
-  a:visited {
-    color: #8378E8; }
+  color: #8DB2EB;
+}
+a:hover {
+  color: #8DB2EB;
+  text-decoration: underline;
+}
+a:visited {
+  color: #8378E8;
+}
 
 .button.is-primary {
-  background-color: #8DB2EB !important; }
-  .button.is-primary:hover {
-    background-color: #4c86e0 !important;
-    text-decoration: none; }
+  background-color: #8DB2EB !important;
+}
+.button.is-primary:hover {
+  background-color: #4c86e0 !important;
+  text-decoration: none;
+}
 
 .label {
-  color: #d8d8d8; }
+  color: #d8d8d8;
+}
 
 .input, .textarea, .select select {
   background-color: #2d3134;
   border-color: #3A3D4E;
-  color: #f5f5f5; }
+  color: #f5f5f5;
+}
 
 .input:hover, .textarea:hover, .select select:hover, .is-hovered.input, .is-hovered.textarea, .select select.is-hovered {
-  border-color: #83858D; }
+  border-color: #83858D;
+}
 
 .input:focus, .textarea:focus, .select select:focus, .is-focused.input, .is-focused.textarea, .select select.is-focused, .input:active, .textarea:active, .select select:active, .is-active.input, .is-active.textarea, .select select.is-active {
-  border-color: #8DB2EB; }
+  border-color: #8DB2EB;
+}
 
 .select:not(.is-multiple):not(.is-loading)::after {
-  border-color: #8DB2EB; }
+  border-color: #8DB2EB;
+}
 
 .select:not(.is-multiple):not(.is-loading):hover::after {
-  border-color: #8DB2EB; }
+  border-color: #8DB2EB;
+}
 
 /* Site footer */
 .footer {
   background: #212426;
   border-top: 1px solid #45485d;
-  z-index: 50; }
+  z-index: 50;
+}
 
 .has-text-primary {
-  color: #8DB2EB !important; }
+  color: #8DB2EB !important;
+}
 
 .has-text-dark {
-  color: #3A3D4E !important; }
+  color: #3A3D4E !important;
+}
 
 .has-text-danger {
-  color: #f00048 !important; }
+  color: #f00048 !important;
+}
 
 .has-text-danger:hover {
-  color: #f00048 !important; }
+  color: #f00048 !important;
+}
 
 a.has-text-red, a.has-text-red:hover {
-  color: #f00048; }
+  color: #f00048;
+}
 
 .button.is-link {
-  background-color: #8DB2EB; }
+  background-color: #8DB2EB;
+}
 
 .button.is-link:hover {
-  background-color: #4c86e0; }
+  background-color: #4c86e0;
+}
 
 strong {
-  color: #e8e8e8; }
+  color: #e8e8e8;
+}
 
 .raku.links-block .head {
-  color: #cccccc; }
+  color: #cccccc;
+}
 .raku.links-block a {
-  color: #8DB2EB; }
-  .raku.links-block a:hover {
-    color: #4c86e0; }
+  color: #8DB2EB;
+}
+.raku.links-block a:hover {
+  color: #4c86e0;
+}
 
 /* Hopepage title */
 .hero-body {
   background: linear-gradient(180deg, #030303 0.2%, #170F44 1%, #35229E 82.29%, #271974 100%);
-  mix-blend-mode: normal; }
+  mix-blend-mode: normal;
+}
 
 /* Raku page template */
 .raku.page-title {
-  color: #EED891; }
+  color: #EED891;
+}
 
 .raku.page-header .page-edit {
-  color: #83858D; }
-  .raku.page-header .page-edit .page-edit-button {
-    background: #282c2e;
-    color: gainsboro;
-    border-color: #3A3D4E; }
-    .raku.page-header .page-edit .page-edit-button:hover {
-      background: #212426; }
+  color: #83858D;
+}
+.raku.page-header .page-edit .page-edit-button {
+  background: #282c2e;
+  color: gainsboro;
+  border-color: #3A3D4E;
+}
+.raku.page-header .page-edit .page-edit-button:hover {
+  background: #212426;
+}
 
 /* Raku search page */
 .raku-search .search-category {
   background: #282c2e;
   border: 1px solid #3A3D4E;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  color: #f5f5f5; }
+  color: #f5f5f5;
+}
 .raku-search .search-match {
-  background: #1C6301; }
+  background: #1C6301;
+}
 .raku-search .search-category-title {
   color: #EED891;
-  border-bottom: 1px solid #3A3D4E; }
+  border-bottom: 1px solid #3A3D4E;
+}
 
 /* Categories */
 .raku-category.category-block {
   border: 1px solid #3A3D4E;
   border-bottom: 5px solid #45485d;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+}
 
 .raku-category .category-header {
   background: #212426;
   border-bottom: 1px solid #3A3D4E;
-  color: #83858D; }
+  color: #83858D;
+}
 .raku-category .category-item:not(:last-child) {
-  border-bottom: 1px solid #3A3D4E; }
+  border-bottom: 1px solid #3A3D4E;
+}
 
 /* Programs page template */
 .raku-programs .programs-item-title {
-  border-bottom: 1px solid #3A3D4E; }
+  border-bottom: 1px solid #3A3D4E;
+}
 
 /* Raku headings */
 .raku-h1 {
   background: #212426;
   border: 1px solid #3A3D4E;
-  border-bottom: 3px solid #EED891; }
+  border-bottom: 3px solid #EED891;
+}
 
 .raku-h2 {
-  border-bottom: 3px solid #EED891; }
+  border-bottom: 3px solid #EED891;
+}
 
 .raku-h1, .raku-h2, .raku-h3, .raku-h4, .raku-h5, .raku-h6 {
-  colors: #EED891; }
-  .raku-h1 a, .raku-h2 a, .raku-h3 a, .raku-h4 a, .raku-h5 a, .raku-h6 a {
-    color: #EED891; }
-  .raku-h1 code, .raku-h2 code, .raku-h3 code, .raku-h4 code, .raku-h5 code, .raku-h6 code {
-    color: unset;
-    background: unset;
-    font-weight: 600; }
+  colors: #EED891;
+}
+.raku-h1 a, .raku-h2 a, .raku-h3 a, .raku-h4 a, .raku-h5 a, .raku-h6 a {
+  color: #EED891;
+}
+.raku-h1 code, .raku-h2 code, .raku-h3 code, .raku-h4 code, .raku-h5 code, .raku-h6 code {
+  color: unset;
+  background: unset;
+  font-weight: 600;
+}
 
 .raku-h1 a:hover, .raku-h2 a:hover, .raku-h3 a:hover, .raku-h4 a:hover, .raku-h5 a:hover, .raku-h6 a:hover {
   color: #8DB2EB;
-  text-decoration: none; }
+  text-decoration: none;
+}
 
 .raku-anchor {
-  color: #3A3D4E; }
+  color: #3A3D4E;
+}
 
 a.raku-anchor:hover {
-  color: #8DB2EB; }
+  color: #8DB2EB;
+}
 
 a.raku-anchor,
 .raku-h1 a.raku-anchor, .raku-h2 a.raku-anchor, .raku-h3 a.raku-anchor, .raku-h4 a.raku-anchor, .raku-h5 a.raku-anchor, .raku-h6 a.raku-anchor {
-  color: gainsboro; }
-  a.raku-anchor:hover,
-  .raku-h1 a.raku-anchor:hover, .raku-h2 a.raku-anchor:hover, .raku-h3 a.raku-anchor:hover, .raku-h4 a.raku-anchor:hover, .raku-h5 a.raku-anchor:hover, .raku-h6 a.raku-anchor:hover {
-    color: #8DB2EB; }
+  color: gainsboro;
+}
+a.raku-anchor:hover,
+.raku-h1 a.raku-anchor:hover, .raku-h2 a.raku-anchor:hover, .raku-h3 a.raku-anchor:hover, .raku-h4 a.raku-anchor:hover, .raku-h5 a.raku-anchor:hover, .raku-h6 a.raku-anchor:hover {
+  color: #8DB2EB;
+}
 
 .raku-h1:hover a.raku-anchor, .raku-h2:hover a.raku-anchor, .raku-h3:hover a.raku-anchor, .raku-h4:hover a.raku-anchor, .raku-h5:hover a.raku-anchor, .raku-h6:hover a.raku-anchor {
-  visibility: visible; }
+  visibility: visible;
+}
 
 /* Version note */
 .raku.version-note {
   background: #f2f2f2;
   border: 1px solid #3A3D4E;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+}
 
 .version-note-header {
-  color: #EED891; }
+  color: #EED891;
+}
 
 .table {
   background-color: #1B1D1E;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  color: #e8e8e8; }
+  color: #e8e8e8;
+}
 
 .table thead td, .table thead th {
-  color: #e8e8e8; }
+  color: #e8e8e8;
+}
 
 .table td, .table th {
-  border: 1px solid #3A3D4E; }
+  border: 1px solid #3A3D4E;
+}
 
 .card {
   color: #f5f5f5;
-  background-color: #1B1D1E; }
+  background-color: #1B1D1E;
+}
 
 .raku-about .card {
   border: 1px solid #e5e5e5;
   border-bottom: 3px solid #e5e5e5;
-  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07); }
+  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07);
+}
 
 .raku.tabs {
   background: #282c2e;
   border: 1px solid #3A3D4E;
   border-bottom: unset;
-  color: #f5f5f5; }
-  .raku.tabs ul {
-    border-color: #3A3D4E; }
-  .raku.tabs a {
-    color: #f5f5f5; }
-  .raku.tabs.is-boxed a:hover {
-    background-color: #3A3D4E;
-    color: #e8e8e8; }
-  .raku.tabs.is-boxed a {
-    border-right: 1px solid #3A3D4E; }
-  .raku.tabs.is-boxed li.is-active a {
-    background: #1B1D1E;
-    color: gainsboro;
-    border-top: 1px solid transparent;
-    border-right: 1px solid #3A3D4E;
-    border-bottom: 1px solid #3A3D4E; }
+  color: #f5f5f5;
+}
+.raku.tabs ul {
+  border-color: #3A3D4E;
+}
+.raku.tabs a {
+  color: #f5f5f5;
+}
+.raku.tabs.is-boxed a:hover {
+  background-color: #3A3D4E;
+  color: #e8e8e8;
+}
+.raku.tabs.is-boxed a {
+  border-right: 1px solid #3A3D4E;
+}
+.raku.tabs.is-boxed li.is-active a {
+  background: #1B1D1E;
+  color: gainsboro;
+  border-top: 1px solid transparent;
+  border-right: 1px solid #3A3D4E;
+  border-bottom: 1px solid #3A3D4E;
+}
 
 p > code {
   background-color: #212426;
-  border: 1px solid #2d3134; }
+  border: 1px solid #2d3134;
+}
 
 .raku-sidebar {
   background-color: #212426;
   border-right: 1px solid #3A3D4E;
-  border-bottom: 3px solid #3A3D4E; }
-  .raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
-    color: gainsboro; }
-  .raku-sidebar .menu-list ::marker {
-    color: #EED891; }
-  .raku-sidebar .menu-list li ul {
-    border-left: 1px solid #3A3D4E; }
-  .raku-sidebar .menu-list a {
-    color: #f5f5f5; }
-    .raku-sidebar .menu-list a:hover {
-      background: #3A3D4E;
-      text-decoration: none; }
-    .raku-sidebar .menu-list a.is-active {
-      color: #212426; }
-      .raku-sidebar .menu-list a.is-active:hover {
-        background: #8DB2EB; }
+  border-bottom: 3px solid #3A3D4E;
+}
+.raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
+  color: gainsboro;
+}
+.raku-sidebar .menu-list ::marker {
+  color: #EED891;
+}
+.raku-sidebar .menu-list li ul {
+  border-left: 1px solid #3A3D4E;
+}
+.raku-sidebar .menu-list a {
+  color: #f5f5f5;
+}
+.raku-sidebar .menu-list a:hover {
+  background: #3A3D4E;
+  text-decoration: none;
+}
+.raku-sidebar .menu-list a.is-active {
+  color: #212426;
+}
+.raku-sidebar .menu-list a.is-active:hover {
+  background: #8DB2EB;
+}
 
 .raku-sidebar.category-sidebar li a.is-active {
   background-color: #2f323f;
-  border-left: 3px solid #8DB2EB; }
+  border-left: 3px solid #8DB2EB;
+}
 .raku-sidebar.category-sidebar a.is-active {
-  color: #f5f5f5; }
-  .raku-sidebar.category-sidebar a.is-active:hover {
-    background: #2f323f; }
+  color: #f5f5f5;
+}
+.raku-sidebar.category-sidebar a.is-active:hover {
+  background: #2f323f;
+}
 
 a > code {
-  color: #8DB2EB; }
+  color: #8DB2EB;
+}
 
 code {
   background-color: #212426;
-  color: #EED891; }
+  color: #EED891;
+}
+
+pre.browser-hl {
+  padding: 0;
+}
 
 .raku-code {
   border-bottom: 3px solid #3A3D4E;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  border: 1px solid #3A3D4E; }
-  .raku-code .code-button {
-    background: #8DB2EB;
-    color: #1B1D1E;
-    border: #3A3D4E; }
-    .raku-code .code-button:hover {
-      background-color: #4c86e0; }
-  .raku-code .code-name {
-    color: #EED891; }
-  .raku-code .code-output {
-    background: #282c2e;
-    border-top: 1px solid #3A3D4E; }
-  .raku-code .code-output-title {
-    border-bottom: 1px solid #3A3D4E;
-    color: #EED891; }
-  .raku-code pre {
-    background-color: #212426;
-    color: #f5f5f5; }
+  border: 1px solid #3A3D4E;
+}
+.raku-code label {
+  float: right;
+  font-size: xx-small;
+  font-style: italic;
+}
+.raku-code .code-button {
+  background: #8DB2EB;
+  color: #1B1D1E;
+  border: #3A3D4E;
+}
+.raku-code .code-button:hover {
+  background-color: #4c86e0;
+}
+.raku-code .code-name {
+  color: #EED891;
+}
+.raku-code .code-output {
+  background: #282c2e;
+  border-top: 1px solid #3A3D4E;
+}
+.raku-code .code-output-title {
+  border-bottom: 1px solid #3A3D4E;
+  color: #EED891;
+}
+.raku-code pre {
+  background-color: #212426;
+  color: #f5f5f5;
+}
 
 .hero.error-page .hero-body {
-  background: #1B1D1E; }
+  background: #1B1D1E;
+}
 
 .error-icon .icon {
-  color: #f5f5f5; }
+  color: #f5f5f5;
+}
 
 .hero .error-title {
   color: #f00048;

--- a/Website/plugins/ogdenwebb/css/themes/light.css
+++ b/Website/plugins/ogdenwebb/css/themes/light.css
@@ -1,365 +1,483 @@
 a.button strong {
-  color: #f5f5f5; }
+  color: #f5f5f5;
+}
 
 a.button.is-primary .icon {
-  color: #f5f5f5; }
+  color: #f5f5f5;
+}
 
 /* Collection */
 .raku .container .columns.listing .listf-container {
   border: 1px solid #cccccc;
   border-bottom: 5px solid #d9d9d9;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
-  .raku .container .columns.listing .listf-container .listf-caption {
-    background: #f2f2f2;
-    border-bottom: 1px solid #cccccc;
-    color: #83858D; }
-  .raku .container .columns.listing .listf-container .listf-desc:not(:last-of-type) {
-    border-bottom: 1px solid #cccccc; }
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+}
+.raku .container .columns.listing .listf-container .listf-caption {
+  background: #f2f2f2;
+  border-bottom: 1px solid #cccccc;
+  color: #83858D;
+}
+.raku .container .columns.listing .listf-container .listf-desc:not(:last-of-type) {
+  border-bottom: 1px solid #cccccc;
+}
 
 html {
-  background: #fafafa; }
+  background: #fafafa;
+}
 
 body {
   background: #fafafa;
-  color: #030303; }
+  color: #030303;
+}
 
 .navbar-logo-tm {
-  color: black; }
+  color: black;
+}
 
 /* Site header */
 .navbar {
   background: #f2f2f2;
-  border-bottom: 1px solid #d9d9d9; }
+  border-bottom: 1px solid #d9d9d9;
+}
 
 .navbar a {
-  color: #004FB3; }
-  .navbar a:hover {
-    color: #004FB3;
-    text-decoration: none; }
-  .navbar a:visited {
-    color: #004FB3; }
+  color: #004FB3;
+}
+.navbar a:hover {
+  color: #004FB3;
+  text-decoration: none;
+}
+.navbar a:visited {
+  color: #004FB3;
+}
 
 a.navbar-item:hover {
-  background: #e5e5e5; }
+  background: #e5e5e5;
+}
 
 .navbar-item.has-dropdown:focus .navbar-link, .navbar-item.has-dropdown:hover .navbar-link, .navbar-item.has-dropdown.is-active .navbar-link {
-  background-color: #e5e5e5; }
+  background-color: #e5e5e5;
+}
 
 .navbar-dropdown {
   background-color: #f2f2f2;
-  border-top: 2px solid #cccccc; }
+  border-top: 2px solid #cccccc;
+}
 
 .navbar-link:not(.is-arrowless)::after {
-  border-color: #004FB3; }
+  border-color: #004FB3;
+}
 
 .navbar-divider {
-  background-color: #fafafa; }
+  background-color: #fafafa;
+}
 
 .navbar-menu {
-  background-color: #f2f2f2; }
+  background-color: #f2f2f2;
+}
 
 .navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover,
 a.navbar-item:focus-within, a.navbar-item.is-active, .navbar-link:focus, .navbar-link:focus-within, .navbar-link:hover, .navbar-link.is-active {
   background-color: #e5e5e5;
-  color: #030303; }
+  color: #030303;
+}
 
 #query::placeholder {
-  color: #83858D; }
+  color: #83858D;
+}
 
 .navbar-search-autocomplete {
   color: black;
   background-color: #f5f5f5;
   box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07);
-  border: 1px solid #cccccc; }
-  .navbar-search-autocomplete li {
-    padding: 0 5px; }
-    .navbar-search-autocomplete li.ui-autocomplete-category {
-      color: #A30031;
-      font-weight: 600; }
-    .navbar-search-autocomplete li:hover, .navbar-search-autocomplete li[aria-selected="true"] {
-      cursor: pointer;
-      background-color: #e8e8e8; }
-    .navbar-search-autocomplete li mark {
-      background: transparent;
-      color: #ff7a7a;
-      font-weight: bold; }
-  .navbar-search-autocomplete .autocomplete-result-category {
-    color: #A30031; }
-    .navbar-search-autocomplete .autocomplete-result-category:hover {
-      background-color: unset; }
+  border: 1px solid #cccccc;
+}
+.navbar-search-autocomplete li {
+  padding: 0 5px;
+}
+.navbar-search-autocomplete li.ui-autocomplete-category {
+  color: #A30031;
+  font-weight: 600;
+}
+.navbar-search-autocomplete li:hover, .navbar-search-autocomplete li[aria-selected=true] {
+  cursor: pointer;
+  background-color: #e8e8e8;
+}
+.navbar-search-autocomplete li mark {
+  background: transparent;
+  color: rgb(255, 122, 122);
+  font-weight: bold;
+}
+.navbar-search-autocomplete .autocomplete-result-category {
+  color: #A30031;
+}
+.navbar-search-autocomplete .autocomplete-result-category:hover {
+  background-color: unset;
+}
 
 a {
-  color: #004FB3; }
-  a:hover {
-    color: #004FB3;
-    text-decoration: underline; }
-  a:visited {
-    color: #5503B3; }
+  color: #004FB3;
+}
+a:hover {
+  color: #004FB3;
+  text-decoration: underline;
+}
+a:visited {
+  color: #5503B3;
+}
 
 .button.is-primary {
-  background-color: #004FB3 !important; }
-  .button.is-primary:hover {
-    background-color: #003880 !important;
-    text-decoration: none; }
+  background-color: #004FB3 !important;
+}
+.button.is-primary:hover {
+  background-color: #003880 !important;
+  text-decoration: none;
+}
 
 .label {
-  color: #3A3D4E; }
+  color: #3A3D4E;
+}
 
 .input, .textarea, .select select {
   background-color: #fafafa;
   border-color: #cccccc;
-  color: #030303; }
+  color: #030303;
+}
 
 .input:hover, .textarea:hover, .select select:hover, .is-hovered.input, .is-hovered.textarea, .select select.is-hovered {
-  border-color: #d8d8d8; }
+  border-color: #d8d8d8;
+}
 
 .input:focus, .textarea:focus, .select select:focus, .is-focused.input, .is-focused.textarea, .select select.is-focused, .input:active, .textarea:active, .select select:active, .is-active.input, .is-active.textarea, .select select.is-active {
-  border-color: #004FB3; }
+  border-color: #004FB3;
+}
 
 .select:not(.is-multiple):not(.is-loading)::after {
-  border-color: #004FB3; }
+  border-color: #004FB3;
+}
 
 .select:not(.is-multiple):not(.is-loading):hover::after {
-  border-color: #004FB3; }
+  border-color: #004FB3;
+}
 
 /* Site footer */
 .footer {
   background: #f2f2f2;
   border-top: 1px solid #d9d9d9;
-  z-index: 50; }
+  z-index: 50;
+}
 
 .has-text-primary {
-  color: #004FB3 !important; }
+  color: #004FB3 !important;
+}
 
 .has-text-dark {
-  color: #3A3D4E !important; }
+  color: #3A3D4E !important;
+}
 
 .has-text-danger {
-  color: #A30031 !important; }
+  color: #A30031 !important;
+}
 
 .has-text-danger:hover {
-  color: #A30031 !important; }
+  color: #A30031 !important;
+}
 
 a.has-text-red, a.has-text-red:hover {
-  color: #A30031; }
+  color: #A30031;
+}
 
 .button.is-link {
-  background-color: #004FB3; }
+  background-color: #004FB3;
+}
 
 .button.is-link:hover {
-  background-color: #002d67; }
+  background-color: #002d67;
+}
 
 strong {
-  color: black; }
+  color: black;
+}
 
 .raku.links-block .head {
-  color: #83858D; }
+  color: #83858D;
+}
 .raku.links-block a {
-  color: #004FB3; }
-  .raku.links-block a:hover {
-    color: #003880; }
+  color: #004FB3;
+}
+.raku.links-block a:hover {
+  color: #003880;
+}
 
 /* Hopepage title */
 .hero-body {
   background: linear-gradient(180deg, #051A33 0.2%, #3F103A 1%, #9F0046 82.29%, #B3004F 100%);
-  mix-blend-mode: normal; }
+  mix-blend-mode: normal;
+}
 
 /* Raku page template */
 .raku.page-title {
-  color: #A30031; }
+  color: #A30031;
+}
 
 .raku.page-header .page-edit {
-  color: #83858D; }
-  .raku.page-header .page-edit .page-edit-button {
-    background: #f5f5f5;
-    color: black;
-    border-color: #cccccc; }
-    .raku.page-header .page-edit .page-edit-button:hover {
-      background: #f2f2f2; }
+  color: #83858D;
+}
+.raku.page-header .page-edit .page-edit-button {
+  background: #f5f5f5;
+  color: black;
+  border-color: #cccccc;
+}
+.raku.page-header .page-edit .page-edit-button:hover {
+  background: #f2f2f2;
+}
 
 /* Raku search page */
 .raku-search .search-category {
   background: #f5f5f5;
   border: 1px solid #cccccc;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  color: #030303; }
+  color: #030303;
+}
 .raku-search .search-match {
-  background: #EED891; }
+  background: #EED891;
+}
 .raku-search .search-category-title {
   color: #A30031;
-  border-bottom: 1px solid #cccccc; }
+  border-bottom: 1px solid #cccccc;
+}
 
 /* Categories */
 .raku-category.category-block {
   border: 1px solid #cccccc;
   border-bottom: 5px solid #d9d9d9;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+}
 
 .raku-category .category-header {
   background: #f2f2f2;
   border-bottom: 1px solid #cccccc;
-  color: #83858D; }
+  color: #83858D;
+}
 .raku-category .category-item:not(:last-child) {
-  border-bottom: 1px solid #cccccc; }
+  border-bottom: 1px solid #cccccc;
+}
 
 /* Programs page template */
 .raku-programs .programs-item-title {
-  border-bottom: 1px solid #cccccc; }
+  border-bottom: 1px solid #cccccc;
+}
 
 /* Raku headings */
 .raku-h1 {
   background: #f2f2f2;
   border: 1px solid #cccccc;
-  border-bottom: 3px solid #A30031; }
+  border-bottom: 3px solid #A30031;
+}
 
 .raku-h2 {
-  border-bottom: 3px solid #A30031; }
+  border-bottom: 3px solid #A30031;
+}
 
 .raku-h1, .raku-h2, .raku-h3, .raku-h4, .raku-h5, .raku-h6 {
-  colors: #A30031; }
-  .raku-h1 a, .raku-h2 a, .raku-h3 a, .raku-h4 a, .raku-h5 a, .raku-h6 a {
-    color: #A30031; }
-  .raku-h1 code, .raku-h2 code, .raku-h3 code, .raku-h4 code, .raku-h5 code, .raku-h6 code {
-    color: unset;
-    background: unset;
-    font-weight: 600; }
+  colors: #A30031;
+}
+.raku-h1 a, .raku-h2 a, .raku-h3 a, .raku-h4 a, .raku-h5 a, .raku-h6 a {
+  color: #A30031;
+}
+.raku-h1 code, .raku-h2 code, .raku-h3 code, .raku-h4 code, .raku-h5 code, .raku-h6 code {
+  color: unset;
+  background: unset;
+  font-weight: 600;
+}
 
 .raku-h1 a:hover, .raku-h2 a:hover, .raku-h3 a:hover, .raku-h4 a:hover, .raku-h5 a:hover, .raku-h6 a:hover {
   color: #004FB3;
-  text-decoration: none; }
+  text-decoration: none;
+}
 
 .raku-anchor {
-  color: #3A3D4E; }
+  color: #3A3D4E;
+}
 
 a.raku-anchor:hover {
-  color: #004FB3; }
+  color: #004FB3;
+}
 
 a.raku-anchor,
 .raku-h1 a.raku-anchor, .raku-h2 a.raku-anchor, .raku-h3 a.raku-anchor, .raku-h4 a.raku-anchor, .raku-h5 a.raku-anchor, .raku-h6 a.raku-anchor {
-  color: black; }
-  a.raku-anchor:hover,
-  .raku-h1 a.raku-anchor:hover, .raku-h2 a.raku-anchor:hover, .raku-h3 a.raku-anchor:hover, .raku-h4 a.raku-anchor:hover, .raku-h5 a.raku-anchor:hover, .raku-h6 a.raku-anchor:hover {
-    color: #004FB3; }
+  color: black;
+}
+a.raku-anchor:hover,
+.raku-h1 a.raku-anchor:hover, .raku-h2 a.raku-anchor:hover, .raku-h3 a.raku-anchor:hover, .raku-h4 a.raku-anchor:hover, .raku-h5 a.raku-anchor:hover, .raku-h6 a.raku-anchor:hover {
+  color: #004FB3;
+}
 
 .raku-h1:hover a.raku-anchor, .raku-h2:hover a.raku-anchor, .raku-h3:hover a.raku-anchor, .raku-h4:hover a.raku-anchor, .raku-h5:hover a.raku-anchor, .raku-h6:hover a.raku-anchor {
-  visibility: visible; }
+  visibility: visible;
+}
 
 /* Version note */
 .raku.version-note {
   background: #f2f2f2;
   border: 1px solid #cccccc;
-  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07); }
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+}
 
 .version-note-header {
-  color: #A30031; }
+  color: #A30031;
+}
 
 .table {
   background-color: #fafafa;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  color: black; }
+  color: black;
+}
 
 .table thead td, .table thead th {
-  color: #3A3D4E; }
+  color: #3A3D4E;
+}
 
 .table td, .table th {
-  border: 1px solid #cccccc; }
+  border: 1px solid #cccccc;
+}
 
 .card {
   color: #030303;
-  background-color: #fafafa; }
+  background-color: #fafafa;
+}
 
 .raku-about .card {
   border: 1px solid #e5e5e5;
   border-bottom: 3px solid #e5e5e5;
-  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07); }
+  box-shadow: 1px 2px 2px 0px rgba(0, 0, 0, 0.07);
+}
 
 .raku.tabs {
   background: #f5f5f5;
   border: 1px solid #cccccc;
   border-bottom: unset;
-  color: #030303; }
-  .raku.tabs ul {
-    border-color: #cccccc; }
-  .raku.tabs a {
-    color: #030303; }
-  .raku.tabs.is-boxed a:hover {
-    background-color: #3A3D4E;
-    color: black; }
-  .raku.tabs.is-boxed a {
-    border-right: 1px solid #cccccc; }
-  .raku.tabs.is-boxed li.is-active a {
-    background: #fafafa;
-    color: black;
-    border-top: 1px solid transparent;
-    border-right: 1px solid #cccccc;
-    border-bottom: 1px solid #cccccc; }
+  color: #030303;
+}
+.raku.tabs ul {
+  border-color: #cccccc;
+}
+.raku.tabs a {
+  color: #030303;
+}
+.raku.tabs.is-boxed a:hover {
+  background-color: #3A3D4E;
+  color: black;
+}
+.raku.tabs.is-boxed a {
+  border-right: 1px solid #cccccc;
+}
+.raku.tabs.is-boxed li.is-active a {
+  background: #fafafa;
+  color: black;
+  border-top: 1px solid transparent;
+  border-right: 1px solid #cccccc;
+  border-bottom: 1px solid #cccccc;
+}
 
 p > code {
   background-color: #fafafa;
-  border: 1px solid white; }
+  border: 1px solid white;
+}
 
 .raku-sidebar {
   background-color: #f2f2f2;
   border-right: 1px solid #cccccc;
-  border-bottom: 3px solid #cccccc; }
-  .raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
-    color: black; }
-  .raku-sidebar .menu-list ::marker {
-    color: #A30031; }
-  .raku-sidebar .menu-list li ul {
-    border-left: 1px solid #cccccc; }
-  .raku-sidebar .menu-list a {
-    color: #030303; }
-    .raku-sidebar .menu-list a:hover {
-      background: #d8d8d8;
-      text-decoration: none; }
-    .raku-sidebar .menu-list a.is-active {
-      color: #f7f7f7; }
-      .raku-sidebar .menu-list a.is-active:hover {
-        background: #004FB3; }
+  border-bottom: 3px solid #cccccc;
+}
+.raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
+  color: black;
+}
+.raku-sidebar .menu-list ::marker {
+  color: #A30031;
+}
+.raku-sidebar .menu-list li ul {
+  border-left: 1px solid #cccccc;
+}
+.raku-sidebar .menu-list a {
+  color: #030303;
+}
+.raku-sidebar .menu-list a:hover {
+  background: #d8d8d8;
+  text-decoration: none;
+}
+.raku-sidebar .menu-list a.is-active {
+  color: #f7f7f7;
+}
+.raku-sidebar .menu-list a.is-active:hover {
+  background: #004FB3;
+}
 
 .raku-sidebar.category-sidebar li a.is-active {
   background-color: #d8d8d8;
-  border-left: 3px solid #004FB3; }
+  border-left: 3px solid #004FB3;
+}
 .raku-sidebar.category-sidebar a.is-active {
-  color: #030303; }
-  .raku-sidebar.category-sidebar a.is-active:hover {
-    background: #d8d8d8; }
+  color: #030303;
+}
+.raku-sidebar.category-sidebar a.is-active:hover {
+  background: #d8d8d8;
+}
 
 a > code {
-  color: #004FB3; }
+  color: #004FB3;
+}
 
 code {
   background-color: #f2f2f2;
-  color: #A30031; }
+  color: #A30031;
+}
+
+pre.browser-hl {
+  padding: 0;
+}
 
 .raku-code {
   border-bottom: 3px solid #cccccc;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
-  border: 1px solid #cccccc; }
-  .raku-code .code-button {
-    background: #004FB3;
-    color: #fafafa;
-    border: #cccccc; }
-    .raku-code .code-button:hover {
-      background-color: #003880; }
-  .raku-code .code-name {
-    color: #A30031; }
-  .raku-code .code-output {
-    background: #f5f5f5;
-    border-top: 1px solid #cccccc; }
-  .raku-code .code-output-title {
-    border-bottom: 1px solid #cccccc;
-    color: #A30031; }
-  .raku-code pre {
-    background-color: #fafafa;
-    color: #030303; }
+  border: 1px solid #cccccc;
+}
+.raku-code label {
+  float: right;
+  font-size: xx-small;
+  font-style: italic;
+}
+.raku-code .code-button {
+  background: #004FB3;
+  color: #fafafa;
+  border: #cccccc;
+}
+.raku-code .code-button:hover {
+  background-color: #003880;
+}
+.raku-code .code-name {
+  color: #A30031;
+}
+.raku-code .code-output {
+  background: #f5f5f5;
+  border-top: 1px solid #cccccc;
+}
+.raku-code .code-output-title {
+  border-bottom: 1px solid #cccccc;
+  color: #A30031;
+}
+.raku-code pre {
+  background-color: #fafafa;
+  color: #030303;
+}
 
 .hero.error-page .hero-body {
-  background: #fafafa; }
+  background: #fafafa;
+}
 
 .error-icon .icon {
-  color: #030303; }
+  color: #030303;
+}
 
 .hero .error-title {
   color: #A30031;

--- a/Website/plugins/ogdenwebb/scss/themes/_themes-template-common.scss
+++ b/Website/plugins/ogdenwebb/scss/themes/_themes-template-common.scss
@@ -498,10 +498,18 @@ code {
   color: $heading;
 }
 
+pre.browser-hl { padding: 0; }
+
 .raku-code {
   border-bottom: 3px solid $border;
   box-shadow: $shadow-below;
   border: 1px solid $border;
+
+  label {
+    float: right;
+    font-size: xx-small;
+    font-style: italic;
+  }
 
   .code-button {
     background: $primary;


### PR DESCRIPTION
Fixes #199 (which was reduced IMHO to highlighting other languages properly)
@lizmat @cfa @2colours @Altai-man @AlexDaniel  I think you have all commented on syntax highlighting at some point. 

Prior to this Patch, all code in code-blocks was sent to the Raku highlighter. Since all block codes are now labelled with a `:lang`, the renderer should send other languages to an appropriate highlighter.

Rather than re-invent the wheel, this Patch pulls in [Highlight-js](https://highlightjs.org/) to handle all languages other than Raku. (A Raku plugin for Highlight-js was started but not finished).

If a code-block has a `:lang<xxx>` where xxx is not Raku or Rakudoc, then Highlight-js is invoked to highlight it. Otherwise, the existing Raku syntax highlighter is used.

The new setup is running in new-raku. To see the effect try [Haskell](https://new-raku.finanalyst.org/language/haskell-to-p6) or [Python](https://new-raku.finanalyst.org/language/py-nutshell)

There are caveats: Not all of the `:lang` options used in `Raku/Doc/doc` sources match the common languages for which highlight-js is bundled. For example, `:lang<pseudo>` and `:lang<shell>`

There are two work-arounds:
1. change the source to match a language that highlights-js bundles
2. find a non-default language that highlights-js supports, open a new ticket here, and it can be added to the stylesheets..