### PR TITLE
restyle page-edit button to fixed position when text scrolled

### DIFF
--- a/Website/plugins/page-styling/css/page-styling-dark.css
+++ b/Website/plugins/page-styling/css/page-styling-dark.css
@@ -177,16 +177,21 @@ strong {
   color: #EED891;
 }
 
-.raku.page-header .page-edit {
+.page-edit {
   color: #83858D;
+  left: 95vw;
+  position: fixed;
+  top: 15vh;
+  z-index: 10;
+  opacity: 50%;
 }
-.raku.page-header .page-edit .page-edit-button {
-  background: #282c2e;
-  color: gainsboro;
+.page-edit .page-edit-button {
+  background: #1B1D1E;
+  color: #EED891;
   border-color: #3A3D4E;
 }
-.raku.page-header .page-edit .page-edit-button:hover {
-  background: #212426;
+.page-edit .page-edit-button:hover {
+  background: #282c2e;
 }
 
 /* Raku search page */

--- a/Website/plugins/page-styling/css/page-styling-light.css
+++ b/Website/plugins/page-styling/css/page-styling-light.css
@@ -177,16 +177,21 @@ strong {
   color: #A30031;
 }
 
-.raku.page-header .page-edit {
+.page-edit {
   color: #83858D;
+  left: 95vw;
+  position: fixed;
+  top: 15vh;
+  z-index: 10;
+  opacity: 50%;
 }
-.raku.page-header .page-edit .page-edit-button {
-  background: #f5f5f5;
-  color: black;
+.page-edit .page-edit-button {
+  background: #fafafa;
+  color: #A30031;
   border-color: #cccccc;
 }
-.raku.page-header .page-edit .page-edit-button:hover {
-  background: #f2f2f2;
+.page-edit .page-edit-button:hover {
+  background: #f5f5f5;
 }
 
 /* Raku search page */

--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -149,6 +149,7 @@ use v6.d;
         else {
             qq:to/BLOCK/
             <div class="tile is-ancestor section">
+                { %tml<page-edit>.(%prm,%tml) }
                 <div id="left-column" class="tile is-parent is-2 is-hidden">
                     <div id="left-col-inner">
                         { %tml<toc-sidebar>.(%prm, %tml)  }
@@ -182,7 +183,6 @@ use v6.d;
                 <div class="raku page-subtitle has-text-centered">
                 { %prm<subtitle> }
                 </div>
-                { %tml<page-edit>.(%prm,%tml) }
             </div>
         </section>
         BLOCK

--- a/Website/plugins/page-styling/scss/_themes-template-common.scss
+++ b/Website/plugins/page-styling/scss/_themes-template-common.scss
@@ -194,18 +194,23 @@ strong {
   color: $heading;
 }
 
-.raku.page-header .page-edit {
-  color: $grey-dark;
+.page-edit {
+    color: $grey-dark;
+    left: 95vw;
+    position: fixed;
+    top: 15vh;
+    z-index: 10;
+    opacity: 50%;
 
-  .page-edit-button {
-    background: $scheme-main-ter;
-    color: $text-dark;
-    border-color: $border;
+    .page-edit-button {
+        background: $scheme-main;
+        color: $heading;
+        border-color: $border;
 
-    &:hover {
-      background: $scheme-main-bis;
+        &:hover {
+            background: $scheme-main-ter;
+        }
     }
-  }
 }
 
 /* Raku search page */


### PR DESCRIPTION
- if an edit is needed, now there is no need to scroll to top of file
- move the div to the main tile
- restyle to make fairly unobtrusive
- z-index so it floats above text.
- opacity 50% so when overlapping, text is visible