### PR TITLE
Docs dev

### DIFF
--- a/EBook/configs/01-config.raku
+++ b/EBook/configs/01-config.raku
@@ -1,0 +1,23 @@
+%(
+    :mode-sources<structure-sources>, # content for the website structure
+    :mode-cache<structure-cache>, # cache for the above
+    :mode-ignore<
+        footnotes.rakudoc glossary.rakudoc toc.rakudoc language.rakudoc programs.rakudoc
+    >, # files to ignore
+    :mode-obtain(), # not a remote repository
+    :mode-refresh(), # ditto
+    :mode-extensions<rakudoc pod6>, # only use these for content
+    :no-code-escape,# must use this when using highlighter
+    :destination<../ebook_final>, # where the html files will be sent relative to Mode directory
+    :asset-out-path<assets>, # where the image assets will be sent relative to destination
+    :landing-place<index>, # the first file
+    :report-path<reports>,
+    :output-ext<xhtml>,
+    :templates<templates>,
+    :!no-status, # show progress
+    :!collection-info, # do not show milestone data
+    :!without-report, # make a report - default is False, but set True
+    :!without-completion, # we want the Cro app to start
+    :!full-render, # force rendering of all output files
+    :no-preserve-state, # we do not want to archive intermediate data
+)

--- a/EBook/configs/02-plugins.raku
+++ b/EBook/configs/02-plugins.raku
@@ -1,0 +1,19 @@
+%(
+    :plugins<plugins>,
+    :plugin-format<html>,
+    plugins-required => %(
+        :setup<raku-doc-setup>,
+        :render<
+            hiliter
+            ebook-embed
+            font-awesome tablemanager rakudoc-table
+            camelia simple-extras listfiles images deprecate-span filterlines
+            typegraph generated
+            gather-js-jq gather-css
+        >,
+        :report<link-plugin-assets-report>,
+        :transfer<gather-js-jq gather-css images raku-doc-setup ebook-embed>,
+        :compilation<listfiles ebook-embed>,
+        :completion<ebook-embed>,
+    ),
+)

--- a/EBook/configs/03-plugin-options.raku
+++ b/EBook/configs/03-plugin-options.raku
@@ -1,0 +1,5 @@
+%(
+    plugin-options => %(
+        ebook-embed => %( :spine<introduction reference miscellaneous> ),
+    ),
+)

--- a/META6.json
+++ b/META6.json
@@ -8,10 +8,10 @@
   ],
   "auth": "zef:raku",
   "depends": [
-    "Raku::Pod::Render:ver<4.7.2+>",
-    "Pod::From::Cache:ver<0.5.0+>",
+    "Raku::Pod::Render:ver<4.10.5+>",
+    "Pod::From::Cache:ver<0.5.4+>",
     "RakuConfig:ver<0.7.3+>",
-    "Collection:ver<0.17.2+>",
+    "Collection:ver<0.17.3+>",
     "Terminal::ANSIColor:ver<0.9+>:auth<zef:lizmat>",
     "Doc::TypeGraph:ver<2.2.1.1+>",
     "Doc::TypeGraph::Viz:ver<2.2.1.1+>",

--- a/META6.json
+++ b/META6.json
@@ -11,7 +11,7 @@
     "Raku::Pod::Render:ver<4.7.2+>",
     "Pod::From::Cache:ver<0.5.0+>",
     "RakuConfig:ver<0.7.3+>",
-    "Collection:ver<0.15.1+>",
+    "Collection:ver<0.17.2+>",
     "Terminal::ANSIColor:ver<0.9+>:auth<zef:lizmat>",
     "Doc::TypeGraph:ver<2.2.1.1+>",
     "Doc::TypeGraph::Viz:ver<2.2.1.1+>",

--- a/Website/configs/01-config.raku
+++ b/Website/configs/01-config.raku
@@ -4,6 +4,11 @@
     :mode-ignore<search.rakudoc error-report.rakudoc language.rakudoc programs.rakudoc>, # files to ignore
     :mode-obtain(), # not a remote repository
     :mode-refresh(), # ditto
+    #| the array of strings sent to the OS by run to obtain the repo's commit-id
+    :mode-source-versioning<git -C Website rev-parse --short HEAD>,
+    #| the array of strings sent to the OS by run to obtain version data per file
+    #| the string is appended by the path of the file before the run is executed
+    :mode-source-per-file-versioning('git','-C','Website/structure-sources', 'log', '-1', '--format="%h %cs"', '--'),
     :mode-extensions<rakudoc pod6>, # only use these for content
     :no-code-escape,# must use this when using highlighter
     :destination<../rendered_html>, # where the html files will be sent relative to Mode directory

--- a/Website/plugins/generated/template.raku
+++ b/Website/plugins/generated/template.raku
@@ -7,7 +7,7 @@ use v6.d;
         { %prm<raw-contents> // '' }
         <ul>
             <li>Based on <a href="https://github.com/Raku/doc">Raku/doc (documentation content)</a> source commit { %prm<generated><commit-id>.trim }.</li>
-            <li>Based on <a href="https://github.com/Raku/doc-website">Raku/doc-website (website tooling)</a> source commit: ' ~ %prm<generated><mode-commit-id>.trim ~ '.</li>')
+            <li>Based on <a href="https://github.com/Raku/doc-website">Raku/doc-website (website tooling)</a> source commit: { %prm<generated><mode-commit-id>.trim}.</li>
             <li>Generated on { %prm<generated><g-date> } at { %prm<generated><g-time> } UTC.</li>
         </ul>
         </div>

--- a/Website/plugins/generated/template.raku
+++ b/Website/plugins/generated/template.raku
@@ -6,7 +6,8 @@ use v6.d;
         <div class="collection-generated">
         { %prm<raw-contents> // '' }
         <ul>
-            <li>Based on commit { %prm<generated><commit-id>.trim }.</li>
+            <li>Based on <a href="https://github.com/Raku/doc">Raku/doc (documentation content)</a> source commit { %prm<generated><commit-id>.trim }.</li>
+            <li>Based on <a href="https://github.com/Raku/doc-website">Raku/doc-website (website tooling)</a> source commit: ' ~ %prm<generated><mode-commit-id>.trim ~ '.</li>')
             <li>Generated on { %prm<generated><g-date> } at { %prm<generated><g-time> } UTC.</li>
         </ul>
         </div>

--- a/Website/plugins/page-styling/config.raku
+++ b/Website/plugins/page-styling/config.raku
@@ -8,7 +8,7 @@
 	:name<page-styling>,
 	:render<move-images.raku>,
 	:template-raku<page-styling.raku>,
-	:version<0.2.21>,
+	:version<0.3.1>,
 	:add-css<
 		css/page-styling-main.css
 		css/page-styling-dark.css css/page-styling-light.css

--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -229,7 +229,23 @@ use v6.d;
         BLOCK
     },
     footer-left => sub (%prm, %tml ) {
-        q:to/FLEFT/
+        my $commit;
+        if %prm<config><last-edited>:exists and %prm<config><last-edited>.so {
+            $commit = qq:to/TIME/;
+                    <div class="level-item" title="{ %prm<config><last-edited> }">
+                      <a>Commit</a>
+                    </div>
+                TIME
+        }
+        elsif %prm<config><last-edited>:exists {
+            $commit = q:to/TIME/;
+                    <div class="level-item" title="Unavailable">
+                      <a>Commit</a>
+                    </div>
+                TIME
+        }
+        else { $commit = '' }
+        qq:to/FLEFT/
         <div class="level-left">
             <div class="level-item">
               <a href="/about">About</a>
@@ -237,6 +253,7 @@ use v6.d;
             <div class="level-item">
               <a id="toggle-theme">Toggle theme</a>
             </div>
+            $commit
         </div>
         FLEFT
     },
@@ -250,12 +267,20 @@ use v6.d;
         FRIGHT
     },
     page-edit => sub (%prm, %tml) {
+        my $commit = '';
+        $commit = %prm<config><last-edited> if %prm<config><last-edited>:exists;
+        with $commit {
+            $commit = '&#13;Commit: ' ~ $commit;
+        }
+        else {
+            $commit = '&#13;Commit: Unavailable'
+        }
         if %prm<config><path> ~~ / ^ .+ 'docs/' ( .+) $ / {
             qq:to/BLOCK/
             <div class="page-edit">
                 <a class="button page-edit-button"
                    href="https://github.com/Raku/doc/edit/main/{ %tml<escaped>.(~$0) }"
-                   title="Edit this page.">
+                   title="Edit this page.$commit">
                   <span class="icon is-right">
                     <i class="fas fa-pen-alt is-medium"></i>
                   </span>
@@ -268,7 +293,7 @@ use v6.d;
             <div class="page-edit">
                 <a class="button page-edit-button"
                    href="https://github.com/Raku/doc-website/edit/main/{ %tml<escaped>.(~$/) }"
-                   title="Edit this page.">
+                   title="Edit this page.$commit">
                   <span class="icon is-right">
                     <i class="fas fa-pen-alt is-medium"></i>
                   </span>

--- a/config.raku
+++ b/config.raku
@@ -10,6 +10,11 @@ use v6.d;
     #| assumes CWD set to the directory of sources
     #:source-refresh(),
     :source-refresh<git -C local_raku_docs/ pull>,
+    #| the array of strings sent to the OS by run to obtain the repo's commit-id
+    :source-versioning<git -C local_raku_docs/doc rev-parse --short HEAD>,
+    #| the array of strings sent to the OS by run to obtain version data per file
+    #| the string is appended by the path of the file before the run is executed
+    :source-per-file-versioning('git','-C','local_raku_docs/doc', 'log', '-1', '--format="%h %cs"', '--'),
     # processing options independent of Mode
     # by default, unless set in config file, options are False
     :!without-processing, # process all files if possible


### PR DESCRIPTION
This is now working as planned on [new-raku eg 101-basics](https://new-raku.finanalyst.org/language/101-basics)
Also try [about](https://new-raku.finanalyst.org/about) where the information in the page is about the repo, with separate information about the Raku/doc-website files, and the Raku/docs files, as well as information about the 'about.rakudoc' file itself (not its contents) in the Commit footer and edit button