### PR TITLE
move ToC from ogdenwebb to filtered-toc plugin

### DIFF
--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -4,7 +4,9 @@
     plugins-required => %(
         :setup<raku-doc-setup>,
         :render<
-            hiliter font-awesome ogdenwebb camelia simple-extras listfiles images deprecate-span filterlines
+            hiliter font-awesome ogdenwebb
+            filtered-toc
+            camelia simple-extras listfiles images deprecate-span filterlines
             tablemanager secondaries typegraph generated
             search-bar link-error-test
             gather-js-jq gather-css

--- a/Website/plugins/filtered-toc/README.rakudoc
+++ b/Website/plugins/filtered-toc/README.rakudoc
@@ -1,0 +1,13 @@
+=begin pod
+=TITLE filtered-toc is for Raku Documentation site
+
+This Collection plugin renders the TOC and Index (glossary) for a sidebar in
+the Raku Documentation suite.
+
+It replaces the 'Raku-toc-block' template.
+
+=head1 Custom blocks
+
+=head1 Templates
+
+=end pod

--- a/Website/plugins/filtered-toc/config.raku
+++ b/Website/plugins/filtered-toc/config.raku
@@ -1,0 +1,18 @@
+%(
+	:auth<collection>,
+	:authors(
+		"finanalyst",
+	),
+	:custom-raku(),
+	:license<Artistic-2.0>,
+	:name<filtered-toc>,
+	:render,
+	:template-raku<filtered-toc-template.raku>,
+	:js-script<filtered-toc.js>,
+	:add-css<css/filtered-toc-dark.css css/filtered-toc-light.css>,
+	:jquery-link(
+		['src="https://rawgit.com/farzher/fuzzysort/master/fuzzysort.js"', 1],
+	),
+	:information<jquery-link>,
+	:version<0.1.2>,
+)

--- a/Website/plugins/filtered-toc/css/filtered-toc-dark.css
+++ b/Website/plugins/filtered-toc/css/filtered-toc-dark.css
@@ -1,0 +1,40 @@
+.raku-sidebar {
+  background-color: #212426;
+  border-right: 1px solid #3A3D4E;
+  border-bottom: 3px solid #3A3D4E;
+}
+.raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
+  color: gainsboro;
+}
+.raku-sidebar .menu-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+}
+.raku-sidebar .menu-list ::marker {
+  color: #EED891;
+}
+.raku-sidebar .menu-list > ul {
+  margin-left: 1em;
+  list-style: circle;
+}
+.raku-sidebar .menu-list > ul > ul {
+  margin-left: 1em;
+  list-style: square;
+}
+.raku-sidebar .menu-list > ul > ul > ul {
+  margin-left: 1em;
+  list-style: disclosure-closed;
+}
+.raku-sidebar .menu-list a {
+  color: #f5f5f5;
+}
+.raku-sidebar .menu-list a:hover {
+  background: #3A3D4E;
+  text-decoration: none;
+}
+.raku-sidebar .menu-list a.is-active {
+  color: #212426;
+}
+.raku-sidebar .menu-list a.is-active:hover {
+  background: #004FB3;
+}

--- a/Website/plugins/filtered-toc/css/filtered-toc-light.css
+++ b/Website/plugins/filtered-toc/css/filtered-toc-light.css
@@ -1,0 +1,40 @@
+.raku-sidebar {
+  background-color: #f2f2f2;
+  border-right: 1px solid #cccccc;
+  border-bottom: 3px solid #cccccc;
+}
+.raku-sidebar .input::placeholder, .raku-sidebar .textarea::placeholder, .raku-sidebar .select select::placeholder {
+  color: black;
+}
+.raku-sidebar .menu-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+}
+.raku-sidebar .menu-list ::marker {
+  color: #A30031;
+}
+.raku-sidebar .menu-list > ul {
+  margin-left: 1em;
+  list-style: circle;
+}
+.raku-sidebar .menu-list > ul > ul {
+  margin-left: 1em;
+  list-style: square;
+}
+.raku-sidebar .menu-list > ul > ul > ul {
+  margin-left: 1em;
+  list-style: disclosure-closed;
+}
+.raku-sidebar .menu-list a {
+  color: #030303;
+}
+.raku-sidebar .menu-list a:hover {
+  background: #d8d8d8;
+  text-decoration: none;
+}
+.raku-sidebar .menu-list a.is-active {
+  color: #f7f7f7;
+}
+.raku-sidebar .menu-list a.is-active:hover {
+  background: #004FB3;
+}

--- a/Website/plugins/filtered-toc/filtered-toc-template.raku
+++ b/Website/plugins/filtered-toc/filtered-toc-template.raku
@@ -1,0 +1,33 @@
+#!/usr/bin/env raku
+use v6.d;
+%(
+    raku-toc-block => sub (%prm, %tml) {
+        if %prm<toc> {
+            qq:to/TOC/
+              <div class="field">
+                <label class="label has-text-centered">Table of Contents</label>
+                <div class="control has-icons-right">
+                  <input id="toc-filter" class="input" type="text" placeholder="Filter">
+                  <span class="icon is-right has-text-grey">
+                    <i class="fas fa-search is-medium"></i>
+                  </span>
+                </div>
+              </div>
+              <div class="raku-sidebar">
+                <aside id="toc-menu" class="menu">
+                { %prm<toc> }
+                </aside>
+              </div>
+            TOC
+        }
+        else {
+            qq:to/TOC/
+                <input type="checkbox" id="No-TOC"
+                    checked="checked"
+                    style="visibility: collapse;">
+                </input>
+                <div class="content">No table of contents available</div>
+            TOC
+        }
+    },
+);

--- a/Website/plugins/filtered-toc/filtered-toc.js
+++ b/Website/plugins/filtered-toc/filtered-toc.js
@@ -1,0 +1,29 @@
+$(document).ready( function() {
+    var originalTOC = $('#toc-menu').html();
+    $("#toc-filter").keyup(function () {
+        $('#toc-menu').html(originalTOC);
+        var searchText = this.value.toLowerCase();
+        if (searchText.length === 0) return;
+        var $menuListElements = $('.menu-list').find("li");
+        var $matchingListElements = $menuListElements.filter(function (i, li) {
+            var listItemHTML = li.firstChild.innerHTML;
+            var fuzzyRes = fuzzysort.go(searchText, [listItemHTML])[0];
+            if (fuzzyRes === undefined || fuzzyRes.score < -8000) {
+                return false;
+            }
+            var res = fuzzysort.highlight(fuzzyRes);
+            if (res !== null) {
+                var nodes = $(li).contents().filter(function (i, node) { return node.nodeType == 1; });
+                nodes[0].innerHTML = res;
+                return true;
+            } else {
+                return false;
+            }
+        });
+        $menuListElements.hide();
+        $($matchingListElements).each(function (i, elem) {
+            $(elem).parents('li').show();
+        });
+        $matchingListElements.show();
+    });
+});

--- a/Website/plugins/filtered-toc/scss/_filtered-toc-common.scss
+++ b/Website/plugins/filtered-toc/scss/_filtered-toc-common.scss
@@ -1,0 +1,49 @@
+$size-4: 1.5rem; // 24px
+$weight-semibold: 600;
+$weight-bold: 700;
+
+.raku-sidebar {
+  background-color: $scheme-main-bis;
+  border-right: 1px solid $border;
+  border-bottom: 3px solid $border;
+
+  .input::placeholder, .textarea::placeholder, .select select::placeholder {
+    color: $text-dark;
+  }
+
+  .menu-list {
+    ::marker {
+      color: $heading;
+    }
+
+    list-style: disc;
+    padding-left: $size-4;
+    > ul {
+        margin-left: 1em;
+        list-style: circle;
+        > ul {
+            margin-left: 1em;
+            list-style: square;
+            > ul {
+                margin-left: 1em;
+                list-style: disclosure-closed;
+            }
+        }
+    }
+
+    a {
+      color: $text;
+      &:hover {
+        background: $menu-item-hover-background-color;
+        text-decoration: none;
+      }
+      &.is-active {
+        color: $text-invert;
+        &:hover {
+          background: $primary;
+        }
+      }
+    }
+  }
+}
+

--- a/Website/plugins/filtered-toc/scss/_themes-colors.scss
+++ b/Website/plugins/filtered-toc/scss/_themes-colors.scss
@@ -1,0 +1,25 @@
+// Common theme colors
+
+$black:         #030303;
+$black-bis:     #1B1D1E;
+$black-ter:     #212426;
+
+$grey-darker:   #3A3D4E;
+$grey-dark:     #83858D;
+$grey:          #cccccc;
+$grey-light:    #d8d8d8;
+$grey-lighter:  #e5e5e5;
+$grey-lightest: #f2f2f2;
+
+$white-ter:     #f5f5f5;
+$white-bis:     #f7f7f7;
+$white:         #fafafa;
+
+$orange:       hsl(14,  100%, 53%);
+$yellow:       #EED891;
+$green:        #1C6301;
+$turquoise:    #005C43;
+$cyan:         hsl(204, 71%,  53%);
+$blue:         #004FB3;
+$purple:       #5503B3;
+$red:          #A30031;

--- a/Website/plugins/filtered-toc/scss/filtered-toc-dark.scss
+++ b/Website/plugins/filtered-toc/scss/filtered-toc-dark.scss
@@ -1,0 +1,11 @@
+@import "_themes-colors.scss";
+$scheme-main-bis: $black-ter;
+$border: $grey-darker;
+$text: $white-ter;
+$text-dark: darken($text, 10);
+$text-invert: $black-ter;
+$heading: $yellow;
+$menu-item-hover-background-color: $grey-darker;
+$primary:  $blue;
+
+@import "_filtered-toc-common.scss";

--- a/Website/plugins/filtered-toc/scss/filtered-toc-light.scss
+++ b/Website/plugins/filtered-toc/scss/filtered-toc-light.scss
@@ -1,0 +1,11 @@
+@import "_themes-colors.scss";
+$scheme-main-bis: $grey-lightest;
+$border: $grey;
+$text: $black;
+$text-dark: darken($text, 10);
+$text-invert: $white-bis;
+$heading: $red;
+$menu-item-hover-background-color: $grey-light;
+$primary:  $blue;
+
+@import "_filtered-toc-common.scss";

--- a/Website/plugins/filtered-toc/t/05-basic.rakutest
+++ b/Website/plugins/filtered-toc/t/05-basic.rakutest
@@ -1,0 +1,5 @@
+use v6.d;
+use Test;
+use Collection::TestPlugin;
+test-plugin();
+done-testing

--- a/Website/plugins/ogdenwebb/core.js
+++ b/Website/plugins/ogdenwebb/core.js
@@ -73,8 +73,6 @@ $(document).ready( function() {
 });
 
 $(document).ready( function() {
-    // trigger the highlighter
-    hljs.highlightAll();
     var sidebar_is_shown = localStorage.getItem('sidebarIsShown');;
     if (sidebar_is_shown === null) {
         // If the screen is not wide enough and the sidebar overlaps content -
@@ -104,34 +102,6 @@ $(document).ready( function() {
             $(icon_container).html(FontAwesome.icon({prefix: 'fas', iconName: 'chevron-right'}).html[0]);
         }
     };
-
-    var originalTOC = $('#toc-menu').html();
-    $("#toc-filter").keyup(function () {
-        $('#toc-menu').html(originalTOC);
-        var searchText = this.value.toLowerCase();
-        if (searchText.length === 0) return;
-        var $menuListElements = $('.menu-list').find("li");
-        var $matchingListElements = $menuListElements.filter(function (i, li) {
-            var listItemHTML = li.firstChild.innerHTML;
-            var fuzzyRes = fuzzysort.go(searchText, [listItemHTML])[0];
-            if (fuzzyRes === undefined || fuzzyRes.score < -8000) {
-                return false;
-            }
-            var res = fuzzysort.highlight(fuzzyRes);
-            if (res !== null) {
-                var nodes = $(li).contents().filter(function (i, node) { return node.nodeType == 1; });
-                nodes[0].innerHTML = res;
-                return true;
-            } else {
-                return false;
-            }
-        });
-        $menuListElements.hide();
-        $($matchingListElements).each(function (i, elem) {
-            $(elem).parents('li').show();
-        });
-        $matchingListElements.show();
-    });
     // copy code block to clipboard adapted from solution at
     // https://stackoverflow.com/questions/34191780/javascript-copy-string-to-clipboard-as-text-html
     // if behaviour problems with different browsers add stylesheet code from that solution.
@@ -151,4 +121,3 @@ $(document).ready( function() {
         document.body.removeChild(container);
     });
 });
-


### PR DESCRIPTION
This patch structurally has no effect on the build, but makes styling of the ToC easier. It will make the change to a different HTML setup easier. Visually, there **is** a change to the ToC. Four levels of heading are distinguished, instead of two.