### PR TITLE
issue #309 reports a redundant link, patch removes it

### DIFF
--- a/Website/plugins/secondaries/header-templates.raku
+++ b/Website/plugins/secondaries/header-templates.raku
@@ -160,16 +160,18 @@ use v6.d;
                         $kind = 'routine';
                         $category = 'operator'
                     }
-                    %prm<heading><defs>{$fn} = {} unless %prm<heading><defs>{$fn}:exists;
-                    %prm<heading><defs>{$fn}{$target} = %(
-                        :$name,
-                        :$kind,
-                        :$subkind,
-                        :$category,
-                        # only one category per defn
+                    if $name {
+                        %prm<heading><defs>{$fn} = {} unless %prm<heading><defs>{$fn}:exists;
+                        %prm<heading><defs>{$fn}{$target} = %(
+                            :$name,
+                            :$kind,
+                            :$subkind,
+                            :$category,
+                            # only one category per defn
 
-                    );
-                    $bookmark = "\n<!-- defnmark $target { %prm<level> // '1' } -->\n";
+                        );
+                        $bookmark = "\n<!-- defnmark $target { %prm<level> // '1' } -->\n";
+                    }
                 }
             }
         }


### PR DESCRIPTION
- the source file `5to6-nutshell` contains the heading `C<constant>` that matches the regex looking for composite files, but this is a false positive as no name is generated
- this patch to the `Website/plugins/secondaries` verifies `.name` is non-blank.