### PR TITLE
addresses issue #407

### DIFF
--- a/Website/plugins/filtered-toc/config.raku
+++ b/Website/plugins/filtered-toc/config.raku
@@ -8,11 +8,11 @@
 	:name<filtered-toc>,
 	:render,
 	:template-raku<filtered-toc-template.raku>,
-	:js-script<filtered-toc.js>,
+	:jquery(['filtered-toc.js', 2], ),
 	:add-css<css/filtered-toc-dark.css css/filtered-toc-light.css>,
-	:jquery-link(
-		['src="https://rawgit.com/farzher/fuzzysort/master/fuzzysort.js"', 1],
+	:js-link(
+		['src="https://cdn.jsdelivr.net/npm/fuzzysort@2.0.4/fuzzysort.min.js"', 1],
 	),
-	:information<jquery-link>,
-	:version<0.1.3>,
+	:information<js-link script>,
+	:version<0.1.6>,
 )


### PR DESCRIPTION
- ToC filtering depends on fuzzysort library
- Library was updated to 3.0.0, changing API, breaking ToC filtering
- Previous version (2.0.4) available on different cdn