### PR TITLE
fix bug in secondaries

### DIFF
--- a/Website/plugins/secondaries/gen-secondaries.raku
+++ b/Website/plugins/secondaries/gen-secondaries.raku
@@ -17,9 +17,10 @@ sub (ProcessedPod $pp, %processed, %options) {
         (.+?)
         <?before
             "<h$level"
-            | "<h{ $level - 1 }"
-            | "<h{ $level - 2 }"
-            | "<h{ $level - 3 }"
+            | "<h{ $level - 1 > 0 ?? $level - 1 !! '' }"
+            | "<h{ $level - 2 > 0 ?? $level - 2 !! '' }"
+            | "<h{ $level - 3 > 0 ?? $level - 3 !! '' }"
+            | "<h{ $level - 4 > 0 ?? $level - 4 !! '' }"
             | '</section'
             | '</body'
             | $


### PR DESCRIPTION
- Composite pages are created from chunks of HTML in Primary pages from the start of Heading of some level eg `<h2` to the next heading of the same level or lower, eg `<h1`
- the regex was failing because it was generating `<h-1`