### PR TITLE
Enable gzip compression in Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -8,6 +8,8 @@
 
     root * /usr/share/caddy
 
+    encode gzip
+
   map {path} {npath} {
     import /usr/share/caddy/assets/deprecated-urls
     import /usr/share/caddy/assets/prettyurls


### PR DESCRIPTION
This will gzip responses from our webserver if the client indicates
support for it. All modern browsers do.

