### PR TITLE
fix issue #288 problem searching for `\`,`.`,`..`

### DIFF
--- a/Website/plugins/options-search/add-options-search.raku
+++ b/Website/plugins/options-search/add-options-search.raku
@@ -44,7 +44,7 @@ sub ($pp, %processed, %options) {
                 :category($podf.pod-config-data<subkind>.tc),
                 :$value,
                 :$info,
-                :url(escape-json('/' ~ $fn)),
+                :url(escape-json('/' ~ $podf.path)),
                 :type<composite>,
             )
         }

--- a/Website/plugins/options-search/config.raku
+++ b/Website/plugins/options-search/config.raku
@@ -11,7 +11,7 @@
 	:name<options-search>,
 	:render,
 	:template-raku<options-search-templates.raku>,
-	:version<0.1.13>,
+	:version<0.1.14>,
 	:information<css-link>,
 	:add-css<css/options-search-light.css css/options-search-dark.css>,
 	:js-link(

--- a/Website/plugins/secondaries/config.raku
+++ b/Website/plugins/secondaries/config.raku
@@ -12,5 +12,5 @@
 	:transfer<cleanup.raku>,
 	:hash-urls,
 	:information('hash-urls',),
-	:version<0.4.1>,
+	:version<0.4.7>,
 )

--- a/Website/plugins/secondaries/t/15-gen-secondaries.rakutest
+++ b/Website/plugins/secondaries/t/15-gen-secondaries.rakutest
@@ -173,7 +173,7 @@ with $pp {
 
 # generate hashed files
 @triples = &secondaries($pp,%processed, %(:no-status,) );
-@expected = <and ...>.map( { 'hashed/' ~ nqp::sha1($_ ) ~ '.html' } ) ;
+@expected = <routine/and routine/...>.map( { 'hashed/' ~ nqp::sha1($_ ) ~ '.html' } ) ;
 @expected.push: 'assets/prettyurls';
 is @triples.elems,@expected.elems, 'correct no of hashed secondaries generated';
 is @triples[0][0], any(@expected), 'got 1 right file';


### PR DESCRIPTION
- searching for one of the above yields candidates that are named, eg.`routine/.`, but a page gets a 404.
- after some testing on various browsers/OS, it seems that those three specific character sequences cannot be used as filenames everywhere. Browsers/OS modify the URL before it reaches the server
- To overcome this behaviour, the three composite filenames `.` `..` `\` are mapped to URLs that will be preserved.
- This patch only affects three filenames and does not affect any other name.
- This problem was also present in the Documentable build of the website.
- patch changes `secondaries` plugin to create the url, and place the url in the podf structure. The `options-search` plugin is modified to pick up the url from the podf structure instead of forming the name by a rule.