### PR TITLE
new sitemap plugin completes issue #201

### DIFF
--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -9,9 +9,9 @@
             camelia simple-extras listfiles images deprecate-span filterlines
             tablemanager secondaries typegraph generated
             options-search link-error-test
-            gather-js-jq gather-css
+            gather-js-jq gather-css sitemap
         >,
-        :report<link-plugin-assets-report>,
+        :report<link-plugin-assets-report sitemap>,
         :transfer<secondaries gather-js-jq gather-css images raku-doc-setup options-search>,
         :compilation<secondaries listfiles options-search>,
         :completion<cro-app>,

--- a/Website/configs/03-plugin-options.raku
+++ b/Website/configs/03-plugin-options.raku
@@ -10,6 +10,7 @@
         ),
         sitemap => %(
             :root-domain<https://docs.raku.org>,
+            :sitemap-destination<../../rendered_html>,
         )
     ),
 )

--- a/Website/configs/03-plugin-options.raku
+++ b/Website/configs/03-plugin-options.raku
@@ -8,12 +8,8 @@
         link-error-test => %(
             :no-remote,
         ),
-        raku-repl => %(
-            :websocket-host<finanalyst.org>,
-            :websocket-port<443>,
-        ),
-        search-bar => %(
-            :search-site<docs.raku.org>,
-        ),
+        sitemap => %(
+            :root-domain<https://docs.raku.org>,
+        )
     ),
 )

--- a/Website/plugins/sitemap/README.rakudoc
+++ b/Website/plugins/sitemap/README.rakudoc
@@ -1,0 +1,9 @@
+=begin pod
+=TITLE sitemap is a plugin for Collection
+
+The plugin is for the report milestone
+
+It uses the collected information on all rendered files to generate a SEO
+site map
+
+=end pod

--- a/Website/plugins/sitemap/config.raku
+++ b/Website/plugins/sitemap/config.raku
@@ -1,0 +1,15 @@
+%(
+	:auth<collection>,
+	:authors(
+		"finanalyst",
+	),
+	:license<Artistic-2.0>,
+	:name<sitemap>,
+	:report<make-sitemap.raku>,
+	:render,
+	:custom-raku(),
+	:template-raku(),
+	:version<0.1.1>,
+	:root-domain<https://docs.raku.org>,
+	:information<root-domain>,
+)

--- a/Website/plugins/sitemap/config.raku
+++ b/Website/plugins/sitemap/config.raku
@@ -9,7 +9,5 @@
 	:render,
 	:custom-raku(),
 	:template-raku(),
-	:version<0.1.1>,
-	:root-domain<https://docs.raku.org>,
-	:information<root-domain>,
+	:version<0.1.2>,
 )

--- a/Website/plugins/sitemap/make-sitemap.raku
+++ b/Website/plugins/sitemap/make-sitemap.raku
@@ -1,0 +1,30 @@
+use v6.d;
+sub (%processed, @plugins-used, $processed, %options --> Array ) {
+    my %config = $processed.get-data('sitemap');
+    my $root = %config<root-domain> // '';
+    my $sitemap = q:to/START/;
+    <?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    START
+    my $priority;
+    for %processed.keys -> $fn {
+        given $fn {
+            when any(< introduction reference miscellaneous > ) { $priority = 0.8 }
+            when / ^ 'language/' / { $priority = 0.7 }
+            when / ^ 'type/' / { $priority = 0.6 }
+            default { $priority = 0.5 }
+        }
+        $sitemap ~= qq:to/URL/;
+            <url>
+                <loc>$root/$fn/\</loc>
+                <priority>$priority\</priority>
+            </url>
+        URL
+    }
+
+    $sitemap ~= q:to/END/;
+    </urlset>
+    END
+    # return array of pairs
+    ['../../rendered_html/sitemap.xml' => $sitemap ]
+}

--- a/Website/plugins/sitemap/make-sitemap.raku
+++ b/Website/plugins/sitemap/make-sitemap.raku
@@ -1,7 +1,10 @@
 use v6.d;
 sub (%processed, @plugins-used, $processed, %options --> Array ) {
     my %config = $processed.get-data('sitemap');
-    my $root = %config<root-domain> // '';
+    exit note 'Sitemap plugin error. Must set configuration for ｢root-domain｣ and  ｢sitemap-destination｣'
+        unless %config<root-domain>:exists and %config<sitemap-destination>:exists;
+    my $root = %config<root-domain>;
+    my $dest = %config<sitemap-destination>;
     my $sitemap = q:to/START/;
     <?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -26,5 +29,5 @@ sub (%processed, @plugins-used, $processed, %options --> Array ) {
     </urlset>
     END
     # return array of pairs
-    ['../../rendered_html/sitemap.xml' => $sitemap ]
+    ["$dest/sitemap.xml" => $sitemap ]
 }

--- a/Website/plugins/sitemap/t/05-basic.rakutest
+++ b/Website/plugins/sitemap/t/05-basic.rakutest
@@ -1,0 +1,5 @@
+use v6.d;
+use Test;
+use Test::CollectionPlugin;
+test-plugin();
+done-testing


### PR DESCRIPTION
- new plugin for report stage (needs to be registered in render stage too to get options)
- generates `sitemap.xml` for SEO and puts it in html root directory
- (no other change needed as search engines pick up the file)
- change plugins config to add plugin
- change plugin-options config to add root-domain
- remove redundant plugin-options
- some priorities are given to files, which may affect their relative rankings in a search engines result response.