### PR TITLE
Set up typegraphs dir as a symlink on CI

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,7 +4,7 @@ steps:
   - label: "Build site"
     key: build
     commands:
-      - mkdir -p /home/builder/cache
+      - ./.buildkite/setup-typegraphs-cache.sh
       - zef install . --deps-only
       - ./bin_files/build-site --without-completion --no-status
       - ./bin_files/build-site --no-status EBook

--- a/.buildkite/setup-typegraphs-cache.sh
+++ b/.buildkite/setup-typegraphs-cache.sh
@@ -7,7 +7,8 @@ abspath="/home/builder/cache/typegraphs"
 
 if [ ! -s $relpath ]; then
   rm -rf $relpath
+  mkdir -p $abspath
+  ln -s $abspath $relpath
 fi
 
-ln -s $abspath $relpath
 

--- a/.buildkite/setup-typegraphs-cache.sh
+++ b/.buildkite/setup-typegraphs-cache.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+set -e
+
+relpath="Website/plugins/typegraph/typegraphs"
+abspath="/home/builder/cache/typegraphs"
+
+if [ ! -s $relpath ]; then
+  rm -rf $relpath
+fi
+
+ln -s $abspath $relpath
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 /.idea/
 /.precomp/
-/Website/plugins/typegraph/typegraphs/*.svg
+/Website/plugins/typegraph/typegraphs/
 /doc_cache/
 /rendered_html/
 /local_raku_docs/
 /Website/structure-cache/
 /Website/reports/
-/Website/typegraph/typegraphs/*.svg
 /raku-doc-website.iml
+

--- a/Website/plugins/typegraph/add-type-graph.raku
+++ b/Website/plugins/typegraph/add-type-graph.raku
@@ -5,13 +5,13 @@ use Collection::Progress;
 
 sub ($pp, %options) {
     unless (
-        ('typegraphs'.IO ~~ :e & :d)
+        ('typegraphs'.IO ~~ (:e & :d) | :s)
         and ( 'type-graph.txt'.IO.modified le 'typegraphs'.IO.modified )
         and ( +'typegraphs'.IO.dir > 1 )
         )
     {
         note 'Generating Typegraphs' unless %options<no-status>;
-        mkdir 'typegraphs' unless 'typegraphs'.IO ~~ :e & :d;
+        mkdir 'typegraphs' unless 'typegraphs'.IO ~~ (:e & :d) | :s;
         my $viz = Doc::TypeGraph::Viz.new;
         my $tg  = Doc::TypeGraph.new-from-file('type-graph.txt');
         $viz.write-type-graph-images(path => "typegraphs",


### PR DESCRIPTION
Our goal is to create a persistent cache of svg files between builds.

When a CI agent is first created, the cache will populate the svg
files in the build agent's home directory. Subsequent builds should
be faster. Refs https://github.com/Raku/doc-website/issues/393