### PR TITLE
Routines table had some incorrect escaping and hard-coded HTML

### DIFF
--- a/Website/plugins/secondaries/config.raku
+++ b/Website/plugins/secondaries/config.raku
@@ -12,5 +12,5 @@
 	:transfer<cleanup.raku>,
 	:hash-urls,
 	:information('hash-urls',),
-	:version<0.4.7>,
+	:version<0.5.0>,
 )

--- a/Website/plugins/secondaries/gen-secondaries.raku
+++ b/Website/plugins/secondaries/gen-secondaries.raku
@@ -154,7 +154,8 @@ sub (ProcessedPod $pp, %processed, %options) {
                     .<category>.tc,
                     $dn,
                     .<subkind>,
-                    qq[[<a href="/{ .<source> }#{ .<target> }">{ .<source> }</a>]]
+                    .<source>,
+                    .<target>
                 ];
             }
             # Construct TOC

--- a/Website/plugins/tablemanager/config.raku
+++ b/Website/plugins/tablemanager/config.raku
@@ -9,7 +9,7 @@
 	:name<tablemanager>,
 	:render,
 	:template-raku<tm-temps.raku>,
-	:version<0.1.0>,
+	:version<0.2.0>,
 	:jquery<tableManager.js>,
 	:add-css<
 		tm-styling.css

--- a/Website/plugins/tablemanager/tm-temps.raku
+++ b/Website/plugins/tablemanager/tm-temps.raku
@@ -23,9 +23,13 @@ use v6.d;
                         }
                         $head ~= "</tr>\n</thead>\n";
                         my $body = "<tbody>\n";
-                        for @rows[ 1..^$d-rows ] -> @row {
-                            $body ~= '<tr>' ~ @row.map({ "<td>$_\</td>" }).join('') ~ "</tr>\n";
-                        }
+                        $body ~= [~] @rows[ 1..^$d-rows ].map({
+                            qq:to/ROW/;
+                                <tr><td>{ .[0] }</td><td>{ .[1].trans( qw｢ <    >    &   " ｣ => qw｢ &lt; &gt; &amp; &quot; ｣) }</td>
+                                <td>{ .[2].trans(qw｢ <    >    &   " ｣ => qw｢ &lt; &gt; &amp; &quot; ｣) }</td>
+                                <td><a href="{ .[3] }#{ .[4] }">{ .[3] }</a></td></tr>
+                            ROW
+                        });
                         $body ~= "\n</tbody>\n\</table>\n</div>";
                         $rv ~= $head ~ $body ~ qq:to/SCR/
                             <script>


### PR DESCRIPTION
- Some routine names, eg `<?>`, were not HTML escaped
- The routines dataset was no generic enough
- Dataset created in *secondaries* and used in *tablemanager*
- Refactored secondaries and tablemanager plugins.