### PR TITLE
Link-error-test plugin finds unfulfilled links

### DIFF
--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -13,7 +13,7 @@
         >,
         :report<link-plugin-assets-report sitemap>,
         :transfer<secondaries gather-js-jq gather-css images raku-doc-setup options-search>,
-        :compilation<secondaries listfiles options-search>,
+        :compilation<secondaries listfiles link-error-test options-search>,
         :completion<cro-app>,
     ),
 )

--- a/Website/configs/03-plugin-options.raku
+++ b/Website/configs/03-plugin-options.raku
@@ -7,6 +7,7 @@
         ),
         link-error-test => %(
             :no-remote,
+            :run-tests,
         ),
         sitemap => %(
             :root-domain<https://docs.raku.org>,

--- a/Website/plugins/link-error-test/README.rakudoc
+++ b/Website/plugins/link-error-test/README.rakudoc
@@ -11,17 +11,18 @@ The report stage has access to all links, but C<Collection> stores report output
 plugin stores output in the output (html) folder. Consequently links in structure files can be tested at the
 report stage, but compiled into html.
 
-One testing approach is to check all links using Javascript within the error page. However, Cross over restrictions
-make the retrieval of just headers from popular sources, such as Wikipedia, a pain inside a browser.
-
-Consequently, the links are tested in three ways:
+Links are tested in three ways:
 =item external links (viz., to http(s):// schemas) are tested using LibCurl and checking the response code.
 =item local links, which are links to targets in documents within the Collection, are tested
 by verifying whether the file exists at the location specified.
 
+=item2 The Secondaries plugin generates files which may have escaped aliases. The Secondary
+plugin passes the aliases into the dataspace for this plugin. Consequently, this
+plugin must appear in the configuration list before Secondaries.
+
 =item internal links, which are links within a document (viz. a C<#target> schema),
 and internal links to local files (viz., a C</path/to/file#internal_target> schema) are tested by looking
-at the C<targets> datastructure that C<ProcessedPod> collects. All targets are registered to ensure that
+at the C<targets> data structure that C<ProcessedPod> collects. All targets are registered to ensure that
 they are unique.
 
 =head1 Configuration

--- a/Website/plugins/link-error-test/config.raku
+++ b/Website/plugins/link-error-test/config.raku
@@ -10,6 +10,7 @@
 	:license<Artistic-2.0>,
 	:name<link-error-test>,
 	:!no-remote,
+	:run-tests,
 	:render,
 	:template-raku<let-templates.raku>,
 	:version<0.3.6>,

--- a/Website/plugins/link-error-test/let-templates.raku
+++ b/Website/plugins/link-error-test/let-templates.raku
@@ -1,117 +1,108 @@
 #!/usr/bin/env perl6
 %(
-
     linkerrortest => sub (%prm, %tml) {
         my $rv = '';
         if %prm<linkerrortest>:exists and +%prm<linkerrortest>.keys {
             my $data = %prm<linkerrortest>;
             # structure: no-file|no-target|unknown|remote
-            my %titles = <no-file no-target unknown remote >
-                    Z=> 'Links to missing files',
-                        'Links to non-existent interior targets',
-                        'Unknown target schema (typo in L<> ?)',
-                        'Remote http/s links with bad host or 404';
+            my %titles =
+                no-file => %( :div('Links to missing files'), :cap(q:to/CAP/), ),
+                    <table class="table"><tr>
+					<th>Document with glitch</th>
+                    <th>Displayed text</th>
+                    <th>Non-Existent target file</th>
+                    </tr>
+                    CAP
+                no-target => %( :div('Links to non-existent interior targets'), :cap(q:to/CAP/), ),
+                    <table class="table"><tr>
+					<th>Document with glitch</th>
+                    <th>Displayed text</th>
+                    <th col-span="2">Document containing anchor</th>
+                    <th>Attempted anchor name (variants tried)</th>
+                    </tr>
+                    CAP
+                unknown => %( :div('Unknown target schema (typo in L<> ?)'), :cap(q:to/CAP/), ),
+                    <table class="table"><tr>
+					<th>Document with glitch</th>
+                    <th>Displayed text</th>
+                    <th>Dubious url</th>
+                    </tr>
+                    CAP
+                remote  => %( :div('Remote http/s links with bad host or 404'), :cap(q:to/CAP/), :not-set(q:to/NOT/),),
+                    <table class="table"><tr>
+					<th>Document with glitch</th>
+                    <th>Displayed text</th>
+                    <th>Dubious url</th>
+                    <th>Error response</th>
+                    </tr>
+                    CAP
+                    <table class="table"><tr>
+					<th>Remote link test skipped</th>
+                    <th>Link-error-test plugin has option <strong>no-remote</strong> set to True</th>
+                    </tr>
+                    NOT
+            ;
             for <remote no-target unknown no-file> -> $type {
                 my %object = $data{$type};
-                next if (! %object.elems)
-                    or ( $type eq 'remote' and ! %object<no_test> and %object.elems eq 1 );
-                $rv ~= '<h2 class="raku-h2">' ~ %titles{$type} ~ "</h2>\n";
-                given $type {
-                    when 'remote' {
-                        if %object<no_test> {
-                            $rv ~= q:to/HEADER/ ~ "\n"
-                                    <div class="let-file header">
-                                    <div class="let-response header"><div>Remote link test skipped</div>
-                                    <div class="let-link-text header">LET plugin config file has 'no-remote' set</div>
-                                    </div></div>
-                                HEADER
-                        }
-                        else {
-                            $rv ~= q:to/HEADER/ ~ "\n"
-                                    <div class="let-file header">
-                                    <div>Document containing link<div class="let-clickable">Click for originating document in new tab</div></div>
-                                    <div class="let-link-text header">Originating link text</div>
-                                    <div class="let-links header">Dubious url
-                                    <div class="let-response header">Error response</div>
-                                    </div></div>
-                                HEADER
-                        }
-                    }
-                    when 'no-target' {
-                        $rv ~= q:to/HEADER/ ~ "\n"
-                                <div class="let-file header"><div>Document containing link<div class="let-clickable">Click for originating document in new tab</div></div>
-                                <div class="let-link-text header">Originating link text
-                                <div class="let-link-file header"><div>A document generates a web-page<div class="let-clickable">Click for destination document in new tab</div></div>
-                                <div class="let-link-target header">An internal target is referenced but does not exist (variants tried)</div>
-                                </div></div></div>
-                            HEADER
-                    }
-                    when 'no-file' {
-                        $rv ~= q:to/HEADER/ ~ "\n"
-                                <div class="let-file header"><div>Document containing link<div class="let-clickable">Click for originating document in new tab</div></div>
-                                <div class="let-link-text header">Originating link text
-                                <div class="let-link-file header">Non-Existent target file</div>
-                                </div></div>
-                            HEADER
-                    }
-                    default {
-                        $rv ~= q:to/HEADER/ ~ "\n"
-                                <div class="let-file header"><div>Document containing link<div class="let-clickable">Click for originating document in new tab</div></div>
-                                <div class="let-link-text header">Originating link text
-                                <div class="let-url header">Dubious url</div>
-                                </div></div>
-                            HEADER
-                    }
+                next unless %object.elems;
+                $rv ~= '<h2 class="raku-h2">' ~ %titles{$type}<div> ~ "</h2>\n";
+                if $type eq 'remote' and %object<no_test> {
+                    $rv ~= %titles{$type}<not-set>
                 }
-                unless %object<no_test> {
+                else {
+                    $rv ~= %titles{$type}<cap>;
                     for %object.sort.grep( { .value ~~ Positional } ).map(|*.kv) -> $fn, $resp {
-                        $rv ~= '<div class="let-file"><div>' ~ $fn ~ '<a class="let-clickable" href="' ~ $fn ~ '" target="_blank" rel="noopener noreferrer">Clickable</a></div>';
+                        $rv ~= qq:to/HEAD/;
+                            <tr>\<td>\<a class="button" href="$fn" target="_blank" rel="noopener noreferrer">$fn\</a>\</td>
+                        HEAD
                         when $type eq 'no-file' {
+                            $rv ~= '<td></td><td></td></tr>';
                             for $resp.list -> %info {
-                                $rv ~= '<div class="let-link-text">' ~ %tml<escaped>( %info<link-label> )
-                                    ~ '<div class="let-link-file">'
+                                $rv ~= '<tr><td></td><td>' ~ %tml<escaped>( %info<link-label> )
+                                    ~ '</td><td>'
                                     ~ %tml<escaped>(%info<file>)
-                                    ~ '</div></div>'
+                                    ~ "</td></tr>\n"
                             }
-                            $rv ~= "</div>\n";
                         }
                         when $type eq 'unknown' {
+                            $rv ~= '<td></td><td></td></tr>';
                             for $resp.list -> %info {
-                                $rv ~= '<div class="let-link-text">' ~ %tml<escaped>( %info<link-label> ) ~ '</div>'
-                                    ~ '<div class="let-links">'
+                                $rv ~= '<tr><td></td><td>' ~ %tml<escaped>( %info<link-label> )
+                                    ~ '</td><td>'
                                     ~ %tml<escaped>(%info<url>)
-                                    ~ '</div>'
+                                    ~ '</td>'
                             }
-                            $rv ~= "</div>\n";
+                            $rv ~= "</tr>\n";
                         }
                         when $type eq 'remote' {
+                            $rv ~= '<td></td><td></td><td></td></tr>';
                             for $resp.list -> %info {
-                                $rv ~='<div class="let-link-text">' ~ %tml<escaped>( %info<link-label> ) ~ '</div>'
-                                    ~  '<div class="let-links">'
-                                    ~ %tml<escaped>( %info<url> )
-                                    ~ '<div class="let-response">'
+                                $rv ~= '<tr><td></td><td>' ~ %tml<escaped>( %info<link-label> )
+                                    ~ '</td><td>'
+                                    ~ %tml<escaped>(%info<url> )
+                                    ~ '</td><td>'
                                     ~ %info<resp>
-                                    ~ "</div></div>\n"
+                                    ~ "</td></tr>\n"
                             }
-                            $rv ~= "</div>\n";
                         }
                         when $type eq 'no-target' {
+                            $rv ~= '<td></td><td></td><td></td></tr>';
                             for $resp.list -> %info {
-                                $rv ~= '<div class="let-link-text">' ~ %tml<escaped>( %info<link-label> )
-                                    ~ '<div class="let-link-file"><div>'
-                                    ~ %tml<escaped>( %info<file> )
-                                    ~ '<a class="let-clickable" href="' ~ %tml<escaped>( %info<file> ) ~ '" target="_blank" rel="noopener noreferrer">Clickable</a></div>'
+                                $rv ~= '<tr><td></td><td>' ~ %tml<escaped>( %info<link-label> )
+                                    ~ '</td><td>'
+                                    ~ '<a class="button" href="' ~ %tml<escaped>( %info<file> ) ~ '" target="_blank" rel="noopener noreferrer">'
+                                    ~ %tml<escaped>(%info<file> )
+                                    ~ "</a></td><td></td></tr>\n"
                                     ~ %info<targets>.map( {
-                                        '<div class="let-link-target">'
+                                        '<tr><td></td><td></td><td></td><td>'
                                         ~ %tml<escaped>( $_ )
-                                        ~ '</div>'
+                                        ~ "</td></tr>\n"
                                     } )
-                                    ~ "</div></div>\n"
                             }
-                            $rv ~= "</div>\n";
                         }
                     }
                 }
+                $rv ~= "</table>\n"
             }
         }
         else {

--- a/Website/plugins/secondaries/gen-secondaries.raku
+++ b/Website/plugins/secondaries/gen-secondaries.raku
@@ -59,6 +59,8 @@ sub (ProcessedPod $pp, %processed, %options) {
     my %things = %( routine => {}, syntax => {});
     #| url mapping data
     my %url-maps;
+    #| aliases for targets
+    my %aliases;
     #| templates hash in ProcessedPod instance
     my %templates := $pp.tmpl;
     #| container for the triples describing the files to be transferred once created
@@ -69,6 +71,7 @@ sub (ProcessedPod $pp, %processed, %options) {
     for %definitions.kv -> $fn, %targets {
         counter(:dec) unless %options<no-status>;
         my $html = %processed{$fn}.pod-output;
+        my $title = %processed{$fn}.title.subst(/ ^ class \s /,'');
         while $html ~~ m:c / <defnmark> / {
             given $/<defnmark> {
                 my $targ = .<target>.Str;
@@ -79,6 +82,7 @@ sub (ProcessedPod $pp, %processed, %options) {
                 my $kind = %attr<kind>:delete;
                 %attr<target> = $targ;
                 %attr<source> = $fn;
+                %attr<src-title> = $title;
                 $level = .<level>.Str;
                 $html ~~ m:c / <chunk> /;
                 %attr<body> = $/<chunk>[0].Str.trim;
@@ -103,8 +107,10 @@ sub (ProcessedPod $pp, %processed, %options) {
             my $url = "{ $kind.Str.lc }/$esc-dn";
             %url-maps{ $url } = $mapped-name;
             %url-maps{ $fn-new.subst(/\"/,'\"',:g) } = $mapped-name;
+            %aliases{ $fn-new.subst(/\"/,'\"',:g) } = $url;
             unless $fn-name-old eq $fn-new {
-                %url-maps{ $fn-name-old.subst(/\"/,'\"',:g) } = $mapped-name
+                %url-maps{ $fn-name-old.subst(/\"/,'\"',:g) } = $mapped-name;
+                %aliases{ $fn-name-old.subst(/\"/,'\"',:g) } = $url;
             }
             my $title = $dn.trans(qw｢ &lt; &gt; &amp; &quot; ｣ => qw｢ <    >    &   " ｣);
             my $subtitle = 'Combined from primary sources listed below.';
@@ -124,8 +130,9 @@ sub (ProcessedPod $pp, %processed, %options) {
                 @subkind.append: .<subkind>;
                 @category.append: .<category>;
                 @sources.push: .<source>;
-                my $target = .<source> ~ $kind ~ .<subkind>;
-                my $text = 'In ' ~ .<source>;
+                my $target = "({.<src-title>})_{.<subkind>}_$dn".subst(/ \s /,'_',:g);
+                $podf.targets{ $target }++;
+                my $text = 'In ' ~ .<src-title>;
                 @toc.push: %( :1level, :$text, :$target );
                 $body ~= %templates<heading>.(%(
                   :1level,
@@ -176,6 +183,11 @@ sub (ProcessedPod $pp, %processed, %options) {
         %ns := $pp.get-data('tablemanager');
         %ns<dataset> = {} without %ns<dataset>;
         %ns<dataset><routines> = @routines;
+    }
+    my %let-ns;
+    if 'link-error-test' ~~ any( $pp.plugin-datakeys ) {
+        %let-ns := $pp.get-data('link-error-test');
+        %let-ns<aliases> = %aliases;
     }
     if $hash-urls {
         'prettyurls'.IO.spurt: %url-maps.fmt("\"\/%s\" \"\/%s\"").join("\n");

--- a/Website/structure-sources/about.rakudoc
+++ b/Website/structure-sources/about.rakudoc
@@ -34,4 +34,6 @@ can be found in this L<Credits file | https://raw.githubusercontent.com/Raku/doc
 =for Generated  :headlevel(0)
 The web site was generated as follows:
 
+Link errors in the documentation suite can be found at L<Error report|error-report>.
+
 =end pod


### PR DESCRIPTION
- Link data is saved when parsing sources
- Target anchors created during rendering are saved
- LET compares link data and target data, and reports on mismatch
- The plugin was broken
- The format of the errors is converted into an HTML table and is better than the grid styling.
- A link to the error-report is placed in the About page.