### PR TITLE
Style terms that are indexed, but only in paragraphs, not in headings

### DIFF
--- a/Website/plugins/page-styling/css/page-styling-dark.css
+++ b/Website/plugins/page-styling/css/page-styling-dark.css
@@ -483,3 +483,15 @@ a.button.is-primary .icon {
   margin: 0 0 2em;
   text-align: center;
 }
+
+a.index-entry {
+  text-decoration: none;
+  cursor: help;
+}
+a.index-entry span.glossary-entry {
+  padding: 0 0.3em 0 0.3em;
+  border-radius: 0.5em;
+  border: 2px solid #454b4f;
+  background-color: #212426;
+  color: #f5f5f5;
+}

--- a/Website/plugins/page-styling/css/page-styling-light.css
+++ b/Website/plugins/page-styling/css/page-styling-light.css
@@ -483,3 +483,15 @@ a.button.is-primary .icon {
   margin: 0 0 2em;
   text-align: center;
 }
+
+a.index-entry {
+  text-decoration: none;
+  cursor: help;
+}
+a.index-entry span.glossary-entry {
+  padding: 0 0.3em 0 0.3em;
+  border-radius: 0.5em;
+  border: 2px solid #f8efd3;
+  background-color: #f8efd3;
+  color: #030303;
+}

--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -264,10 +264,10 @@ use v6.d;
         BLOCK
     },
     heading => sub (%prm, %tml) {
-        my $txt = %prm<text> // '';
+        my $txt = %prm<text>;
         my $index-parse = $txt ~~ /
-            ( '<a name="index-entry-' .+? '</a>' )
-            '<span class="glossary-entry">' ( .+? ) '</span>'
+            ( '<a name="index-entry-' .+? '"></a>' )
+            '<span class="glossary-entry-heading">' ( .+? ) '</span>'
         /;
         my $h = 'h' ~ (%prm<level> // '1');
         my $targ = %tml<escaped>.(%prm<target>);
@@ -442,20 +442,29 @@ use v6.d;
         }
     },
     'format-x' => sub (%prm, %tml) {
+        my $beg;
+        my $end;
         my $indexedheader = %prm<meta>.elems ?? %prm<meta>[0].join(';') !! %prm<text>;
-        my $beg = qq[
-            <a name="{ %prm<target> // ''}" class="index-entry"
-            data-indexedheader="{ $indexedheader }"></a>
-            { (%prm<text>.defined and %prm<text> ne '') ?? '<span class="glossary-entry">' !! '' }
-        ];
-        my $end = '</span>';
+        my $text = %prm<text> // '';
+        if %prm<context> eq 'Heading' {
+            $beg = qq[<a name="{ %prm<target> }"{ $indexedheader ?? (' data-indexedheader="' ~ $indexedheader ~ '"') !! '' }></a><span class="glossary-entry-heading">];
+            $end = '</span>';
+        }
+        else {
+            my $index-text;
+            $index-text = %prm<meta>.map( { $_.elems ?? ( "\x2983" ~ $_.map({ "\x301a$_\x301b" }) ~ "\x2984") !! "\x301a$_\x301b" })
+                if %prm<meta>.elems;
+            $beg = qq[<a name="{ %prm<target> }" class="index-entry">]
+                    ~ ($index-text && $text ?? qq[<span class="glossary-entry" data-index-text="{ $index-text }">] !! '')
+                    ;
+            $end = ($index-text && $text ?? '</span>' !! '') ~ '</a>';
+        }
         my $mark = "\xFF\xFF";
         if %prm<context>.Str eq 'InCodeBlock' {
             $beg = $mark ~ $beg ~ $mark;
             $end = $mark ~ $end ~ $mark;
         }
-        # if there is indexedheader but no text, must still return beg. If indexh.. but text, then end
-        $beg ~ ( (%prm<text>.defined and %prm<text> ne '') ?? %prm<text> ~ $end !! '' )
+        $beg ~ $text ~ $end
     },
     table => sub (%prm, %tml) {
         my $tb = %tml.prior('table').(%prm, %tml);

--- a/Website/plugins/page-styling/scss/_themes-template-common.scss
+++ b/Website/plugins/page-styling/scss/_themes-template-common.scss
@@ -523,3 +523,14 @@ a.button.is-primary .icon {
         text-align: center;
     }
 }
+a.index-entry {
+    text-decoration: none;
+    cursor: help;
+    span.glossary-entry {
+        padding: 0 0.3em 0 0.3em;
+        border-radius: 0.5em;
+        border: 2px solid $index-border;
+        background-color: $index-background;
+        color: $text;
+    }
+}

--- a/Website/plugins/page-styling/scss/page-styling-dark.scss
+++ b/Website/plugins/page-styling/scss/page-styling-dark.scss
@@ -131,4 +131,9 @@ $search-match: $green;
 
 $homepage-gradient: linear-gradient(180deg, #030303 0.2%, #170F44 1%, #35229E 82.29%, #271974 100%);
 
+$index-background: $scheme-main-bis;
+$index-border: lighten($index-background, 15);
+$index-popup-background: $scheme-invert-bis;
+$index-popup-colour: $primary;
+
 @import "_themes-template-common.scss";

--- a/Website/plugins/page-styling/scss/page-styling-light.scss
+++ b/Website/plugins/page-styling/scss/page-styling-light.scss
@@ -130,4 +130,9 @@ $search-match: $yellow;
 
 $homepage-gradient: linear-gradient(180deg, #051A33 0.2%, #3F103A 1%, #9F0046 82.29%, #B3004F 100%);
 
+$index-background: lighten($yellow, 15);
+$index-border: $index-background;
+$index-popup-background: $grey-light;
+$index-popup-colour: $primary-dark;
+
 @import "_themes-template-common.scss";


### PR DESCRIPTION
This is a rebased form of PR #330. 
Changes to page-styling, in the template for `X<>`
No tooltip.  Image shows `language/operators` page in docs.raku.org (left) and new-raku.finanalyst.org (right).

![Screenshot from 2023-12-29 12-33-19](https://github.com/Raku/doc-website/assets/363676/39342e98-5014-4108-a6ce-afcb09ce263c)
