### PR TITLE
removes the syntax highlighting dependency on Net

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,9 +7,7 @@ steps:
       - mkdir -p /home/builder/cache
       - POD_RENDER_NO_HIGHLIGHTER=1 zef install Raku::Pod::Render
       - zef install . --deps-only
-      - ./bin_files/build-site --without-completion --no-status
-      - ./bin_files/build-site --no-status EBook
-      - buildkite-agent artifact upload ./rendered_html/RakuDocumentation.epub
+      - ./bin_files/build-site --without-completion
       - ./.buildkite/archive.sh
       - buildkite-agent artifact upload ./raku-doc-website.tar.gz
       - rm ./raku-doc-website.tar.gz

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,7 +5,7 @@ steps:
     key: build
     commands:
       - mkdir -p /home/builder/cache
-      - zef install . --deps-only
+      - POD_RENDER_NO_HIGHLIGHTER=1 zef install . --deps-only
       - ./bin_files/build-site --without-completion
       - ./.buildkite/archive.sh
       - buildkite-agent artifact upload ./raku-doc-website.tar.gz

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,7 +5,6 @@ steps:
     key: build
     commands:
       - mkdir -p /home/builder/cache
-      - POD_RENDER_NO_HIGHLIGHTER=1 zef install Raku::Pod::Render
       - zef install . --deps-only
       - ./bin_files/build-site --without-completion
       - ./.buildkite/archive.sh

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,7 +6,9 @@ steps:
     commands:
       - mkdir -p /home/builder/cache
       - POD_RENDER_NO_HIGHLIGHTER=1 zef install . --deps-only
-      - ./bin_files/build-site --without-completion
+      - ./bin_files/build-site --without-completion --no-status
+      - ./bin_files/build-site --no-status EBook
+      - buildkite-agent artifact upload ./rendered_html/RakuDocumentation.epub
       - ./.buildkite/archive.sh
       - buildkite-agent artifact upload ./raku-doc-website.tar.gz
       - rm ./raku-doc-website.tar.gz

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,6 +5,7 @@ steps:
     key: build
     commands:
       - mkdir -p /home/builder/cache
+      - POD_RENDER_NO_HIGHLIGHTER=1 zef install Raku::Pod::Render
       - zef install . --deps-only
       - ./bin_files/build-site --without-completion --no-status
       - ./bin_files/build-site --no-status EBook

--- a/EBook/configs/02-plugins.raku
+++ b/EBook/configs/02-plugins.raku
@@ -4,7 +4,7 @@
     plugins-required => %(
         :setup<raku-doc-setup>,
         :render<
-            hiliter
+            rainbow
             ebook-embed rakudoc-table
             generated
             gather-css

--- a/EBook/plugins/rainbow/README.rakudoc
+++ b/EBook/plugins/rainbow/README.rakudoc
@@ -1,0 +1,12 @@
+=begin pod
+=TITLE rainbow is a plugin for Collection
+
+The plugin is for the render milestone
+
+It is a direct replacement for hiliter, but only relies on Raku.
+
+=head1 Custom blocks
+
+=head1 Templates
+
+=end pod

--- a/EBook/plugins/rainbow/config.raku
+++ b/EBook/plugins/rainbow/config.raku
@@ -1,0 +1,23 @@
+%(
+	:auth<collection>,
+	:authors(
+		"finanalyst",
+	),
+	:custom-raku(),
+	:license<Artistic-2.0>,
+	:name<rainbow>,
+	:render,
+	:template-raku<template.raku>,
+	:version<0.1.0>,
+	:css-link(
+		'href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-light.min.css" title="light"',
+		'href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css" title="dark"',
+	),
+	:js-link(
+		['src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"', 2 ],
+		['src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/haskell.min.js"', 2 ],
+	),
+	:add-css<css/rainbow-dark.css css/rainbow-light.css>,
+	:jquery( ['rainbow.js', 4], ),
+	:information<css-link js-link jquery>,
+)

--- a/EBook/plugins/rainbow/css/rainbow-dark.css
+++ b/EBook/plugins/rainbow/css/rainbow-dark.css
@@ -1,0 +1,128 @@
+/* Basic code colors */
+textarea::-moz-selection {
+  background: #212426;
+}
+
+textarea::selection {
+  background: #212426;
+}
+
+.raku-code {
+  position: relative;
+  margin: 1rem 0;
+  border-bottom: 3px solid #3A3D4E;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+  border: 1px solid #3A3D4E;
+}
+.raku-code button.copy-code {
+  cursor: pointer;
+  opacity: 0;
+  padding: 0 0.25rem 0.25rem 0.25rem;
+  position: absolute;
+}
+.raku-code:hover button.copy-code {
+  opacity: 0.5;
+}
+.raku-code label {
+  float: right;
+  font-size: xx-small;
+  font-style: italic;
+  height: auto;
+  margin: 0 5px 0 0;
+}
+.raku-code pre.browser-hl {
+  padding: 7px;
+}
+.raku-code .code-name {
+  padding-top: 0.75rem;
+  padding-left: 1.25rem;
+  color: #EED891;
+  font-weight: 500;
+}
+.raku-code pre {
+  background-color: #212426;
+  color: #f2f2f2;
+  display: inline-block;
+  overflow: scroll;
+  width: 96%;
+}
+.raku-code .rakudoc-in-code {
+  padding: 1.25rem 1.5rem;
+}
+.raku-code .section {
+  /* https://github.com/Raku/doc-website/issues/144 */
+  padding: 0rem;
+}
+
+/* the span classes in the code */
+.highlite-NAME_SCALAR {
+  color: #EED891;
+}
+
+.highlite-NAME_ARRAY {
+  color: #EED891;
+}
+
+.highlite-NAME_HASH {
+  color: #EED891;
+}
+
+.highlite-NAME_CODE {
+  color: #978DEB;
+}
+
+.highlite-KEYWORD {
+  color: #8DE1EB;
+}
+
+.highlite-OPERATOR {
+  color: #E05C4C;
+}
+
+.highlite-TYPE {
+  color: #E04C86;
+}
+
+.highlite-ROUTINE {
+  color: #978DEB;
+}
+
+.highlite-STRING {
+  color: #68F3CA;
+}
+
+.highlite-STRING_DELIMITER {
+  color: #E05C4C;
+}
+
+.highlite-ESCAPE {
+  color: #E05C4C;
+}
+
+.highlite-TEXT {
+  color: #f5f5f5;
+}
+
+.highlite-COMMENT {
+  color: #6C7292;
+}
+
+.highlite-REGEX_SPECIAL {
+  color: #6295E3;
+}
+
+.highlite-REGEX_LITERAL {
+  color: #6C7292;
+}
+
+.highlite-REGEX_DELIMITER {
+  color: #E05C4C;
+}
+
+.highlite-POD_TEXT {
+  color: #E04C86;
+}
+
+.highlite-POD_MARKUP {
+  color: #E04C86;
+}

--- a/EBook/plugins/rainbow/css/rainbow-light.css
+++ b/EBook/plugins/rainbow/css/rainbow-light.css
@@ -1,0 +1,120 @@
+/* Basic code colors */
+.raku-code {
+  position: relative;
+  margin: 1rem 0;
+  border-bottom: 3px solid #cccccc;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+  border: 1px solid #cccccc;
+}
+.raku-code button.copy-code {
+  cursor: pointer;
+  opacity: 0;
+  padding: 0 0.25rem 0.25rem 0.25rem;
+  position: absolute;
+}
+.raku-code:hover button.copy-code {
+  opacity: 0.5;
+}
+.raku-code label {
+  float: right;
+  font-size: xx-small;
+  font-style: italic;
+  height: auto;
+  margin: 0 5px 0 0;
+}
+.raku-code pre.browser-hl {
+  padding: 7px;
+}
+.raku-code .code-name {
+  padding-top: 0.75rem;
+  padding-left: 1.25rem;
+  color: #A30031;
+  font-weight: 500;
+}
+.raku-code pre {
+  background-color: #fafafa;
+  color: #030303;
+  display: inline-block;
+  overflow: scroll;
+  width: 96%;
+}
+.raku-code .rakudoc-in-code {
+  padding: 1.25rem 1.5rem;
+}
+.raku-code .section {
+  /* https://github.com/Raku/doc-website/issues/144 */
+  padding: 0rem;
+}
+
+/* the span classes in the code */
+.highlite-NAME_SCALAR {
+  color: #5503B3;
+}
+
+.highlite-NAME_ARRAY {
+  color: #5503B3;
+}
+
+.highlite-NAME_HASH {
+  color: #5503B3;
+}
+
+.highlite-NAME_CODE {
+  color: #005C43;
+}
+
+.highlite-KEYWORD {
+  color: #223B9E;
+}
+
+.highlite-OPERATOR {
+  color: #C01823;
+}
+
+.highlite-TYPE {
+  color: #A3004F;
+}
+
+.highlite-ROUTINE {
+  color: #005C43;
+}
+
+.highlite-STRING {
+  color: #004FB3;
+}
+
+.highlite-STRING_DELIMITER {
+  color: #C01823;
+}
+
+.highlite-ESCAPE {
+  color: #C01823;
+}
+
+.highlite-TEXT {
+  color: #030303;
+}
+
+.highlite-COMMENT {
+  color: #6D4F4B;
+}
+
+.highlite-REGEX_SPECIAL {
+  color: #1C6301;
+}
+
+.highlite-REGEX_LITERAL {
+  color: #6C7292;
+}
+
+.highlite-REGEX_DELIMITER {
+  color: #C01823;
+}
+
+.highlite-POD_TEXT {
+  color: #A3004F;
+}
+
+.highlite-POD_MARKUP {
+  color: #A3004F;
+}

--- a/EBook/plugins/rainbow/rainbow.js
+++ b/EBook/plugins/rainbow/rainbow.js
@@ -1,0 +1,4 @@
+$(document).ready( function() {
+    // trigger the highlighter
+    hljs.highlightAll();
+});

--- a/EBook/plugins/rainbow/scss/_rainbow-main.scss
+++ b/EBook/plugins/rainbow/scss/_rainbow-main.scss
@@ -1,0 +1,72 @@
+@import "_variables.scss";
+
+// Raku code highlighting
+.raku-code {
+  position: relative;
+  margin: $size-6 0;
+  border-bottom: 3px solid $border;
+  box-shadow: $shadow-below;
+  border: 1px solid $border;
+
+  button.copy-code {
+    cursor: pointer;
+    opacity: 0;
+    padding: 0 0.25rem 0.25rem 0.25rem;
+    position: absolute;
+  }
+  &:hover button.copy-code {
+    opacity: 0.5;
+  }
+
+  label {
+    float: right;
+    font-size: xx-small;
+    font-style: italic;
+    height: auto;
+    margin: 0 5px 0 0;
+  }
+
+// required to match highlights-js css with raku highlighter css
+  pre.browser-hl { padding: 7px; }
+
+  .code-name {
+    padding-top: $size-7;
+    padding-left: $size-5;
+    color: $heading;
+    font-weight: $weight-medium;
+  }
+   pre {
+    background-color: $code-background;
+    color: $code-foreground;
+    display: inline-block;
+    overflow: scroll;
+    width: 96%;
+  }
+  .rakudoc-in-code {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .section {
+    /* https://github.com/Raku/doc-website/issues/144 */
+    padding: 0rem;
+  }
+}
+/* the span classes in the code */
+.highlite-NAME_SCALAR { color: $code-scalar-color; }
+.highlite-NAME_ARRAY { color: $code-array-color; }
+.highlite-NAME_HASH { color: $code-hash-color; }
+.highlite-NAME_CODE { color: $code-code-color; }
+.highlite-KEYWORD { color: $code-keyword-color; }
+.highlite-OPERATOR { color: $code-operator-color; }
+.highlite-TYPE { color: $code-type-color; }
+.highlite-ROUTINE { color: $code-routine-color; }
+.highlite-STRING { color: $code-string-color; }
+.highlite-STRING_DELIMITER { color: $code-string-delimiter-color; }
+.highlite-ESCAPE { color: $code-escape-color; }
+.highlite-TEXT { color: $text; }
+.highlite-COMMENT { color: $code-comment-color; }
+.highlite-REGEX_SPECIAL { color: $code-regex-special-color; }
+.highlite-REGEX_LITERAL { color: $code-regex-literal-color; }
+.highlite-REGEX_DELIMITER { color: $code-regex-delimiter-color; }
+.highlite-POD_TEXT { color: $code-pod-text-color; }
+.highlite-POD_MARKUP { color: $code-pod-text-color; }

--- a/EBook/plugins/rainbow/scss/_themes-colors.scss
+++ b/EBook/plugins/rainbow/scss/_themes-colors.scss
@@ -1,0 +1,25 @@
+// Common theme colors
+
+$black:         #030303;
+$black-bis:     #1B1D1E;
+$black-ter:     #212426;
+
+$grey-darker:   #3A3D4E;
+$grey-dark:     #83858D;
+$grey:          #cccccc;
+$grey-light:    #d8d8d8;
+$grey-lighter:  #e5e5e5;
+$grey-lightest: #f2f2f2;
+
+$white-ter:     #f5f5f5;
+$white-bis:     #f7f7f7;
+$white:         #fafafa;
+
+$orange:       hsl(14,  100%, 53%);
+$yellow:       #EED891;
+$green:        #1C6301;
+$turquoise:    #005C43;
+$cyan:         hsl(204, 71%,  53%);
+$blue:         #004FB3;
+$purple:       #5503B3;
+$red:          #A30031;

--- a/EBook/plugins/rainbow/scss/_variables.scss
+++ b/EBook/plugins/rainbow/scss/_variables.scss
@@ -1,0 +1,77 @@
+// Sizes & Weight
+$size-1: 3rem;
+$size-2: 2.5rem;
+$size-3: 2rem;
+$size-4: 1.5rem; // 24px
+$size-5: 1.25rem; // 20px
+$size-6: 1rem; // 16px
+$size-7: 0.75rem;
+
+$weight-light: 300;
+$weight-normal: 400;
+$weight-medium: 500;
+$weight-semibold: 600;
+$weight-bold: 700;
+
+// Spacing
+$block-spacing: 1.5rem;
+
+// Responsiveness
+// The container horizontal gap, which acts as the offset for breakpoints
+$gap: 32px;
+$smartphone-portrait: 480px;
+// 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
+$tablet: 769px;
+// 960px container + 4rem
+// $desktop: 960px + (2 * $gap);
+$desktop: 1140px + (2 * $gap);
+// 1152px container + 4rem
+$widescreen: 1152px + (2 * $gap);
+$widescreen-enabled: true;
+// 1344px container + 4rem
+$fullhd: 1344px + (2 * $gap);
+
+$fullhd-enabled: false;
+$widescreen-enabled: false;
+
+// Typography
+$family-sans-serif: "Inter", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+$family-monospace: monospace;
+$render-mode: optimizeLegibility;
+
+$family-primary: $family-sans-serif;
+// $family-secondary: $family-sans-serif;
+$family-secondary: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+$family-code: $family-monospace;
+
+$size-small: $size-7;
+$size-normal: $size-6;
+$size-medium: $size-5;
+$size-large: $size-4;
+
+$sizes: $size-1 $size-2 $size-3 $size-4 $size-5 $size-6 $size-7;
+
+// Sort
+$hero-body-padding-medium: 6rem 0.5rem;
+$icon-dimensions-large: 6rem;
+$body-line-height: 1.5;
+
+$footer-padding: 0;
+
+$navbar-height: 3.75rem;
+$search-query-input-width-tablet: 500px;
+$search-query-input-width-expanded: 992px;
+
+$menu-label-font-size: 0.75rem;
+
+$menu-item-radius: 0px;
+$menu-list-line-height: 1.05;
+$menu-nested-list-padding-left: 0.5em;
+$menu-nested-list-margin: 0.5em;
+$menu-list-link-padding: 0.5em 0.5em;
+
+$section-padding: $size-4 $size-4;
+$control-radius: 3px;
+
+// Code
+$code-padding: 0.25em 0.25em 0.25em 0.25em !default

--- a/EBook/plugins/rainbow/scss/rainbow-dark.scss
+++ b/EBook/plugins/rainbow/scss/rainbow-dark.scss
@@ -1,0 +1,42 @@
+/* Basic code colors */
+@import '_themes-colors.scss';
+$border:  $grey-darker;
+$shadow-below: 0 2px 3px 0 rgba( 0, 0, 0, 0.07 );
+$heading: $yellow;
+
+// Text colors
+$text: $white-ter;
+$text-invert: $black-ter;
+$text-light: lighten($text, 10);
+$text-dark: darken($text, 10);
+$text-strong: darken($text, 5);
+
+
+$code-background: #212426;
+$code-foreground: #f2f2f2;
+$code-selection: lighten($code-background, 10);
+
+$code-code-color:             #978DEB;
+$code-routine-color:          #978DEB;
+$code-comment-color:          #6C7292;
+$code-keyword-color:          #8DE1EB;
+$code-number-color:           #6295E3;
+$code-operator-color:         #E05C4C;
+$code-string-color:           #68F3CA;
+$code-type-color:             #E04C86;
+$code-scalar-color:           #EED891;
+$code-array-color:            #EED891;
+$code-hash-color:             #EED891;
+$code-pod-text-color:         #E04C86;
+$code-pod-markup-color:       #EED891;
+$code-string-delimiter-color: #E05C4C;
+$code-escape-color:           #E05C4C;
+$code-regex-special-color:    #6295E3;
+$code-regex-literal-color:    #6C7292;
+$code-regex-delimiter-color:  #E05C4C;
+
+// Fix selection background
+textarea::-moz-selection { background: $code-background; }
+textarea::selection { background: $code-background; }
+
+@import '_rainbow-main.scss';

--- a/EBook/plugins/rainbow/scss/rainbow-light.scss
+++ b/EBook/plugins/rainbow/scss/rainbow-light.scss
@@ -1,0 +1,35 @@
+/* Basic code colors */
+@import '_themes-colors.scss';
+$border: $grey;
+$shadow-below: 0 2px 3px 0 rgba( 0, 0, 0, 0.07 );
+$heading: $red;
+$code-background: #fafafa;
+$code-foreground: #030303;
+
+// Text colors
+$text: $black;
+$text-invert: $white-bis;
+$text-light: lighten($text, 10);
+$text-dark: darken($text, 10);
+$text-strong: darken($text, 5);
+
+$code-code-color:             #005C43;
+$code-routine-color:          #005C43;
+$code-comment-color:          #6D4F4B;
+$code-keyword-color:          #223B9E;
+$code-number-color:           #1C6301;
+$code-operator-color:         #C01823;
+$code-string-color:           #004FB3;
+$code-type-color:             #A3004F;
+$code-scalar-color:           #5503B3;
+$code-array-color:            #5503B3;
+$code-hash-color:             #5503B3;
+$code-pod-text-color:         #A3004F;
+$code-pod-markup-color:       #5503B3;
+$code-string-delimiter-color: #C01823;
+$code-escape-color:           #C01823;
+$code-regex-special-color:    #1C6301;
+$code-regex-literal-color:    #6C7292;
+$code-regex-delimiter-color:  #C01823;
+
+@import '_rainbow-main.scss';

--- a/EBook/plugins/rainbow/t/05-basic.rakutest
+++ b/EBook/plugins/rainbow/t/05-basic.rakutest
@@ -1,0 +1,5 @@
+use v6.d;
+use Test;
+use Test::CollectionPlugin;
+test-plugin();
+done-testing

--- a/EBook/plugins/rainbow/template.raku
+++ b/EBook/plugins/rainbow/template.raku
@@ -1,0 +1,97 @@
+use v6.d;
+use Rainbow;
+
+my %hilight-langs = %(
+    'HTML' => 'xml',
+    'XML' => 'xml',
+    'BASH' => 'bash',
+    'C++' => 'cpp',
+    'C#' => 'csharp',
+    'SCSS' => 'css',
+    'SASS' => 'css',
+    'CSS' => 'css',
+    'MARKDOWN' => 'markdown',
+    'DIFF' => 'diff',
+    'RUBY' => 'ruby',
+    'GO' => 'go',
+    'TOML' => 'ini',
+    'INI' => 'ini',
+    'JAVA' => 'java',
+    'JAVASCRIPT' => 'javascript',
+    'JSON' => 'json',
+    'KOTLIN' => 'kotlin',
+    'LESS' => 'less',
+    'LUA' => 'lua',
+    'MAKEFILE' => 'makefile',
+    'PERL' => 'perl',
+    'OBJECTIVE-C' => 'objectivec',
+    'PHP' => 'php',
+    'PHP-TEMPLATE' => 'php-template',
+    'PHPTEMPLATE' => 'php-template',
+    'PHP_TEMPLATE' => 'php-template',
+    'PYTHON' => 'python',
+    'PYTHON-REPL' => 'python-repl',
+    'PYTHON_REPL' => 'python-repl',
+    'R' => 'r',
+    'RUST' => 'rust',
+    'SCSS' => 'scss',
+    'SHELL' => 'shell',
+    'SQL' => 'sql',
+    'SWIFT' => 'swift',
+    'YAML' => 'yaml',
+    'TYPESCRIPT' => 'typescript',
+    'BASIC' => 'vbnet',
+    '.NET' => 'vbnet',
+    'HASKELL' => 'haskell',
+);
+
+# Callable returns a hash
+%(
+    block-code => sub (%prm, %tml) {
+        # if :lang is set != raku / rakudoc, then enable highlightjs
+        # otherwise pass through Raku syntax highlighter.
+        my $code;
+        my $syntax-label;
+        if %prm<lang>:exists {
+            if %prm<lang>.uc ~~ any( %hilight-langs.keys ) {
+                $syntax-label = %prm<lang>.tc ~  ' highlighting by highlight-js';
+                $code = qq:to/HILIGHT/;
+                    <pre class="browser-hl">
+                    <code class="language-{ %hilight-langs{ %prm<lang>.uc } }">{ %tml<escaped>(%prm<contents>) }
+                    </code></pre>
+                    HILIGHT
+            }
+            elsif %prm<lang> ~~ any( <Raku Rakudoc raku rakudoc> ) {
+                $syntax-label = %prm<lang>.tc ~ ' highlighting';
+            }
+            else {
+                $syntax-label = "｢{ %prm<lang> }｣ without highlighting";
+                $code = qq:to/NOHIGHS/;
+                    <pre class="nohighlights">
+                    { %tml<escaped>( %prm<contents> ) }
+                    </pre>
+                    NOHIGHS
+            }
+        }
+        else {
+            $syntax-label = 'Raku highlighting';
+        }
+        without $code {
+            $code = Rainbow::tokenize(%prm<contents>).map( -> $t {
+                if $t.type.key ne 'TEXT' {
+                    qq[<span class="highlite-{$t.type.key}">{%tml<escaped>($t.text)}</span>]
+                }
+                else { %tml<escaped>($t.text) }
+            }).join;
+        }
+        qq[
+            <div class="raku-code raku-lang">
+                <button class="copy-code" title="Copy code"><i class="far fa-clipboard"></i></button>
+                <label>$syntax-label\</label>
+                <div>
+                    <pre class="nohighlights">$code\</pre>
+                </div>
+            </div>
+        ]
+    },
+)

--- a/META6.json
+++ b/META6.json
@@ -15,7 +15,8 @@
     "Terminal::ANSIColor:ver<0.9+>:auth<zef:lizmat>",
     "Doc::TypeGraph:ver<2.2.1.1+>",
     "Doc::TypeGraph::Viz:ver<2.2.1.1+>",
-    "Cro::HTTP:ver<0.8.9>:auth<zef:cro>"
+    "Cro::HTTP:ver<0.8.9>:auth<zef:cro>",
+    "Rainbow:ver<0.1.0>:auth<zef:patrickb>"
   ],
   "build-depends": [],
   "test-depends": [],

--- a/META6.json
+++ b/META6.json
@@ -16,7 +16,7 @@
     "Doc::TypeGraph:ver<2.2.1.1+>",
     "Doc::TypeGraph::Viz:ver<2.2.1.1+>",
     "Cro::HTTP:ver<0.8.9>:auth<zef:cro>",
-    "Rainbow:ver<0.1.0>:auth<zef:patrickb>"
+    "Rainbow:ver<0.2.1+>:auth<zef:patrickb>"
   ],
   "build-depends": [],
   "test-depends": [],

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name": "Raku-Official-Documentation",
   "description": "Tool chain for creating the Raku official documentation site",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "perl": "6.d",
   "authors": [
     "Richard Hainsworth, aka finanalyst"

--- a/Website/configs/02-plugins.raku
+++ b/Website/configs/02-plugins.raku
@@ -4,7 +4,8 @@
     plugins-required => %(
         :setup<raku-doc-setup>,
         :render<
-            hiliter font-awesome page-styling
+            rainbow
+            font-awesome page-styling
             filtered-toc
             announcements
             camelia simple-extras listfiles images filterlines

--- a/Website/plugins/rainbow/README.rakudoc
+++ b/Website/plugins/rainbow/README.rakudoc
@@ -1,0 +1,12 @@
+=begin pod
+=TITLE rainbow is a plugin for Collection
+
+The plugin is for the render milestone
+
+It is a direct replacement for hiliter, but only relies on Raku.
+
+=head1 Custom blocks
+
+=head1 Templates
+
+=end pod

--- a/Website/plugins/rainbow/config.raku
+++ b/Website/plugins/rainbow/config.raku
@@ -1,0 +1,23 @@
+%(
+	:auth<collection>,
+	:authors(
+		"finanalyst",
+	),
+	:custom-raku(),
+	:license<Artistic-2.0>,
+	:name<rainbow>,
+	:render,
+	:template-raku<template.raku>,
+	:version<0.1.0>,
+	:css-link(
+		'href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-light.min.css" title="light"',
+		'href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css" title="dark"',
+	),
+	:js-link(
+		['src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"', 2 ],
+		['src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/haskell.min.js"', 2 ],
+	),
+	:add-css<css/rainbow-dark.css css/rainbow-light.css>,
+	:jquery( ['rainbow.js', 4], ),
+	:information<css-link js-link jquery>,
+)

--- a/Website/plugins/rainbow/css/rainbow-dark.css
+++ b/Website/plugins/rainbow/css/rainbow-dark.css
@@ -1,0 +1,128 @@
+/* Basic code colors */
+textarea::-moz-selection {
+  background: #212426;
+}
+
+textarea::selection {
+  background: #212426;
+}
+
+.raku-code {
+  position: relative;
+  margin: 1rem 0;
+  border-bottom: 3px solid #3A3D4E;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+  border: 1px solid #3A3D4E;
+}
+.raku-code button.copy-code {
+  cursor: pointer;
+  opacity: 0;
+  padding: 0 0.25rem 0.25rem 0.25rem;
+  position: absolute;
+}
+.raku-code:hover button.copy-code {
+  opacity: 0.5;
+}
+.raku-code label {
+  float: right;
+  font-size: xx-small;
+  font-style: italic;
+  height: auto;
+  margin: 0 5px 0 0;
+}
+.raku-code pre.browser-hl {
+  padding: 7px;
+}
+.raku-code .code-name {
+  padding-top: 0.75rem;
+  padding-left: 1.25rem;
+  color: #EED891;
+  font-weight: 500;
+}
+.raku-code pre {
+  background-color: #212426;
+  color: #f2f2f2;
+  display: inline-block;
+  overflow: scroll;
+  width: 96%;
+}
+.raku-code .rakudoc-in-code {
+  padding: 1.25rem 1.5rem;
+}
+.raku-code .section {
+  /* https://github.com/Raku/doc-website/issues/144 */
+  padding: 0rem;
+}
+
+/* the span classes in the code */
+.highlite-NAME_SCALAR {
+  color: #EED891;
+}
+
+.highlite-NAME_ARRAY {
+  color: #EED891;
+}
+
+.highlite-NAME_HASH {
+  color: #EED891;
+}
+
+.highlite-NAME_CODE {
+  color: #978DEB;
+}
+
+.highlite-KEYWORD {
+  color: #8DE1EB;
+}
+
+.highlite-OPERATOR {
+  color: #E05C4C;
+}
+
+.highlite-TYPE {
+  color: #E04C86;
+}
+
+.highlite-ROUTINE {
+  color: #978DEB;
+}
+
+.highlite-STRING {
+  color: #68F3CA;
+}
+
+.highlite-STRING_DELIMITER {
+  color: #E05C4C;
+}
+
+.highlite-ESCAPE {
+  color: #E05C4C;
+}
+
+.highlite-TEXT {
+  color: #f5f5f5;
+}
+
+.highlite-COMMENT {
+  color: #6C7292;
+}
+
+.highlite-REGEX_SPECIAL {
+  color: #6295E3;
+}
+
+.highlite-REGEX_LITERAL {
+  color: #6C7292;
+}
+
+.highlite-REGEX_DELIMITER {
+  color: #E05C4C;
+}
+
+.highlite-POD_TEXT {
+  color: #E04C86;
+}
+
+.highlite-POD_MARKUP {
+  color: #E04C86;
+}

--- a/Website/plugins/rainbow/css/rainbow-light.css
+++ b/Website/plugins/rainbow/css/rainbow-light.css
@@ -1,0 +1,120 @@
+/* Basic code colors */
+.raku-code {
+  position: relative;
+  margin: 1rem 0;
+  border-bottom: 3px solid #cccccc;
+  box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.07);
+  border: 1px solid #cccccc;
+}
+.raku-code button.copy-code {
+  cursor: pointer;
+  opacity: 0;
+  padding: 0 0.25rem 0.25rem 0.25rem;
+  position: absolute;
+}
+.raku-code:hover button.copy-code {
+  opacity: 0.5;
+}
+.raku-code label {
+  float: right;
+  font-size: xx-small;
+  font-style: italic;
+  height: auto;
+  margin: 0 5px 0 0;
+}
+.raku-code pre.browser-hl {
+  padding: 7px;
+}
+.raku-code .code-name {
+  padding-top: 0.75rem;
+  padding-left: 1.25rem;
+  color: #A30031;
+  font-weight: 500;
+}
+.raku-code pre {
+  background-color: #fafafa;
+  color: #030303;
+  display: inline-block;
+  overflow: scroll;
+  width: 96%;
+}
+.raku-code .rakudoc-in-code {
+  padding: 1.25rem 1.5rem;
+}
+.raku-code .section {
+  /* https://github.com/Raku/doc-website/issues/144 */
+  padding: 0rem;
+}
+
+/* the span classes in the code */
+.highlite-NAME_SCALAR {
+  color: #5503B3;
+}
+
+.highlite-NAME_ARRAY {
+  color: #5503B3;
+}
+
+.highlite-NAME_HASH {
+  color: #5503B3;
+}
+
+.highlite-NAME_CODE {
+  color: #005C43;
+}
+
+.highlite-KEYWORD {
+  color: #223B9E;
+}
+
+.highlite-OPERATOR {
+  color: #C01823;
+}
+
+.highlite-TYPE {
+  color: #A3004F;
+}
+
+.highlite-ROUTINE {
+  color: #005C43;
+}
+
+.highlite-STRING {
+  color: #004FB3;
+}
+
+.highlite-STRING_DELIMITER {
+  color: #C01823;
+}
+
+.highlite-ESCAPE {
+  color: #C01823;
+}
+
+.highlite-TEXT {
+  color: #030303;
+}
+
+.highlite-COMMENT {
+  color: #6D4F4B;
+}
+
+.highlite-REGEX_SPECIAL {
+  color: #1C6301;
+}
+
+.highlite-REGEX_LITERAL {
+  color: #6C7292;
+}
+
+.highlite-REGEX_DELIMITER {
+  color: #C01823;
+}
+
+.highlite-POD_TEXT {
+  color: #A3004F;
+}
+
+.highlite-POD_MARKUP {
+  color: #A3004F;
+}

--- a/Website/plugins/rainbow/rainbow.js
+++ b/Website/plugins/rainbow/rainbow.js
@@ -1,0 +1,4 @@
+$(document).ready( function() {
+    // trigger the highlighter
+    hljs.highlightAll();
+});

--- a/Website/plugins/rainbow/scss/_rainbow-main.scss
+++ b/Website/plugins/rainbow/scss/_rainbow-main.scss
@@ -1,0 +1,72 @@
+@import "_variables.scss";
+
+// Raku code highlighting
+.raku-code {
+  position: relative;
+  margin: $size-6 0;
+  border-bottom: 3px solid $border;
+  box-shadow: $shadow-below;
+  border: 1px solid $border;
+
+  button.copy-code {
+    cursor: pointer;
+    opacity: 0;
+    padding: 0 0.25rem 0.25rem 0.25rem;
+    position: absolute;
+  }
+  &:hover button.copy-code {
+    opacity: 0.5;
+  }
+
+  label {
+    float: right;
+    font-size: xx-small;
+    font-style: italic;
+    height: auto;
+    margin: 0 5px 0 0;
+  }
+
+// required to match highlights-js css with raku highlighter css
+  pre.browser-hl { padding: 7px; }
+
+  .code-name {
+    padding-top: $size-7;
+    padding-left: $size-5;
+    color: $heading;
+    font-weight: $weight-medium;
+  }
+   pre {
+    background-color: $code-background;
+    color: $code-foreground;
+    display: inline-block;
+    overflow: scroll;
+    width: 96%;
+  }
+  .rakudoc-in-code {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .section {
+    /* https://github.com/Raku/doc-website/issues/144 */
+    padding: 0rem;
+  }
+}
+/* the span classes in the code */
+.highlite-NAME_SCALAR { color: $code-scalar-color; }
+.highlite-NAME_ARRAY { color: $code-array-color; }
+.highlite-NAME_HASH { color: $code-hash-color; }
+.highlite-NAME_CODE { color: $code-code-color; }
+.highlite-KEYWORD { color: $code-keyword-color; }
+.highlite-OPERATOR { color: $code-operator-color; }
+.highlite-TYPE { color: $code-type-color; }
+.highlite-ROUTINE { color: $code-routine-color; }
+.highlite-STRING { color: $code-string-color; }
+.highlite-STRING_DELIMITER { color: $code-string-delimiter-color; }
+.highlite-ESCAPE { color: $code-escape-color; }
+.highlite-TEXT { color: $text; }
+.highlite-COMMENT { color: $code-comment-color; }
+.highlite-REGEX_SPECIAL { color: $code-regex-special-color; }
+.highlite-REGEX_LITERAL { color: $code-regex-literal-color; }
+.highlite-REGEX_DELIMITER { color: $code-regex-delimiter-color; }
+.highlite-POD_TEXT { color: $code-pod-text-color; }
+.highlite-POD_MARKUP { color: $code-pod-text-color; }

--- a/Website/plugins/rainbow/scss/_themes-colors.scss
+++ b/Website/plugins/rainbow/scss/_themes-colors.scss
@@ -1,0 +1,25 @@
+// Common theme colors
+
+$black:         #030303;
+$black-bis:     #1B1D1E;
+$black-ter:     #212426;
+
+$grey-darker:   #3A3D4E;
+$grey-dark:     #83858D;
+$grey:          #cccccc;
+$grey-light:    #d8d8d8;
+$grey-lighter:  #e5e5e5;
+$grey-lightest: #f2f2f2;
+
+$white-ter:     #f5f5f5;
+$white-bis:     #f7f7f7;
+$white:         #fafafa;
+
+$orange:       hsl(14,  100%, 53%);
+$yellow:       #EED891;
+$green:        #1C6301;
+$turquoise:    #005C43;
+$cyan:         hsl(204, 71%,  53%);
+$blue:         #004FB3;
+$purple:       #5503B3;
+$red:          #A30031;

--- a/Website/plugins/rainbow/scss/_variables.scss
+++ b/Website/plugins/rainbow/scss/_variables.scss
@@ -1,0 +1,77 @@
+// Sizes & Weight
+$size-1: 3rem;
+$size-2: 2.5rem;
+$size-3: 2rem;
+$size-4: 1.5rem; // 24px
+$size-5: 1.25rem; // 20px
+$size-6: 1rem; // 16px
+$size-7: 0.75rem;
+
+$weight-light: 300;
+$weight-normal: 400;
+$weight-medium: 500;
+$weight-semibold: 600;
+$weight-bold: 700;
+
+// Spacing
+$block-spacing: 1.5rem;
+
+// Responsiveness
+// The container horizontal gap, which acts as the offset for breakpoints
+$gap: 32px;
+$smartphone-portrait: 480px;
+// 960, 1152, and 1344 have been chosen because they are divisible by both 12 and 16
+$tablet: 769px;
+// 960px container + 4rem
+// $desktop: 960px + (2 * $gap);
+$desktop: 1140px + (2 * $gap);
+// 1152px container + 4rem
+$widescreen: 1152px + (2 * $gap);
+$widescreen-enabled: true;
+// 1344px container + 4rem
+$fullhd: 1344px + (2 * $gap);
+
+$fullhd-enabled: false;
+$widescreen-enabled: false;
+
+// Typography
+$family-sans-serif: "Inter", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+$family-monospace: monospace;
+$render-mode: optimizeLegibility;
+
+$family-primary: $family-sans-serif;
+// $family-secondary: $family-sans-serif;
+$family-secondary: "Lato", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+$family-code: $family-monospace;
+
+$size-small: $size-7;
+$size-normal: $size-6;
+$size-medium: $size-5;
+$size-large: $size-4;
+
+$sizes: $size-1 $size-2 $size-3 $size-4 $size-5 $size-6 $size-7;
+
+// Sort
+$hero-body-padding-medium: 6rem 0.5rem;
+$icon-dimensions-large: 6rem;
+$body-line-height: 1.5;
+
+$footer-padding: 0;
+
+$navbar-height: 3.75rem;
+$search-query-input-width-tablet: 500px;
+$search-query-input-width-expanded: 992px;
+
+$menu-label-font-size: 0.75rem;
+
+$menu-item-radius: 0px;
+$menu-list-line-height: 1.05;
+$menu-nested-list-padding-left: 0.5em;
+$menu-nested-list-margin: 0.5em;
+$menu-list-link-padding: 0.5em 0.5em;
+
+$section-padding: $size-4 $size-4;
+$control-radius: 3px;
+
+// Code
+$code-padding: 0.25em 0.25em 0.25em 0.25em !default

--- a/Website/plugins/rainbow/scss/rainbow-dark.scss
+++ b/Website/plugins/rainbow/scss/rainbow-dark.scss
@@ -1,0 +1,42 @@
+/* Basic code colors */
+@import '_themes-colors.scss';
+$border:  $grey-darker;
+$shadow-below: 0 2px 3px 0 rgba( 0, 0, 0, 0.07 );
+$heading: $yellow;
+
+// Text colors
+$text: $white-ter;
+$text-invert: $black-ter;
+$text-light: lighten($text, 10);
+$text-dark: darken($text, 10);
+$text-strong: darken($text, 5);
+
+
+$code-background: #212426;
+$code-foreground: #f2f2f2;
+$code-selection: lighten($code-background, 10);
+
+$code-code-color:             #978DEB;
+$code-routine-color:          #978DEB;
+$code-comment-color:          #6C7292;
+$code-keyword-color:          #8DE1EB;
+$code-number-color:           #6295E3;
+$code-operator-color:         #E05C4C;
+$code-string-color:           #68F3CA;
+$code-type-color:             #E04C86;
+$code-scalar-color:           #EED891;
+$code-array-color:            #EED891;
+$code-hash-color:             #EED891;
+$code-pod-text-color:         #E04C86;
+$code-pod-markup-color:       #EED891;
+$code-string-delimiter-color: #E05C4C;
+$code-escape-color:           #E05C4C;
+$code-regex-special-color:    #6295E3;
+$code-regex-literal-color:    #6C7292;
+$code-regex-delimiter-color:  #E05C4C;
+
+// Fix selection background
+textarea::-moz-selection { background: $code-background; }
+textarea::selection { background: $code-background; }
+
+@import '_rainbow-main.scss';

--- a/Website/plugins/rainbow/scss/rainbow-light.scss
+++ b/Website/plugins/rainbow/scss/rainbow-light.scss
@@ -1,0 +1,35 @@
+/* Basic code colors */
+@import '_themes-colors.scss';
+$border: $grey;
+$shadow-below: 0 2px 3px 0 rgba( 0, 0, 0, 0.07 );
+$heading: $red;
+$code-background: #fafafa;
+$code-foreground: #030303;
+
+// Text colors
+$text: $black;
+$text-invert: $white-bis;
+$text-light: lighten($text, 10);
+$text-dark: darken($text, 10);
+$text-strong: darken($text, 5);
+
+$code-code-color:             #005C43;
+$code-routine-color:          #005C43;
+$code-comment-color:          #6D4F4B;
+$code-keyword-color:          #223B9E;
+$code-number-color:           #1C6301;
+$code-operator-color:         #C01823;
+$code-string-color:           #004FB3;
+$code-type-color:             #A3004F;
+$code-scalar-color:           #5503B3;
+$code-array-color:            #5503B3;
+$code-hash-color:             #5503B3;
+$code-pod-text-color:         #A3004F;
+$code-pod-markup-color:       #5503B3;
+$code-string-delimiter-color: #C01823;
+$code-escape-color:           #C01823;
+$code-regex-special-color:    #1C6301;
+$code-regex-literal-color:    #6C7292;
+$code-regex-delimiter-color:  #C01823;
+
+@import '_rainbow-main.scss';

--- a/Website/plugins/rainbow/t/05-basic.rakutest
+++ b/Website/plugins/rainbow/t/05-basic.rakutest
@@ -1,0 +1,5 @@
+use v6.d;
+use Test;
+use Test::CollectionPlugin;
+test-plugin();
+done-testing

--- a/Website/plugins/rainbow/template.raku
+++ b/Website/plugins/rainbow/template.raku
@@ -1,0 +1,97 @@
+use v6.d;
+use Rainbow;
+
+my %hilight-langs = %(
+    'HTML' => 'xml',
+    'XML' => 'xml',
+    'BASH' => 'bash',
+    'C++' => 'cpp',
+    'C#' => 'csharp',
+    'SCSS' => 'css',
+    'SASS' => 'css',
+    'CSS' => 'css',
+    'MARKDOWN' => 'markdown',
+    'DIFF' => 'diff',
+    'RUBY' => 'ruby',
+    'GO' => 'go',
+    'TOML' => 'ini',
+    'INI' => 'ini',
+    'JAVA' => 'java',
+    'JAVASCRIPT' => 'javascript',
+    'JSON' => 'json',
+    'KOTLIN' => 'kotlin',
+    'LESS' => 'less',
+    'LUA' => 'lua',
+    'MAKEFILE' => 'makefile',
+    'PERL' => 'perl',
+    'OBJECTIVE-C' => 'objectivec',
+    'PHP' => 'php',
+    'PHP-TEMPLATE' => 'php-template',
+    'PHPTEMPLATE' => 'php-template',
+    'PHP_TEMPLATE' => 'php-template',
+    'PYTHON' => 'python',
+    'PYTHON-REPL' => 'python-repl',
+    'PYTHON_REPL' => 'python-repl',
+    'R' => 'r',
+    'RUST' => 'rust',
+    'SCSS' => 'scss',
+    'SHELL' => 'shell',
+    'SQL' => 'sql',
+    'SWIFT' => 'swift',
+    'YAML' => 'yaml',
+    'TYPESCRIPT' => 'typescript',
+    'BASIC' => 'vbnet',
+    '.NET' => 'vbnet',
+    'HASKELL' => 'haskell',
+);
+
+# Callable returns a hash
+%(
+    block-code => sub (%prm, %tml) {
+        # if :lang is set != raku / rakudoc, then enable highlightjs
+        # otherwise pass through Raku syntax highlighter.
+        my $code;
+        my $syntax-label;
+        if %prm<lang>:exists {
+            if %prm<lang>.uc ~~ any( %hilight-langs.keys ) {
+                $syntax-label = %prm<lang>.tc ~  ' highlighting by highlight-js';
+                $code = qq:to/HILIGHT/;
+                    <pre class="browser-hl">
+                    <code class="language-{ %hilight-langs{ %prm<lang>.uc } }">{ %tml<escaped>(%prm<contents>) }
+                    </code></pre>
+                    HILIGHT
+            }
+            elsif %prm<lang> ~~ any( <Raku Rakudoc raku rakudoc> ) {
+                $syntax-label = %prm<lang>.tc ~ ' highlighting';
+            }
+            else {
+                $syntax-label = "｢{ %prm<lang> }｣ without highlighting";
+                $code = qq:to/NOHIGHS/;
+                    <pre class="nohighlights">
+                    { %tml<escaped>( %prm<contents> ) }
+                    </pre>
+                    NOHIGHS
+            }
+        }
+        else {
+            $syntax-label = 'Raku highlighting';
+        }
+        without $code {
+            $code = Rainbow::tokenize(%prm<contents>).map( -> $t {
+                if $t.type.key ne 'TEXT' {
+                    qq[<span class="highlite-{$t.type.key}">{%tml<escaped>($t.text)}</span>]
+                }
+                else { %tml<escaped>($t.text) }
+            }).join;
+        }
+        qq[
+            <div class="raku-code raku-lang">
+                <button class="copy-code" title="Copy code"><i class="far fa-clipboard"></i></button>
+                <label>$syntax-label\</label>
+                <div>
+                    <pre class="nohighlights">$code\</pre>
+                </div>
+            </div>
+        ]
+    },
+)


### PR DESCRIPTION
@coke @dontlaugh This new plugin uses @patrickbkr 's very new entirely Raku syntax highlighter (Rainbow).
1. The plugin removes the dependency on the atom-highlighter, which was written originally in coffeescript. 
2. In turn, the removal of atom-highlighter removes entirely the dependency on npm and a large number of other javascript dependency in a webpack. This is a major simplification for anyone wanting to install doc-website, but who does not have npm (or equivalent).
3. Rainbow offers more categories for coloration than the atom-highlighter:
  - instead of variable, we now have scalar, array & hash
  - three regex categories, where none existed before
  - two pod (rakudoc) categories
  - several delimiters
  For the time being I have not differentiated between the variables and delimiters, and kept the colours used by atom-highlighter.
4. To change the colours, there is a list of variables in rainbow-dark.scss and rainbow-dark.scss ($code-xxx-color). Change the color definition. These are then interpolated into the appropriate classes.

Note that if the new highlighter does not work, then the previous highlighter can be re-enabled by swapping 'highliter' for 'rainbow' in the plugin config file.