### PR TITLE
Limit search results to 500

### DIFF
--- a/Website/plugins/options-search/options-search.js
+++ b/Website/plugins/options-search/options-search.js
@@ -100,7 +100,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 },
                 noResults: true,
                 threshold: 0,
-                maxResults: undefined
+                maxResults: 500
             },
             resultItem: {
                 class: "autoComplete_result",


### PR DESCRIPTION
When trying to use the search box, there was a significant delay between each char typed for the first couple of chars. Analyzing the time spent in Safari showed that when I typed 's' which had 3256 matches, 98% of the time was spent in style processing, i.e. rendering all of the results in the search results box. The only way to improve this is to reduce the number of entries we ever try to add.

Setting maxResults to 500 makes the search responsive and still delivers more results than is useful.