### PR TITLE
addresses issue in #401 whitelists all links with typegraphs

### DIFF
--- a/Website/plugins/link-error-test/let-callable.raku
+++ b/Website/plugins/link-error-test/let-callable.raku
@@ -24,6 +24,7 @@ sub ($pr, %processed, %options) {
     my @structure-files;
 
     sub failed-targets($file, Str $target) {
+        return () if $target.contains('typegraphrelations');
         my $old = $target.trim;
         my @ok-targets;
         my @tested-variants;


### PR DESCRIPTION
- all typegraph headings have an id of typegraphrelations
- if a target contains this, the target is passed
- it will not work if the target is in an external file, so this test is too broad, but given the rarity of such a link, I think this fix is the best use of time