### PR TITLE
fixes issues #275 and #279

### DIFF
--- a/Website/plugins/secondaries/gen-secondaries.raku
+++ b/Website/plugins/secondaries/gen-secondaries.raku
@@ -17,6 +17,9 @@ sub (ProcessedPod $pp, %processed, %options) {
         (.+?)
         <?before
             "<h$level"
+            | "<h{ $level - 1 }"
+            | "<h{ $level - 2 }"
+            | "<h{ $level - 3 }"
             | '</section'
             | '</body'
             | $


### PR DESCRIPTION
both issues stem from the same problem: text is included in a secondary file from a primary file from a level2 heading. But the section is terminated by a level1 heading, not a level2 heading. The fix is to look for leveln, n-1, n-2, n-3 headings. By specification of RakuDoc, only headings upto level 4 are distinguished. The regex should be made more generic, perhpas by recursion on level, decrementing it to 0, but I don't know how.