### PR TITLE
Better handling of unknown languages for hiliting / styling of copy b…

### DIFF
--- a/Website/plugins/hiliter/_highlighting.scss
+++ b/Website/plugins/hiliter/_highlighting.scss
@@ -10,9 +10,12 @@
 
   button.copy-code {
     cursor: pointer;
-    opacity: 0.5;
+    opacity: 0;
     padding: 0 0.25rem 0.25rem 0.25rem;
     position: absolute;
+  }
+  &:hover button.copy-code {
+    opacity: 0.5;
   }
 
   label {

--- a/Website/plugins/hiliter/hiliter-dark.css
+++ b/Website/plugins/hiliter/hiliter-dark.css
@@ -74,9 +74,12 @@ textarea::selection {
 }
 .raku-code button.copy-code {
   cursor: pointer;
-  opacity: 0.5;
+  opacity: 0;
   padding: 0 0.25rem 0.25rem 0.25rem;
   position: absolute;
+}
+.raku-code:hover button.copy-code {
+  opacity: 0.5;
 }
 .raku-code label {
   float: right;

--- a/Website/plugins/hiliter/hiliter-light.css
+++ b/Website/plugins/hiliter/hiliter-light.css
@@ -51,9 +51,12 @@
 }
 .raku-code button.copy-code {
   cursor: pointer;
-  opacity: 0.5;
+  opacity: 0;
   padding: 0 0.25rem 0.25rem 0.25rem;
   position: absolute;
+}
+.raku-code:hover button.copy-code {
+  opacity: 0.5;
 }
 .raku-code label {
   float: right;

--- a/Website/plugins/hiliter/template.raku
+++ b/Website/plugins/hiliter/template.raku
@@ -46,6 +46,44 @@ sub set-highlight-basedir( --> Str ) {
 sub test-highlighter( Str $hilite-path --> Bool ) {
     ?("$hilite-path/package-lock.json".IO.f and "$hilite-path/atom-language-perl6".IO.d)
 }
+
+my %hilight-langs = %(
+    'HTML' => 'xml',
+    'XML' => 'xml',
+    'Bash' => 'bash',
+    'C++' => 'cpp',
+    'C#' => 'csharp',
+    'CSS' => 'css',
+    'Markdown' => 'markdown',
+    'Diff' => 'diff',
+    'Ruby' => 'ruby',
+    'Go' => 'go',
+    'TOML, also INI' => 'ini',
+    'Java' => 'java',
+    'JavaScript' => 'javascript',
+    'JSON' => 'json',
+    'Kotlin' => 'kotlin',
+    'Less' => 'less',
+    'Lua' => 'lua',
+    'Makefile' => 'makefile',
+    'Perl' => 'perl',
+    'Objective-C' => 'objectivec',
+    'PHP' => 'php',
+    'PHP Template' => 'php-template',
+    'Python' => 'python',
+    'Python REPL' => 'python-repl',
+    'R' => 'r',
+    'Rust' => 'rust',
+    'SCSS' => 'scss',
+    'Shell Session' => 'shell',
+    'SQL' => 'sql',
+    'Swift' => 'swift',
+    'YAML' => 'yaml',
+    'TypeScript' => 'typescript',
+    'Visual Basic .NET' => 'vbnet',
+    'Haskell' => 'haskell',
+);
+
 # Callable returns a hash
 %(
     block-code => sub (%prm, %tml) {
@@ -56,13 +94,31 @@ sub test-highlighter( Str $hilite-path --> Bool ) {
         # otherwise pass through Raku syntax highlighter.
         my $code;
         my $syntax-label;
-        if %prm<lang>:exists and %prm<lang> ne any(<raku rakudoc Raku Rakudoc>) {
-            $syntax-label = %prm<lang>.tc ~  ' highlighting by highlight-js';
-            $code = qq:to/NOTRAKU/;
-                <pre class="browser-hl"><code class="language-{ %prm<lang> }">{ %prm<contents> }</code></pre>
-                NOTRAKU
+        if %prm<lang>:exists {
+            if %prm<lang> ~~ any( %hilight-langs.keys ) {
+                $syntax-label = %prm<lang>.tc ~  ' highlighting by highlight-js';
+                $code = qq:to/HILIGHT/;
+                    <pre class="browser-hl">
+                    <code class="language-{ %hilight-langs{ %prm<lang> } }">{ %prm<contents> }
+                    </code></pre>
+                    HILIGHT
             }
+            elsif %prm<lang> ~~ any( <Raku Rakudoc raku rakudoc> ) {
+                $syntax-label = %prm<lang>.tc ~ ' highlighting';
+            }
+            else {
+                $syntax-label = "｢{ %prm<lang> }｣ without highlighting";
+                $code = qq:to/NOHIGHS/;
+                    <pre class="nohighlights">
+                    { %prm<contents> }
+                    </pre>
+                    NOHIGHS
+            }
+        }
         else {
+            $syntax-label = 'Raku highlighting';
+        }
+        without $code {
             my @tokens;
             my $t;
             my $parsed = %prm<contents> ~~ / ^ .*? [<marker> .*?]+ $/;
@@ -84,11 +140,11 @@ sub test-highlighter( Str $hilite-path --> Bool ) {
             $code .= subst( / "\xFF\xFF" /, { @tokens.shift }, :g );
         }
         qq[
-                <div class="raku-code raku-lang">
-                    <button class="copy-code" title="Copy code"><i class="far fa-clipboard"></i></button>
-                    <label>$syntax-label\</label>
-                    <div>$code\</div>
-                </div>
-            ]
+            <div class="raku-code raku-lang">
+                <button class="copy-code" title="Copy code"><i class="far fa-clipboard"></i></button>
+                <label>$syntax-label\</label>
+                <div>$code\</div>
+            </div>
+        ]
     },
 )


### PR DESCRIPTION
…utton

Hilight-js bundles 32 common languages + Haskell.
Our highlighter handles Raku and Rakudoc
Some sources have `=code :lang<XXX>` where XXX is not in set above. The formatting is messed up. If a lang is not set, then its Raku. If a lang is in set above, then highlights-js. If a lang neither, then no highlighting. Github had code copy buttons that only appear when source is hovered over. Restyled button to do the same.