### PR TITLE
test creating cache dir

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,6 +4,7 @@ steps:
   - label: "Build site"
     key: build
     commands:
+      - mkdir -p /home/builder/cache
       - zef install . --deps-only
       - ./bin_files/build-site --without-completion --no-status
       - ./bin_files/build-site --no-status EBook


### PR DESCRIPTION
We need an out-of-tree cache dir for svg files. A symlink to this will need to be created.