### PR TITLE
ignore announcements.rakudoc when compiling EBook

### DIFF
--- a/EBook/configs/01-config.raku
+++ b/EBook/configs/01-config.raku
@@ -2,7 +2,7 @@
     :mode-sources<structure-sources>, # content for the website structure
     :mode-cache<structure-cache>, # cache for the above
     :mode-ignore<
-        footnotes.rakudoc glossary.rakudoc toc.rakudoc language.rakudoc programs.rakudoc
+        footnotes.rakudoc glossary.rakudoc toc.rakudoc language.rakudoc programs.rakudoc announcements.rakudoc
     >, # files to ignore
     :mode-obtain(), # not a remote repository
     :mode-refresh(), # ditto


### PR DESCRIPTION
not needed for EBook, and will cause errors when EBook build tries to process `=Note` blocks