### PR TITLE
fixes #346 missing syntax files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /Website/structure-cache/
 /Website/reports/
 /Website/typegraph/typegraphs/*.svg
+/raku-doc-website.iml

--- a/Website/plugins/secondaries/header-templates.raku
+++ b/Website/plugins/secondaries/header-templates.raku
@@ -70,7 +70,7 @@ use v6.d;
             .+ 'data-indexedheader="'
             (.+?)
             '"></a>'
-            \s* '<span class="glossary-entry">'
+            \s* '<span class="glossary-entry-heading">'
             (.+?)
             '</span>'
             /;

--- a/raku-doc-website.iml
+++ b/raku-doc-website.iml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PERL6_MODULE_TYPE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
- files of the form `syntax/qxx` were not being generated in doc-website, but were generated in new-raku.
- a secondary generation error occurred some time back, but the effect was only just noticed.
- fix is minor.
- minor change to .gitignore
- a Comma configuration file seeped from my workspace into repository, so deleted.