### PR TITLE
completes issue #294

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -8,9 +8,10 @@
 
     root * /usr/share/caddy
 
-    map {path} {npath} {
-        import /usr/share/caddy/assets/prettyurls
-    }
+  map {path} {npath} {
+    import /usr/share/caddy/assets/deprecated-urls
+    import /usr/share/caddy/assets/prettyurls
+  }
 
     route {
         error /hashed* 404

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [Building the documentation locally](#building-the-documentation-locally)  
 [Options for build-site](#options-for-build-site)  
 [Directory naming](#directory-naming)  
+[Deprecated URLs](#deprecated-urls)  
 [Plugins and Templates](#plugins-and-templates)  
 [Working on Collection plugins](#working-on-collection-plugins)  
 [Deployment of website](#deployment-of-website)  
@@ -71,6 +72,9 @@ For this reason, documentation sources for this repo are in `repo_docs` and the 
 This may eventually prove unnecessary, but it is a reasonable convention is kept for the time being.
 
 Further, in the future, another Mode may be useful in this repository in due course that generates an epub output.
+
+# Deprecated URLs
+Occasionally, file names change. This would cause a 404 error if an external webpage, e.g. someone's blog, has a link to a changed file name. To overcome this, a mapping file `deprecated-urls` is kept in `Website/plugins/raku-doc-setup`. The plugin adds this file to ``rendered_html/assets/``, and the Caddy system rewrites routes from the deprecated name to the working alternative.
 
 # Plugins and Templates
 Collection is designed to handle multiple Modes, and for plugins to be contributed in a similar way to Raku Modules. However, for the Raku documentation system, it seems pragmatic at the start for the plugins to be tailored specifically for this site.
@@ -151,4 +155,4 @@ Deployment to Production is similar, but not automatic. The site maintainer acti
 
 
 ----
-Rendered from README at 2023-04-13T17:56:32Z
+Rendered from README at 2023-09-10T19:18:22Z

--- a/Website/configs/01-config.raku
+++ b/Website/configs/01-config.raku
@@ -1,7 +1,7 @@
 %(
     :mode-sources<structure-sources>, # content for the website structure
     :mode-cache<structure-cache>, # cache for the above
-    :mode-ignore<search.rakudoc error-report.rakudoc>, # files to ignore
+    :mode-ignore<search.rakudoc error-report.rakudoc language.rakudoc programs.rakudoc>, # files to ignore
     :mode-obtain(), # not a remote repository
     :mode-refresh(), # ditto
     :mode-extensions<rakudoc pod6>, # only use these for content

--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -12,7 +12,7 @@
             gather-js-jq gather-css
         >,
         :report<link-plugin-assets-report>,
-        :transfer<secondaries gather-js-jq gather-css images search-bar >,
+        :transfer<secondaries gather-js-jq gather-css images search-bar raku-doc-setup >,
         :compilation<secondaries listfiles search-bar link-error-test>,
         :completion<cro-app>,
     ),

--- a/Website/configs/03-plugin-options.raku
+++ b/Website/configs/03-plugin-options.raku
@@ -3,6 +3,7 @@
         cro-app => %(
             :port<30000>,
             :host<0.0.0.0>,
+            :url-map<assets/prettyurls assets/deprecated-urls>,
         ),
         link-error-test => %(
             :no-remote,

--- a/Website/plugins/cro-app/cro-run.raku
+++ b/Website/plugins/cro-app/cro-run.raku
@@ -12,7 +12,7 @@ sub ( $destination, $landing, $ext, %p-config, %options ) {
     my $port = %p-config<cro-app><port> // %config<port>;
     my %map;
     my @urls;
-    with %p-config<cro-app><url-map> {
+    for %p-config<cro-app><url-map>.list {
         if ("$destination/$_".IO ~~ :e & :f) {
             for "$destination/$_".IO.lines {
                 if m/ \" ~ \" (.+?) \s+ \" ~ \" (.+) / {

--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -64,7 +64,6 @@ use v6.d;
     'left-bar-toggle' => sub (%prm, %tml ) {
       q:to/BLOCK/
         <div class="left-bar-toggle" title="Toggle Table of Contents (Ctl-a)">
-            <i class="fas fa-cogs"></i>
             <label class="chyronToggle left">
                 <input id="navbar-left-toggle" type="checkbox">
                 <span class="text">Contents</span>
@@ -80,7 +79,6 @@ use v6.d;
                   <input id="navbar-right-toggle" type="checkbox">
                   <span class="text">Search</span>
                 </label>
-                <i class="fas fa-cogs"></i>
             </div>
             BLOCK
        }
@@ -107,23 +105,26 @@ use v6.d;
         qq:to/BLOCK/
           <div id="navMenu" class="navbar-menu">
             <div class="navbar-start">
-                <a class="navbar-item" href="/language">
-                    Language
+                <a class="navbar-item" href="/introduction" title="Getting started, Tutorials, Migration guides">
+                    Introduction
                 </a>
-                <a class="navbar-item" href="/types">
+                <a class="navbar-item" href="/reference" title="Fundamentals, General reference">
+                    Reference
+                </a>
+                <a class="navbar-item" href="/miscellaneous" title="Programs, Experimental">
+                    Miscellaneous
+                </a>
+                <a class="navbar-item" href="/types" title="The core types (classes) available">
                     Types
                 </a>
-                <a class="navbar-item" href="/routines">
+                <a class="navbar-item" href="/routines" title="Searchable table of routines">
                     Routines
                 </a>
-                <a class="navbar-item" href="/programs">
-                    Programs
+                <a class="navbar-item" href="https://raku.org" title="Home page for community">
+                    Raku™
                 </a>
-                <a class="navbar-item" href="https://raku.org">
-                    Raku™ Homepage
-                </a>
-                <a class="navbar-item" href="https://kiwiirc.com/client/irc.libera.chat/#raku">
-                    Chat with us
+                <a class="navbar-item" href="https://kiwiirc.com/client/irc.libera.chat/#raku" title="IRC live logs">
+                    Chat
                 </a>
                 <div class="navbar-item has-dropdown is-hoverable">
                   <a class="navbar-link">

--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -123,7 +123,7 @@ use v6.d;
                 <a class="navbar-item" href="https://raku.org" title="Home page for community">
                     Raku™
                 </a>
-                <a class="navbar-item" href="https://kiwiirc.com/client/irc.libera.chat/#raku" title="IRC live logs">
+                <a class="navbar-item" href="https://kiwiirc.com/client/irc.libera.chat/#raku" title="IRC live chat">
                     Chat
                 </a>
                 <div class="navbar-item has-dropdown is-hoverable">

--- a/Website/plugins/raku-doc-setup/README.rakudoc
+++ b/Website/plugins/raku-doc-setup/README.rakudoc
@@ -5,4 +5,6 @@ The plugin is for the setup milestone
 
 Changes source filename starting 'Language', 'Type', 'Program' to lowercase.
 
+Adds a 'deprecate-urls' file to the assets directory for files whose name is changed.
+
 =end pod

--- a/Website/plugins/raku-doc-setup/README.rakudoc
+++ b/Website/plugins/raku-doc-setup/README.rakudoc
@@ -5,6 +5,6 @@ The plugin is for the setup milestone
 
 Changes source filename starting 'Language', 'Type', 'Program' to lowercase.
 
-Adds a 'deprecate-urls' file to the assets directory for files whose name is changed.
+Adds a 'deprecated-urls' file to the assets directory for files whose name is changed.
 
 =end pod

--- a/Website/plugins/raku-doc-setup/add-deprecate.raku
+++ b/Website/plugins/raku-doc-setup/add-deprecate.raku
@@ -1,0 +1,3 @@
+sub ($pr, %processed, %options --> Array ) {
+    [ ( 'assets/deprecated-urls', 'myself', 'deprecated-urls' ), ]
+}

--- a/Website/plugins/raku-doc-setup/config.raku
+++ b/Website/plugins/raku-doc-setup/config.raku
@@ -6,5 +6,6 @@
 	:license<Artistic-2.0>,
 	:name<raku-doc-setup>,
 	:setup<raku-doc-change-routes.raku>,
-	:version<0.3.5>,
+	:transfer<add-deprecate.raku>,
+	:version<0.3.6>,
 )

--- a/Website/plugins/raku-doc-setup/deprecated-urls
+++ b/Website/plugins/raku-doc-setup/deprecated-urls
@@ -1,0 +1,2 @@
+"/language" "/introduction"
+"/programs" "/miscellaneous"

--- a/Website/structure-sources/index.rakudoc
+++ b/Website/structure-sources/index.rakudoc
@@ -19,24 +19,48 @@
         <div class="container px-4">
           <div class="columns is-multiline">
             <!-- Card -->
-            <div class="column is-one-third">
+            <div class="column is-one-half">
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
-                    <a href="/language">
+                    <a href="/introduction">
                       <span class="icon is-large has-text-primary">
-                        <svg class="svg-inline--fa fa-graduation-cap fa-w-20 icon-large" aria-hidden="true" data-prefix="fas" data-icon="graduation-cap" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" data-fa-i2svg=""><path fill="currentColor" d="M622.34 153.2L343.4 67.5c-15.2-4.67-31.6-4.67-46.79 0L17.66 153.2c-23.54 7.23-23.54 38.36 0 45.59l48.63 14.94c-10.67 13.19-17.23 29.28-17.88 46.9C38.78 266.15 32 276.11 32 288c0 10.78 5.68 19.85 13.86 25.65L20.33 428.53C18.11 438.52 25.71 448 35.94 448h56.11c10.24 0 17.84-9.48 15.62-19.47L82.14 313.65C90.32 307.85 96 298.78 96 288c0-11.57-6.47-21.25-15.66-26.87.76-15.02 8.44-28.3 20.69-36.72L296.6 284.5c9.06 2.78 26.44 6.25 46.79 0l278.95-85.7c23.55-7.24 23.55-38.36 0-45.6zM352.79 315.09c-28.53 8.76-52.84 3.92-65.59 0l-145.02-44.55L128 384c0 35.35 85.96 64 192 64s192-28.65 192-64l-14.18-113.47-145.03 44.56z"></path></svg><!-- <i class="fas fa-graduation-cap icon-large"></i> -->
+                        <i class="fas fa-graduation-cap icon-large"></i>
                       </span>
                     </a>
                   </div>
                   <div class="content has-text-centered">
-                    <p class="title is-5 has-text-primary"><a href="/language">Language Reference &amp; Tutorials</a></p>
+                    <p class="title is-5 has-text-primary"><a href="/introduction">Getting started, Migration guides from other languages, &amp; Tutorials</a></p>
+                  </div>
+                  <div class="content has-text-centered">
+                    Documents introducing the language for various audiences.
+                  </div>
+                  <div class="has-text-centered">
+                    <a class="button is-primary" href="/introduction">
+                      <strong>Learn more</strong>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="column is-one-half">
+              <div class="card card-home">
+                <div class="card-content">
+                  <div class="has-text-centered">
+                    <a href="/reference">
+                      <span class="icon is-large has-text-primary">
+                        <i class="fas fa-book icon-large"></i>
+                      </span>
+                    </a>
+                  </div>
+                  <div class="content has-text-centered">
+                    <p class="title is-5 has-text-primary"><a href="/reference">Language References</a></p>
                   </div>
                   <div class="content has-text-centered">
                     Documents explaining the various conceptual parts of the language.
                   </div>
                   <div class="has-text-centered">
-                    <a class="button is-primary" href="/language">
+                    <a class="button is-primary" href="/reference">
                       <strong>Learn more</strong>
                     </a>
                   </div>
@@ -49,7 +73,7 @@
                   <div class="has-text-centered">
                     <a href="/types">
                       <span class="icon is-large has-text-primary">
-                        <svg class="svg-inline--fa fa-layer-group fa-w-16 icon-large" aria-hidden="true" data-prefix="fas" data-icon="layer-group" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M12.41 148.02l232.94 105.67c6.8 3.09 14.49 3.09 21.29 0l232.94-105.67c16.55-7.51 16.55-32.52 0-40.03L266.65 2.31a25.607 25.607 0 0 0-21.29 0L12.41 107.98c-16.55 7.51-16.55 32.53 0 40.04zm487.18 88.28l-58.09-26.33-161.64 73.27c-7.56 3.43-15.59 5.17-23.86 5.17s-16.29-1.74-23.86-5.17L70.51 209.97l-58.1 26.33c-16.55 7.5-16.55 32.5 0 40l232.94 105.59c6.8 3.08 14.49 3.08 21.29 0L499.59 276.3c16.55-7.5 16.55-32.5 0-40zm0 127.8l-57.87-26.23-161.86 73.37c-7.56 3.43-15.59 5.17-23.86 5.17s-16.29-1.74-23.86-5.17L70.29 337.87 12.41 364.1c-16.55 7.5-16.55 32.5 0 40l232.94 105.59c6.8 3.08 14.49 3.08 21.29 0L499.59 404.1c16.55-7.5 16.55-32.5 0-40z"></path></svg><!-- <i class="fas fa-layer-group icon-large"></i> -->
+                        <i class="fas fa-layer-group icon-large"></i>
                       </span>
                     </a>
                   </div>
@@ -73,7 +97,7 @@
                   <div class="has-text-centered">
                     <a href="/routines">
                       <span class="icon is-large has-text-primary">
-                        <svg class="svg-inline--fa fa-paperclip fa-w-14 icon-large" aria-hidden="true" data-prefix="fas" data-icon="paperclip" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M43.246 466.142c-58.43-60.289-57.341-157.511 1.386-217.581L254.392 34c44.316-45.332 116.351-45.336 160.671 0 43.89 44.894 43.943 117.329 0 162.276L232.214 383.128c-29.855 30.537-78.633 30.111-107.982-.998-28.275-29.97-27.368-77.473 1.452-106.953l143.743-146.835c6.182-6.314 16.312-6.422 22.626-.241l22.861 22.379c6.315 6.182 6.422 16.312.241 22.626L171.427 319.927c-4.932 5.045-5.236 13.428-.648 18.292 4.372 4.634 11.245 4.711 15.688.165l182.849-186.851c19.613-20.062 19.613-52.725-.011-72.798-19.189-19.627-49.957-19.637-69.154 0L90.39 293.295c-34.763 35.56-35.299 93.12-1.191 128.313 34.01 35.093 88.985 35.137 123.058.286l172.06-175.999c6.177-6.319 16.307-6.433 22.626-.256l22.877 22.364c6.319 6.177 6.434 16.307.256 22.626l-172.06 175.998c-59.576 60.938-155.943 60.216-214.77-.485z"></path></svg><!-- <i class="fas fa-paperclip icon-large"></i> -->
+                        <i class="fas fa-paperclip icon-large"></i>
                       </span>
                     </a>
                   </div>
@@ -95,27 +119,27 @@
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
-                    <a href="/programs">
+                    <a href="/miscellaneous">
                       <span class="icon is-large has-text-primary">
-                        <svg class="svg-inline--fa fa-code fa-w-20 icon-large" aria-hidden="true" data-prefix="fas" data-icon="code" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" data-fa-i2svg=""><path fill="currentColor" d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z"></path></svg><!-- <i class="fas fa-code icon-large"></i> -->
+                        <i class="fas fa-code icon-large"></i>
                       </span>
                     </a>
                   </div>
                   <div class="content has-text-centered">
-                    <p class="title is-5 has-text-primary"><a href="/programs">Raku Programs</a></p>
+                    <p class="title is-5 has-text-primary"><a href="/miscellaneous">Miscellaneous</a></p>
                   </div>
                   <div class="content has-text-centered">
-                    Documents explaining various topics focused on Raku programs rather than the language itself.
+                    Documents explaining experimental topics and Raku programs rather than the language itself.
                   </div>
                   <div class="has-text-centered">
-                    <a class="button is-primary" href="/programs">
+                    <a class="button is-primary" href="/miscellaneous">
                       <strong>Learn more</strong>
                     </a>
                   </div>
                 </div>
               </div>
             </div>
-            <div class="column is-one-third">
+            <div class="column is-one-half">
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">
@@ -139,7 +163,7 @@
                 </div>
               </div>
             </div>
-            <div class="column is-one-third">
+            <div class="column is-one-half">
               <div class="card card-home">
                 <div class="card-content">
                   <div class="has-text-centered">

--- a/Website/structure-sources/introduction.rakudoc
+++ b/Website/structure-sources/introduction.rakudoc
@@ -1,0 +1,16 @@
+=begin rakudoc :no-glossary :page-content-columns
+
+=TITLE Raku language documentation
+
+=SUBTITLE Introductory material, tutorials and migration guides for users familiar with other languages.
+
+=for ListFiles :select<kind=Language, category=beginning>
+Getting started
+
+=for ListFiles :select<kind=Language, category=migration>
+Migration guides
+
+=for ListFiles :select<kind=Language, category=tutorial>
+Tutorials
+
+=end rakudoc

--- a/Website/structure-sources/miscellaneous.rakudoc
+++ b/Website/structure-sources/miscellaneous.rakudoc
@@ -1,0 +1,13 @@
+=begin rakudoc :no-glossary :no-toc  :page-content-one-col
+
+=TITLE Raku language documentation
+
+=SUBTITLE Miscellaneous categories
+
+=for ListFiles :select<kind=Language, category=advanced>
+Advanced topics
+
+=for ListFiles :select<kind=Programs>
+Programs
+
+=end rakudoc

--- a/Website/structure-sources/reference.rakudoc
+++ b/Website/structure-sources/reference.rakudoc
@@ -1,0 +1,13 @@
+=begin rakudoc :no-glossary :page-content-columns
+
+=TITLE Raku language documentation
+
+=SUBTITLE Broader explanations of fundamental topics and descriptions of Types and slangs
+
+=for ListFiles :select<kind=Language, category=fundamental>
+Fundamental topics
+
+=for ListFiles :select<kind=Language, category=reference>
+General reference
+
+=end rakudoc

--- a/repo_docs/README.rakudoc
+++ b/repo_docs/README.rakudoc
@@ -72,6 +72,14 @@ This may eventually prove unnecessary, but it is a reasonable convention is kept
 Further, in the future, another Mode may be useful in this repository in due course that
 generates an epub output.
 
+=head1 Deprecated URLs
+
+Occasionally, file names change. This would cause a 404 error if an external webpage,
+e.g. someone's blog, has a link to a changed file name. To overcome this, a mapping file
+C<deprecated-urls> is kept in C<Website/plugins/raku-doc-setup>. The plugin adds this file
+to `rendered_html/assets/`, and the Caddy system rewrites routes from the deprecated name
+to the working alternative.
+
 =head1 Plugins and Templates
 
 Collection is designed to handle multiple Modes, and for plugins to be contributed in


### PR DESCRIPTION
three new top-level pages created from two previous ones
- introduction, from language
- reference from language
- miscellaneous, from programs and language
The navigation bar is changed accordingly, and tooltips (text available when hovering) added
The website index is modified accordingly
Using the `configs/01-config` mode-ignore, the old language and programs files are ignored, but left in the structure_files directory. They can be deleted later.
The `page-styling` plugin is amended so that the navigation bar is modified.