### PR TITLE
Update about.rakudoc

### DIFF
--- a/Website/structure-sources/about.rakudoc
+++ b/Website/structure-sources/about.rakudoc
@@ -34,6 +34,4 @@ can be found in this L<Credits file | https://raw.githubusercontent.com/Raku/doc
 =for Generated  :headlevel(0)
 The web site was generated as follows:
 
-Link errors in the documentation suite can be found at L<Error report|error-report>.
-
 =end pod


### PR DESCRIPTION
Remove link to error-report on About page.
error-report plugin is not enabled, so the link will 404