### PR TITLE
Start creating EBook mode

### DIFF
--- a/EBook/configs/01-config.raku
+++ b/EBook/configs/01-config.raku
@@ -1,0 +1,23 @@
+%(
+    :mode-sources<structure-sources>, # content for the website structure
+    :mode-cache<structure-cache>, # cache for the above
+    :mode-ignore<
+        footnotes.rakudoc glossary.rakudoc toc.rakudoc language.rakudoc programs.rakudoc
+    >, # files to ignore
+    :mode-obtain(), # not a remote repository
+    :mode-refresh(), # ditto
+    :mode-extensions<rakudoc pod6>, # only use these for content
+    :no-code-escape,# must use this when using highlighter
+    :destination<../ebook_final>, # where the html files will be sent relative to Mode directory
+    :asset-out-path<assets>, # where the image assets will be sent relative to destination
+    :landing-place<index>, # the first file
+    :report-path<reports>,
+    :output-ext<xhtml>,
+    :templates<templates>,
+    :!no-status, # show progress
+    :!collection-info, # do not show milestone data
+    :!without-report, # make a report - default is False, but set True
+    :!without-completion, # we want the Cro app to start
+    :!full-render, # force rendering of all output files
+    :no-preserve-state, # we do not want to archive intermediate data
+)

--- a/EBook/configs/02-plugins.raku
+++ b/EBook/configs/02-plugins.raku
@@ -1,0 +1,19 @@
+%(
+    :plugins<plugins>,
+    :plugin-format<html>,
+    plugins-required => %(
+        :setup<raku-doc-setup>,
+        :render<
+            hiliter
+            ebook-embed
+            font-awesome tablemanager rakudoc-table
+            camelia simple-extras listfiles images deprecate-span filterlines
+            typegraph generated
+            gather-js-jq gather-css
+        >,
+        :report<link-plugin-assets-report>,
+        :transfer<gather-js-jq gather-css images raku-doc-setup ebook-embed>,
+        :compilation<listfiles ebook-embed>,
+        :completion<ebook-embed>,
+    ),
+)

--- a/EBook/configs/03-plugin-options.raku
+++ b/EBook/configs/03-plugin-options.raku
@@ -1,0 +1,5 @@
+%(
+    plugin-options => %(
+        ebook-embed => %( :spine<introduction reference miscellaneous> ),
+    ),
+)


### PR DESCRIPTION
- the aim of this node is to create an epub version of the Raku Documentation suite
- An epub can be described as a web site encapsulated into a file.
- See issue #356 for initial design goals.