### PR TITLE
Update types.rakudoc Built-in vs. Built in

### DIFF
--- a/Website/structure-sources/types.rakudoc
+++ b/Website/structure-sources/types.rakudoc
@@ -1,6 +1,6 @@
 =begin pod :no-glossary :page-content-columns
 =TITLE Documented Types
-=SUBTITLE Built in types
+=SUBTITLE Built-in types
 
 This is a list of the built-in types that are documented, sorted by class/enum/module/role
 and by categories.


### PR DESCRIPTION
Built-in is correct as an adjective.