### PR TITLE
Serving robots.txt: match on prod host header

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -7,7 +7,7 @@
     }
 
     @prod {
-        expression {env.PROD} == "true"
+        host docs.raku.org
     }
 
     handle @prod {


### PR DESCRIPTION
We were relying on a server-side env var, but I think we
can just match on a host header instead.

On prod, don't serve /robots.txt

Otherwise, dev deployments serve a file that should prevent
search engine indexing.
