### PR TITLE
Resolves #389 Links in TOC were not escaped.

### DIFF
--- a/Website/plugins/filtered-toc/filtered-toc-template.raku
+++ b/Website/plugins/filtered-toc/filtered-toc-template.raku
@@ -65,7 +65,7 @@ use v6.d;
                 }
                 $rv ~= "\n<li>"
                     ~ '<a href="#'
-                    ~ (%el.<target>)
+                    ~ (%tml<escaped>.(%el.<target>) )
                     ~ '">'
                     ~ (%el.<text> // '')
                     ~ '</a></li>';


### PR DESCRIPTION
- added escaping in plugin 'filtered-toc'