### PR TITLE
resolves issue #303

### DIFF
--- a/Website/plugins/options-search/config.raku
+++ b/Website/plugins/options-search/config.raku
@@ -11,7 +11,7 @@
 	:name<options-search>,
 	:render,
 	:template-raku<options-search-templates.raku>,
-	:version<0.1.14>,
+	:version<0.1.16>,
 	:information<css-link>,
 	:add-css<css/options-search-light.css css/options-search-dark.css>,
 	:js-link(

--- a/Website/plugins/options-search/options-search.js
+++ b/Website/plugins/options-search/options-search.js
@@ -17,6 +17,7 @@ var persist_searchOptions = function (searchOptions) {
 };
 var category = '';
 var autoCompleteJS;
+var openInTab = false;
 
 document.addEventListener('DOMContentLoaded', function () {
     searchOptions = persisted_searchOptions();
@@ -114,9 +115,10 @@ document.addEventListener('DOMContentLoaded', function () {
                       // Modify Results Item Content
                       item.innerHTML = `
                       ${catSpan}
+                      <a href="${data.value.url}">
                       <span class="autoComplete-result-data">
                         ${data.match}
-                      </span>
+                      </span></a>
                       ${extraSpan}`;
                 },
                 highlight: true,
@@ -124,7 +126,7 @@ document.addEventListener('DOMContentLoaded', function () {
             events: {
                 input: {
                     keydown: (event) => {
-                        document.querySelector('.autoComplete_wrapper ul').scrollTop = 0;
+                        //document.querySelector('.autoComplete_wrapper ul').scrollTop = 0;
                         switch (event.keyCode) {
                             // Down/Up arrow
                             case 40:
@@ -135,13 +137,11 @@ document.addEventListener('DOMContentLoaded', function () {
                             // Enter
                             case 13:
                                 event.preventDefault();
-                                if (autoCompleteJS.cursor >= 0) {
-                                    autoCompleteJS.select(event);
-                                }
-                                else {
+                                openInTab =  event.ctrlKey;
+                                if (autoCompleteJS.cursor < 0) {
                                     autoCompleteJS.next();
-                                    autoCompleteJS.select(event);
                                 }
+                                autoCompleteJS.select(autoCompleteJS.cursor)
                                 break;
                             }
                         },
@@ -158,7 +158,7 @@ document.addEventListener('DOMContentLoaded', function () {
                             + '+'
                             + encodeURIComponent( event.detail.query );
                         }
-                        if ( searchOptions.newtab ) {
+                        if ( searchOptions.newtab || openInTab ) {
                             window.open( dest, '_blank');
                         }
                         else {


### PR DESCRIPTION
- users want to be able to auxiliary (for Ubuntu = right) mouse-click and for the url to be opened in a new tab while remaining in the current tab.
- users do not want the position within the list of found candidates to be affected by key entries, which means the position in the list state is also unchanged by cancelling a search or a change in focus.
- for security reasons, 'pop-unders' are made very difficult in javascript
- but browsers all allow this behaviour for HTML links (eg `<a>` tabs).
- users want to have `select` meaning the 'Enter' and left mouse-button to operate as before.
- the Alt-Q shortcut should still toggle between `select` opening the associated URL in a new tab and shift focus to the new tab, or opening in the current tab. This patch:
- modifies the js for the options-search plugin so that each 'visible' item  on the search list contains an `<a>` link, and so the browser behaviour is allowed with right-click.
- the code that takes the list state to the top after a key event (eg cancel) is removed. (The code is commented out, so that if it is wanted for some specific event, the functionality can be returned).
- Config version is bumped.