### PR TITLE
Exploring various options for keyboard shortcuts

### DIFF
--- a/Website/plugins/options-search/css/options-search-dark.css
+++ b/Website/plugins/options-search/css/options-search-dark.css
@@ -60,3 +60,8 @@
   font-style: oblique;
   color: gainsboro;
 }
+
+kbd {
+  background-color: rgba(0, 0, 0, 0.1333333333);
+  border: solid 1px;
+}

--- a/Website/plugins/options-search/css/options-search-light.css
+++ b/Website/plugins/options-search/css/options-search-light.css
@@ -60,3 +60,8 @@
   font-style: oblique;
   color: black;
 }
+
+kbd {
+  background-color: rgba(0, 0, 0, 0.1333333333);
+  border: solid 1px;
+}

--- a/Website/plugins/options-search/options-search-templates.raku
+++ b/Website/plugins/options-search/options-search-templates.raku
@@ -7,7 +7,7 @@ use v6.d;
             <div class="navbar-item">
                 <div class="field has-addons">
                     <div class="autoComplete_options">
-                        <input class="control input" id="autoComplete" type="search" dir="ltr" spellcheck=false autocorrect="off" autocomplete="off" autocapitalize="off" placeholder="🔍 Alt-F to search for ...">
+                        <input class="control input" id="autoComplete" type="search" dir="ltr" spellcheck=false autocorrect="off" autocomplete="off" autocapitalize="off" placeholder="🔍 Type f to search for ...">
                     </div>
                     <div class="control" title="Search options">
                         <a class="button is-primary js-modal-trigger"
@@ -25,7 +25,7 @@ use v6.d;
             <div class="modal-content">
                 <div class="box">
                     <p>The last search was: <span id="selected-candidate" class="ss-selected"></span></p>
-                    <p>The search can be accessed using Alt-F</p>
+                    <p>The search input can be selected by typing <kbd>f</kbd></p>
                     <div class="control is-grouped is-grouped-centered options-search-controls">
                         <label class="centreToggle" title="Include extra information (Alt-E)" style="--switch-width: 10.5">
                            <input id="options-search-extra" type="checkbox">

--- a/Website/plugins/options-search/options-search.js
+++ b/Website/plugins/options-search/options-search.js
@@ -15,6 +15,19 @@ var persisted_searchOptions = function () {
 var persist_searchOptions = function (searchOptions) {
     localStorage.setItem('searchOptions', JSON.stringify( searchOptions ))
 };
+var focusOnSearchBar = function() {
+    // make sure when search key is hit, the div with the search bar is made visible
+    document.getElementById('navMenu').classList.add('is-active');
+    document.querySelector('.navbar-burger.burger').classList.add('is-active');
+    document.getElementById('autoComplete').focus();
+};
+
+var unfocusSearchBar = function() {
+    document.getElementById('navMenu').classList.remove('is-active');
+    document.querySelector('.navbar-burger.burger').classList.remove('is-active');
+    document.getElementById('autoComplete').blur();
+};
+
 var category = '';
 var autoCompleteJS;
 var openInTab = false;
@@ -129,6 +142,11 @@ document.addEventListener('DOMContentLoaded', function () {
                     keydown: (event) => {
                         //document.querySelector('.autoComplete_wrapper ul').scrollTop = 0;
                         switch (event.keyCode) {
+                            // Escape
+                            case 27:
+                                autoCompleteJS.close();
+                                unfocusSearchBar();
+                                break;
                             // Down/Up arrow
                             case 40:
                             case 38:
@@ -259,8 +277,5 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 });
 document.addEventListener('focusOnSearchBar', function() {
-    // make sure when search key is hit, the div with the search bar is made visible
-    document.getElementById('navMenu').classList.add('is-active');
-    document.querySelector('.navbar-burger.burger').classList.add('is-active');
-    document.getElementById('autoComplete').focus();
+    focusOnSearchBar();
 });

--- a/Website/plugins/options-search/scss/_options-search-common.scss
+++ b/Website/plugins/options-search/scss/_options-search-common.scss
@@ -65,3 +65,8 @@ $weight-bold: 700;
         color: darken($text, 10);
     }
 }
+
+kbd {
+    background-color: #0002;
+    border: solid 1px;
+}

--- a/Website/plugins/page-styling/page-styling.js
+++ b/Website/plugins/page-styling/page-styling.js
@@ -158,6 +158,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             })
         }
+        if ( e.key === '\\' ) {
+            // the action should be carried out by the search plugin
+            document.dispatchEvent( searchFocus );
+        }
     });
     // copy code block to clipboard adapted from solution at
     // https://stackoverflow.com/questions/34191780/javascript-copy-string-to-clipboard-as-text-html

--- a/Website/plugins/page-styling/page-styling.js
+++ b/Website/plugins/page-styling/page-styling.js
@@ -84,6 +84,12 @@ const searchFocus = new CustomEvent('focusOnSearchBar');
             "settings": { "alt": true, "ctrl": false, "letter": 'g', "shortcuts": 'enabled' },
         };
         persist_pageOptions( pageOptionsState );
+    } else if ( pageOptionsState.search.alt ) {
+        // TODO: we need to temporarily migrate the keyboard shortcut
+        // to not use alt however, we need a way to migrate the state
+        // as we may change the other shortcuts.
+        pageOptionsState.search.alt = false;
+        persist_pageOptions( pageOptionsState );
     }
 })();
 

--- a/Website/plugins/page-styling/page-styling.js
+++ b/Website/plugins/page-styling/page-styling.js
@@ -79,7 +79,7 @@ const searchFocus = new CustomEvent('focusOnSearchBar');
     if ( pageOptionsState == null ) {
         pageOptionsState = {
             "toc": { "alt": true, "ctrl": false, "letter": 't', "panel": 'closed' },
-            "search": { "alt": true, "ctrl": false, "letter": 'f' },
+            "search": { "alt": false, "ctrl": false, "letter": 'f' },
             "theme": { "alt": true, "ctrl": false, "letter": 'k' },
             "settings": { "alt": true, "ctrl": false, "letter": 'g', "shortcuts": 'enabled' },
         };
@@ -127,15 +127,18 @@ document.addEventListener('DOMContentLoaded', function () {
     });
     // keyboard events to change pageOptions
     document.addEventListener('keydown', e => {
-        if ( pageOptionsState && pageOptionsState.settings.shortcuts !== 'disabled') {
+        if ( e.target == document.body
+             && pageOptionsState
+             && pageOptionsState.settings.shortcuts !== 'disabled') {
              Object.keys( pageOptionsState ).forEach( attr => {
-                if ( (
-                        ( e.altKey && pageOptionsState[ attr ].alt )
-                        ||
-                        ( e.ctrlKey && pageOptionsState[ attr ].ctrl )
-                      )
-                    && e.key === pageOptionsState[ attr ].letter
-                    )
+                if ( ( e.altKey === pageOptionsState[ attr ].alt )
+                     &&
+                     ( e.ctrlKey === pageOptionsState[ attr ].ctrl )
+                     &&
+                     (e.key === pageOptionsState[ attr ].letter
+                      ||
+                      e.keyCode === pageOptionsState[ attr ].letter.toUpperCase().charCodeAt(0) )
+                   )
                 {
                     e.preventDefault();
                     switch( attr ) {
@@ -158,10 +161,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             })
         }
-        if ( e.key === '\\' ) {
-            // the action should be carried out by the search plugin
-            document.dispatchEvent( searchFocus );
-        }
     });
     // copy code block to clipboard adapted from solution at
     // https://stackoverflow.com/questions/34191780/javascript-copy-string-to-clipboard-as-text-html
@@ -182,5 +181,3 @@ document.addEventListener('DOMContentLoaded', function () {
         document.body.removeChild(container);
     });
 });
-
-


### PR DESCRIPTION
A few experiments in this one PR as part of Issue #308. I'm interested in hearing any feedback about which option works better .

1. Changes the search binding from `Alt+F` to just `F` (more specifically lowercase `F`). I added a condition in the event listener to ensure the event target was from the document body. This prevents the event listener from swallowing the single characters that it matches while typing in the input field.
2. I added a binding in the search plugin to unfocus (or blur) the input field and close the search results when the `Escape` key is pressed.
3. Checked the `event.keyCode` against the unicode value for the bound character to fix `Alt` (aka `Option`) modifier to work on Mac. I'd rather move away from this approach because the `keyCode` property is deprecated and may have unexpected results on different keyboard layouts.

