### PR TITLE
Make unique ids for Headings

### DIFF
--- a/Website/plugins/secondaries/gen-secondaries.raku
+++ b/Website/plugins/secondaries/gen-secondaries.raku
@@ -118,8 +118,8 @@ sub (ProcessedPod $pp, %processed, %options) {
                 @subkind.append: .<subkind>;
                 @category.append: .<category>;
                 @sources.push: .<source>;
-                my $target = $kind ~ .<subkind>;
-                my $text = 'From ' ~ .<source>;
+                my $target = .<source> ~ $kind ~ .<subkind>;
+                my $text = 'In ' ~ .<source>;
                 @toc.push: %( :1level, :$text, :$target );
                 $body ~= %templates<heading>.(%(
                   :1level,


### PR DESCRIPTION
ToCs were recently added to Secondary (composite) files, but the targets were not unique, so ToC lines were only 'hitting' the first heading. Patch makes id's Unique.