### PR TITLE
Publish a "docs-dev" tagged image

### DIFF
--- a/.buildkite/container.sh
+++ b/.buildkite/container.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 
+set -eu
+
+image_tag=$1
+
 c=$(buildah from docker.io/caddy:latest)
 buildah add $c raku-doc-website.tar.gz /usr/share/caddy
 buildah add $c Caddyfile /etc/caddy/Caddyfile
-buildah commit --rm $c quay.io/colemanx/raku-doc-website:latest
-buildah push quay.io/colemanx/raku-doc-website:latest
+buildah commit --rm $c quay.io/colemanx/raku-doc-website:$image_tag
+buildah push quay.io/colemanx/raku-doc-website:$image_tag
 

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -10,12 +10,21 @@ steps:
       - "buildkite-agent artifact upload ./raku-doc-website.tar.gz"
       - rm ./raku-doc-website.tar.gz
 
-  - label: "Containerize static assets"
+  - label: "Containerize static assets (tag: latest)"
     key: container
     if: build.branch == 'main'
     depends_on:
       - build
     commands:
       - buildkite-agent artifact download --step build raku-doc-website.tar.gz .
-      - ./.buildkite/container.sh
+      - ./.buildkite/container.sh latest
+
+  - label: "Containerize static assets (tag: docs-dev)"
+    key: container-dev
+    if: build.branch == 'docs-dev'
+    depends_on:
+      - build
+    commands:
+      - buildkite-agent artifact download --step build raku-doc-website.tar.gz .
+      - ./.buildkite/container.sh docs-dev
 


### PR DESCRIPTION
On every push to a git branch called "docs-dev", a container tagged with "docs-dev" will be pushed, overwriting the existing image.

Commits to main (via PRs) will continue to publish to the "latest" tag.

Refs #75 