### PR TITLE
Prevent crawlers from indexing non-prod sites

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -6,6 +6,24 @@
         output stdout
     }
 
+    @prod {
+        expression {env.PROD} == "true"
+    }
+
+    handle @prod {
+        respond /robots.txt 404
+    }
+
+    handle {
+        respond /robots.txt 200 {
+            body <<ROBOTS_TXT
+                User-agent: *
+                Disallow: /
+                ROBOTS_TXT
+            close
+        }
+    }
+
     root * /usr/share/caddy
 
     encode gzip


### PR DESCRIPTION
Introduce an env var configuration: PROD=true

If that is NOT set, then respond to robots.txt with a file that
asks crawlers to stop indexing our site.

I will add this config to production once it lands.
