### PR TITLE
First step to issue #359, no change to the HTML output

### DIFF
--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -8,12 +8,12 @@
             filtered-toc
             camelia simple-extras listfiles images deprecate-span filterlines
             tablemanager secondaries typegraph generated
-            options-search link-error-test
+            options-search link-error-test sqlite-db
             gather-js-jq gather-css sitemap
         >,
         :report<link-plugin-assets-report sitemap>,
-        :transfer<secondaries gather-js-jq gather-css images raku-doc-setup options-search>,
-        :compilation<secondaries listfiles link-error-test options-search>,
+        :transfer<secondaries gather-js-jq gather-css images raku-doc-setup options-search sqlite-db>,
+        :compilation<secondaries listfiles link-error-test options-search sqlite-db>,
         :completion<cro-app>,
     ),
 )

--- a/Website/configs/03-plugin-options.raku
+++ b/Website/configs/03-plugin-options.raku
@@ -8,10 +8,15 @@
         link-error-test => %(
             :no-remote,
             :run-tests,
+            :structure-files<introduction about index miscellaneous reference routines types>,
         ),
         sitemap => %(
             :root-domain<https://docs.raku.org>,
             :sitemap-destination<../../rendered_html>,
-        )
+        ),
+        sqlite-db => %(
+            :database-dir<../../sqlite_dir>,
+            :db-filename<sqlite-db-definition.sql>,
+        ),
     ),
 )

--- a/Website/plugins/sqlite-db/README.rakudoc
+++ b/Website/plugins/sqlite-db/README.rakudoc
@@ -1,0 +1,19 @@
+=begin rakudoc
+=TITLE sqlite-db is a plugin for Collection
+
+The plugin is for the render, compilation, & transfer milestones
+
+Relies on 'secondaries' plugin creating routines data for the 'tablemanager' plugin. So the plugin must
+follow the 'secondaries' plugin.
+
+Outputs a file for the sqlite executable. Transfers it to the directory named in the `database-dir` field.
+
+Transfer cleans up the plugin directory.
+
+=head1 Custom blocks
+None
+
+=head1 Templates
+None
+
+=end rakudoc

--- a/Website/plugins/sqlite-db/cleanup.raku
+++ b/Website/plugins/sqlite-db/cleanup.raku
@@ -1,0 +1,6 @@
+#!/usr/bin/env raku
+use v6.d;
+sub ($pr, %processed, %options --> Array) {
+    $pr.get-data('sqlite-db')<db-filename>.IO.unlink;
+    []
+}

--- a/Website/plugins/sqlite-db/compilation-callable.raku
+++ b/Website/plugins/sqlite-db/compilation-callable.raku
@@ -1,0 +1,30 @@
+use v6.d;
+sub ( $pr, %processed, %options) {
+    my $sql;
+    my %config = $pr.get-data('sqlite-db');
+    if $pr.plugin-datakeys (cont) 'tablemanager' {
+        my @rows = $pr.get-data('tablemanager').<dataset><routines>.list;
+        $sql = q:to/SQL/;
+            CREATE TABLE IF NOT EXISTS routines (
+                Category TEXT,
+                Name TEXT,
+                Type TEXT,
+                URL TEXT
+            );
+            INSERT INTO routines ( Category, Name, Type, URL )
+            VALUES
+            SQL
+        $sql ~= [~] @rows[0 ^..* ].map({
+                '("' ~ .[0] ~ '" , "' ~ .[1] ~ '" , "'~ .[2] ~ '" , "'
+               ~ .[3] ~ '#' ~ .[4]
+               ~ '")'
+               })
+               .join(",\n") ~ ";\n";
+    }
+    else {
+        # change the line below to create a string that will cause a better sqlite result
+       $sql = 'There is no tablemanager data so no routines'
+    }
+    %config<db-filename>.IO.spurt: $sql;
+    [ [ %config<database-dir> ~ '/' ~ %config<db-filename> , 'myself', %config<db-filename> ], ]
+}

--- a/Website/plugins/sqlite-db/compilation-callable.raku
+++ b/Website/plugins/sqlite-db/compilation-callable.raku
@@ -5,12 +5,6 @@ sub ( $pr, %processed, %options) {
     if $pr.plugin-datakeys (cont) 'tablemanager' {
         my @rows = $pr.get-data('tablemanager').<dataset><routines>.list;
         $sql = q:to/SQL/;
-            CREATE TABLE IF NOT EXISTS routines (
-                Category TEXT,
-                Name TEXT,
-                Type TEXT,
-                URL TEXT
-            );
             INSERT INTO routines ( Category, Name, Type, URL )
             VALUES
             SQL
@@ -23,8 +17,11 @@ sub ( $pr, %processed, %options) {
     }
     else {
         # change the line below to create a string that will cause a better sqlite result
-       $sql = 'There is no tablemanager data so no routines'
+       $sql = 'There is no tablemanager data'
     }
     %config<db-filename>.IO.spurt: $sql;
-    [ [ %config<database-dir> ~ '/' ~ %config<db-filename> , 'myself', %config<db-filename> ], ]
+    [
+        [ %config<database-dir> ~ '/schema.sql' , 'myself', 'schema.sql' ],
+        [ %config<database-dir> ~ '/' ~ %config<db-filename> , 'myself', %config<db-filename> ]
+    ]
 }

--- a/Website/plugins/sqlite-db/config.raku
+++ b/Website/plugins/sqlite-db/config.raku
@@ -1,0 +1,16 @@
+%(
+	:auth<collection>,
+	:authors(
+		"finanalyst",
+	),
+	:compilation<compilation-callable.raku>,
+	:custom-raku(),
+	:license<Artistic-2.0>,
+	:name<sqlite-db>,
+	:render,
+	:transfer<cleanup.raku>,
+	:template-raku(),
+	:version<0.1.0>,
+	:database-dir<../sqlite-db>,
+	:db-filename<sqlite-db.sql>,
+)

--- a/Website/plugins/sqlite-db/schema.sql
+++ b/Website/plugins/sqlite-db/schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS routines (
+    Category TEXT,
+    Name TEXT,
+    Type TEXT,
+    URL TEXT
+);

--- a/Website/plugins/sqlite-db/t/05-basic.rakutest
+++ b/Website/plugins/sqlite-db/t/05-basic.rakutest
@@ -1,0 +1,5 @@
+use v6.d;
+use Test;
+use Test::CollectionPlugin;
+test-plugin();
+done-testing


### PR DESCRIPTION
- add sqlite-db plugin
- plugin accesses the dataset created for the Routines page in the website
- the data is formatted into the rows of an sqlite table
- the completed sqlite database is output into a filename specified in the `configs/03-plugin-options.raku` config file, so changing the value of the `db-filename` field of the `sqlite-db` sub-hash changes the output file name.
- the sqlite file is moved by Collection to a directory defined by 'database-dir' relative to the directory in which Collection runs. As set up here, the directory sqlite_dir will be at the same level as the existing renedered_html