### PR TITLE
Fix Issue #368 reset button in search config

### DIFF
--- a/Website/plugins/options-search/config.raku
+++ b/Website/plugins/options-search/config.raku
@@ -11,7 +11,7 @@
 	:name<options-search>,
 	:render,
 	:template-raku<options-search-templates.raku>,
-	:version<0.1.17>,
+	:version<0.1.23>,
 	:information<css-link>,
 	:add-css<css/options-search-light.css css/options-search-dark.css>,
 	:js-link(

--- a/Website/plugins/options-search/options-search-templates.raku
+++ b/Website/plugins/options-search/options-search-templates.raku
@@ -25,7 +25,6 @@ use v6.d;
             <div class="modal-content">
                 <div class="box">
                     <p>The last search was: <span id="selected-candidate" class="ss-selected"></span></p>
-                    <p>The search input can be selected by typing <kbd>f</kbd></p>
                     <div class="control is-grouped is-grouped-centered options-search-controls">
                         <label class="centreToggle" title="Include extra information (Alt-E)" style="--switch-width: 10.5">
                            <input id="options-search-extra" type="checkbox">
@@ -80,6 +79,7 @@ use v6.d;
                         <p>Once a search candidate has been chosen, it can be opened in a new tab or in the current
                         tab (Alt-Q)</p>
                         <p>If all else fails, an item is added to use the Google search engine on the whole site</p>
+                        <button class="button is-warning" id="options-search-reset-defaults">Clear options, reset to defaults</button>
                         <p>Exit this page by pressing &lt;Escape&gt;, or clicking on X or on the background.</p>
                     </div>
                 </div>

--- a/Website/plugins/options-search/options-search.js
+++ b/Website/plugins/options-search/options-search.js
@@ -31,13 +31,7 @@ var unfocusSearchBar = function() {
 var category = '';
 var autoCompleteJS;
 var openInTab = false;
-
-document.addEventListener('DOMContentLoaded', function () {
-    searchOptions = persisted_searchOptions();
-    var searchDataObtained = false;
-    // searchOptions will always be null, unless option changed from default and stored
-    if ( searchOptions == null ) {
-        searchOptions  = {
+var defaultOptions = {
             "loose": false,
             "headings": true,
             "indexed": true,
@@ -46,7 +40,19 @@ document.addEventListener('DOMContentLoaded', function () {
             "newtab": false,
             "extra": true
         };
+
+document.addEventListener('DOMContentLoaded', function () {
+    searchOptions = persisted_searchOptions();
+    var searchDataObtained = false;
+    // searchOptions will always be null until an option is changed from default and stored
+    if ( searchOptions == null ) {
+        searchOptions  = defaultOptions;
     }
+    document.getElementById('options-search-reset-defaults').addEventListener('click', function () {
+        localStorage.removeItem('searchOptions');
+        searchOptions = defaultOptions;
+        window.location.reload();
+    })
     var selectedCandidate = document.getElementById('selected-candidate');
     selectedCandidate.innerHTML = 'No page selected';
     document.getElementById('autoComplete').addEventListener('focus', function () {


### PR DESCRIPTION
- add button to popup window in templates files
- separate defaults to be used twice
- add listener in js file
- after localStorage item is removed, a page refresh is forced to ensure variables and checkboxes are in sync.
- this does mean the modal is forced closed too.