### PR TITLE
Shortcut that will work on Mac (#308)

### DIFF
--- a/Website/plugins/page-styling/page-styling.js
+++ b/Website/plugins/page-styling/page-styling.js
@@ -158,6 +158,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             })
         }
+        if ( e.key === '\\' ) {
+            // the action should be carried out by the search plugin
+            document.dispatchEvent( searchFocus );
+        }
     });
     // copy code block to clipboard adapted from solution at
     // https://stackoverflow.com/questions/34191780/javascript-copy-string-to-clipboard-as-text-html


### PR DESCRIPTION
- Mac and JS do not work consistently, so testing for altKey in JS does not activate the ALT-L type shortcuts.
- Changing for Command-L breaks other shortcuts
- CTRL-L type shortcuts are widely used for other functions, so need to be avoided
- Single character shortcuts can be implemented, but break search box entry
- `/` is a Firefox / Google shortcut.
- `\` seems to be a compromise and has the single function of moving focus to the search entry box. Once the box has focus, `\` then functions as a letter.