### PR TITLE
Remove duplicate section for Composite classes

### DIFF
--- a/Website/structure-sources/types.rakudoc
+++ b/Website/structure-sources/types.rakudoc
@@ -14,9 +14,6 @@ Composite classes
 =for ListFiles :select<kind=Type, subkind=class, category=domain\-specific>
 Domain-specific classes
 
-=for ListFiles :select<kind=Type, subkind=class, category=composite>
-Composite classes
-
 =for ListFiles :select<kind=Type, subkind=class, category=exception>
 Exception classes
 


### PR DESCRIPTION
The section for "Composite classes" on the https://docs.raku.org/types page is duplicated. This PR removes the second instance of it.