### PR TITLE
when shortcuts disabled, the "tool-tips" were left in

### DIFF
--- a/Website/plugins/page-styling/page-styling.raku
+++ b/Website/plugins/page-styling/page-styling.raku
@@ -55,7 +55,7 @@ use v6.d;
     },
     'left-bar-toggle' => sub (%prm, %tml ) {
       q:to/BLOCK/
-        <div class="left-bar-toggle" title="Toggle Table of Contents & Index (Alt-T)">
+        <div class="left-bar-toggle" title="Toggle Table of Contents & Index">
             <label class="chyronToggle left">
                 <input id="navbar-left-toggle" type="checkbox">
                 <span class="text">Contents</span>
@@ -123,13 +123,6 @@ use v6.d;
                     <a class="navbar-item" href="https://github.com/raku/doc/issues">
                       Report an issue with the documentation content
                     </a>
-                    <hr class="navbar-divider">
-                    <label class="centreToggle" title="Enable/Disable shortcuts (Alt-G)" style="--switch-width: 11">
-                       <input id="pageSettings" type="checkbox">
-                       <span class="text">Shortcuts</span>
-                       <span class="on">enabled</span>
-                       <span class="off">disabled</span>
-                    </label>
                   </div>
                 </div>
             </div>


### PR DESCRIPTION
- removing tool-tips from page-styling
- remove disabling option from More