### PR TITLE
fix issue #193

### DIFF
--- a/Website/plugins/options-search/add-options-search.raku
+++ b/Website/plugins/options-search/add-options-search.raku
@@ -57,14 +57,17 @@ sub ($pp, %processed, %options) {
                 :type<primary>,
             )
         }
-        for $podf.raw-toc.grep({ !(.<is-title>) }) {
-            @entries.push: %(
-                :category<Heading>,
-                :value(.<text>),
-                :info('Section in <b>' ~ $podf.title ~ '</b>'),
-                :url(escape-json('/' ~ $fn ~ '#' ~ .<target>)),
-                :type<headings>,
-            )
+        unless $podf.pod-config-data<subkind> eq 'Composite' {
+            # exclude headings from all composite files because they are duplicates
+            for $podf.raw-toc.grep({ !(.<is-title>) }) {
+                @entries.push: %(
+                    :category<Heading>,
+                    :value(.<text>),
+                    :info('Section in <b>' ~ $podf.title ~ '</b>'),
+                    :url(escape-json('/' ~ $fn ~ '#' ~ .<target>)),
+                    :type<headings>,
+                )
+            }
         }
         for $podf.raw-glossary {
             my $value = .key;


### PR DESCRIPTION
- Headings in Composite files were being added to Search data, but composite files are themselves created from Primary headings, so headings in composite files are redundant.
- This patch filters them out of search data.