### PR TITLE
resolves #338 edit content for all pages

### DIFF
--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -291,7 +291,7 @@ use v6.d;
                     <div class="modal-content">
                         <div class="box">
                             <p>This is an automatically generated page and cannot be edited directly. Text in Composite
-                            pages, (urls starting with 'routine' or 'syntax') can be edited by clicking on the
+                            pages, (URLs starting with 'routine' or 'syntax') can be edited by clicking on the
                             link labeled 'in context', and editing the text there.</p>
                             <p>Exit this popup by pressing &lt;Escape&gt;, or clicking on X or on the background.</p>
                         </div>

--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -249,7 +249,7 @@ use v6.d;
         </div>
         FRIGHT
     },
-    page-edit => sub (%prm, %tml) { say %prm<config><path>; say  %prm<config><path> ~~ / 'Website/structure-sources/' .+ $ / ;
+    page-edit => sub (%prm, %tml) {
         if %prm<config><path> ~~ / ^ .+ 'docs/' ( .+) $ / {
             qq:to/BLOCK/
             <div class="page-edit">

--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -249,19 +249,57 @@ use v6.d;
         </div>
         FRIGHT
     },
-    page-edit => sub (%prm, %tml) {
-        return '' unless %prm<config><path> ~~ / ^ .+ 'docs/' ( .+) $ /;
-        qq:to/BLOCK/
-        <div class="page-edit">
-            <a class="button page-edit-button"
-               href="https://github.com/Raku/doc/edit/main/{ %tml<escaped>.(~$0) }"
-               title="Edit this page.">
-              <span class="icon is-right">
-                <i class="fas fa-pen-alt is-medium"></i>
-              </span>
-            </a>
-          </div>
-        BLOCK
+    page-edit => sub (%prm, %tml) { say %prm<config><path>; say  %prm<config><path> ~~ / 'Website/structure-sources/' .+ $ / ;
+        if %prm<config><path> ~~ / ^ .+ 'docs/' ( .+) $ / {
+            qq:to/BLOCK/
+            <div class="page-edit">
+                <a class="button page-edit-button"
+                   href="https://github.com/Raku/doc/edit/main/{ %tml<escaped>.(~$0) }"
+                   title="Edit this page.">
+                  <span class="icon is-right">
+                    <i class="fas fa-pen-alt is-medium"></i>
+                  </span>
+                </a>
+              </div>
+            BLOCK
+        }
+        elsif %prm<config><path> ~~ / 'Website/structure-sources/' .+ $ / {
+            qq:to/BLOCK/
+            <div class="page-edit">
+                <a class="button page-edit-button"
+                   href="https://github.com/Raku/doc-website/edit/main/{ %tml<escaped>.(~$/) }"
+                   title="Edit this page.">
+                  <span class="icon is-right">
+                    <i class="fas fa-pen-alt is-medium"></i>
+                  </span>
+                </a>
+              </div>
+            BLOCK
+        }
+        else {
+            qq:to/BLOCK/
+                <div class="page-edit">
+                    <a class="button js-modal-trigger"
+                        data-target="page-edit-info">
+                        <span class="icon">
+                            <i class="fas fa-pen-alt is-medium"></i>
+                        </span>
+                    </a>
+                </div>
+                <div id="page-edit-info" class="modal">
+                    <div class="modal-background"></div>
+                    <div class="modal-content">
+                        <div class="box">
+                            <p>This is an automatically generated page and cannot be edited directly. Text in Composite
+                            pages, (urls starting with 'routine' or 'syntax') can be edited by clicking on the
+                            link labeled 'in context', and editing the text there.</p>
+                            <p>Exit this popup by pressing &lt;Escape&gt;, or clicking on X or on the background.</p>
+                        </div>
+                    </div>
+                    <button class="modal-close is-large" aria-label="close"></button>
+                </div>
+            BLOCK
+        }
     },
     heading => sub (%prm, %tml) {
         my $txt = %prm<text>;


### PR DESCRIPTION
- adds edit crayon and content to both Composite and structure docs
- composite files get a popup suggesting how to edit source
- structure files get thrown to doc-website to edit structure source, similar to sources in `Raku/docs`