### PR TITLE
Add EBook compilation to website build + container

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,10 +4,11 @@ steps:
   - label: "Build site"
     key: build
     commands:
-      - "zef install . --deps-only"
-      - "./bin_files/build-site --without-completion --no-status"
-      - "./.buildkite/archive.sh"
-      - "buildkite-agent artifact upload ./raku-doc-website.tar.gz"
+      - zef install . --deps-only
+      - ./bin_files/build-site --without-completion --no-status EBook
+      - mv RakuDocumentation.epub rendered_html
+      - ./.buildkite/archive.sh
+      - buildkite-agent artifact upload ./raku-doc-website.tar.gz
       - rm ./raku-doc-website.tar.gz
 
   - label: "Containerize static assets (tag: latest)"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,7 +6,7 @@ steps:
     commands:
       - zef install . --deps-only
       - ./bin_files/build-site EBook --without-completion --no-status
-      - mv RakuDocumentation.epub rendered_html
+      - cp ~/RakuDocumentation.epub rendered_html
       - ./.buildkite/archive.sh
       - buildkite-agent artifact upload ./raku-doc-website.tar.gz
       - rm ./raku-doc-website.tar.gz

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,7 +5,7 @@ steps:
     key: build
     commands:
       - zef install . --deps-only
-      - ./bin_files/build-site --without-completion --no-status EBook
+      - ./bin_files/build-site --no-status EBook
       - mv RakuDocumentation.epub rendered_html
       - ./.buildkite/archive.sh
       - buildkite-agent artifact upload ./raku-doc-website.tar.gz

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,7 +5,7 @@ steps:
     key: build
     commands:
       - zef install . --deps-only
-      - ./bin_files/build-site --no-status EBook
+      - ./bin_files/build-site --without-completion --no-status EBook
       - mv RakuDocumentation.epub rendered_html
       - ./.buildkite/archive.sh
       - buildkite-agent artifact upload ./raku-doc-website.tar.gz

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,8 +5,8 @@ steps:
     key: build
     commands:
       - zef install . --deps-only
-      - ./bin_files/build-site EBook --without-completion --no-status
-      - cp ~/RakuDocumentation.epub rendered_html
+      - ./bin_files/build-site --without-completion --no-status
+      - ./bin_files/build-site --no-status EBook
       - ./.buildkite/archive.sh
       - buildkite-agent artifact upload ./raku-doc-website.tar.gz
       - rm ./raku-doc-website.tar.gz

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,7 +5,7 @@ steps:
     key: build
     commands:
       - zef install . --deps-only
-      - ./bin_files/build-site --without-completion --no-status EBook
+      - ./bin_files/build-site EBook --without-completion --no-status
       - mv RakuDocumentation.epub rendered_html
       - ./.buildkite/archive.sh
       - buildkite-agent artifact upload ./raku-doc-website.tar.gz

--- a/EBook/configs/03-plugin-options.raku
+++ b/EBook/configs/03-plugin-options.raku
@@ -1,7 +1,7 @@
 %(
     plugin-options => %(
         ebook-embed => %(
-           :ebook-path-name<../RakuDocumentation.epub>,
+           :ebook-path-name<../rendered_html/RakuDocumentation.epub>,
         ),
     ),
 )


### PR DESCRIPTION
The build script drops the ebook file in our repository root. We can
move it into the rendered_html folder before archiving. This way, when
the archive is unpacked inside the container, it's located at the
expected root url.

The buildscript should be adjusted to put the ebook in rendered_html
at some point. But this hack works for now.
