### PR TITLE
resolve issues #342 & #362 make indexed things searchable

### DIFF
--- a/Website/plugins/options-search/options-search.js
+++ b/Website/plugins/options-search/options-search.js
@@ -35,6 +35,7 @@ var openInTab = false;
 document.addEventListener('DOMContentLoaded', function () {
     searchOptions = persisted_searchOptions();
     var searchDataObtained = false;
+    // searchOptions will always be null, unless option changed from default and stored
     if ( searchOptions == null ) {
         searchOptions  = {
             "loose": false,
@@ -45,7 +46,6 @@ document.addEventListener('DOMContentLoaded', function () {
             "newtab": false,
             "extra": true
         };
-        persist_searchOptions( searchOptions );
     }
     var selectedCandidate = document.getElementById('selected-candidate');
     selectedCandidate.innerHTML = 'No page selected';

--- a/Website/plugins/options-search/options-search.js
+++ b/Website/plugins/options-search/options-search.js
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', function () {
         searchOptions  = {
             "loose": false,
             "headings": true,
-            "indexed": false,
+            "indexed": true,
             "primary": true,
             "composite": true,
             "newtab": false,


### PR DESCRIPTION
- previous default was not to make them searchable (because too  many things were duplicated)
- the duplicates have now been reduced.
- users who have used the site before will need to remove the localstorage to over-ride the previous default.