### PR TITLE
Change ToC keyboard shortcut

### DIFF
--- a/Website/plugins/page-styling/page-styling.js
+++ b/Website/plugins/page-styling/page-styling.js
@@ -148,12 +148,7 @@ $(document).ready( function() {
     });
     // keyboard events to open / close sidebars
     document.addEventListener('keydown', e => {
-      if (e.ctrlKey && e.key === 's') {
-        // Prevent the Save dialog to open
-        e.preventDefault();
-        $('#navbar-right-toggle').trigger('click');
-      }
-      if (e.ctrlKey && e.key === 'a') {
+      if (e.altKey && e.key === 't') {
         // Prevent the Save dialog to open
         e.preventDefault();
         $('#navbar-left-toggle').trigger('click');

--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -63,7 +63,7 @@ use v6.d;
     },
     'left-bar-toggle' => sub (%prm, %tml ) {
       q:to/BLOCK/
-        <div class="left-bar-toggle" title="Toggle Table of Contents (Ctl-a)">
+        <div class="left-bar-toggle" title="Toggle Table of Contents (Alt-T)">
             <label class="chyronToggle left">
                 <input id="navbar-left-toggle" type="checkbox">
                 <span class="text">Contents</span>


### PR DESCRIPTION
comments to new search function pointed out that common keyboard shortcuts should be avoided. The current ToC shortcut is `Ctrl-A`, which is commonly select-all. So, this is changed to 'Alt-T', which is not common.
- change needed to listener in JS code
- change to title for tool tip