### PR TITLE
Doc site template cleanup

### DIFF
--- a/New_Website/META6.json
+++ b/New_Website/META6.json
@@ -8,7 +8,7 @@
     ],
     "auth": "zef:finanalyst",
     "depends": [
-        "Rakuast::RakuDoc::Render:ver<0.26.2+>",
+        "Rakuast::RakuDoc::Render:ver<0.26.3+>",
         "RakuConfig",
         "PrettyDump",
         "File::Directory::Tree",

--- a/New_Website/META6.json
+++ b/New_Website/META6.json
@@ -1,14 +1,14 @@
 {
     "name": "Elucid8::Doc-Website",
     "description": "Renders Raku documentation sources to web site",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "raku": "6.d",
     "authors": [
         "Richard Hainsworth"
     ],
     "auth": "zef:finanalyst",
     "depends": [
-        "Rakuast::RakuDoc::Render",
+        "Rakuast::RakuDoc::Render:ver<0.26.2+>",
         "RakuConfig",
         "PrettyDump",
         "File::Directory::Tree",

--- a/New_Website/local-lib/Raku-doc-website.rakumod
+++ b/New_Website/local-lib/Raku-doc-website.rakumod
@@ -67,16 +67,16 @@ method templates {
             <!DOCTYPE html>
             <html { $tmpl<html-root> } >
                 <head>
-                <meta charset="UTF-8" />
-                <meta name="viewport" content="width=device-width, initial-scale=1">
-                { $tmpl<head-block> }
-                { $tmpl<favicon> }
-            </head>
-            <body class="has-navbar-fixed-top">
-                { $tmpl<top-of-page> }
-                { $tmpl<main-content> }
-                { $tmpl<footer> }
-            </body>
+                    <meta charset="UTF-8" />
+                    <meta name="viewport" content="width=device-width, initial-scale=1">
+                    { $tmpl<head-block> }
+                    { $tmpl<favicon> }
+                </head>
+                <body class="has-navbar-fixed-top">
+                    { $tmpl<top-of-page> }
+                    { $tmpl<main-content> }
+                    { $tmpl<footer> }
+                </body>
             </html>
             PAGE
         },
@@ -133,9 +133,9 @@ method templates {
                  </figure>
                 { # remove TOC opener if direct-wrap exists and is true, or :!toc
                   (
-                  (%prm<source-data><rakudoc-config><direct-wrap>:exists && %prm<source-data><rakudoc-config><direct-wrap>)
+                  (%prm<source-data><rakudoc-config><direct-wrap><> =:= True)
                    ||
-                   (%prm<source-data><rakudoc-config><toc>:exists && %prm<source-data><rakudoc-config><toc>.not )
+                   (%prm<source-data><rakudoc-config><toc>.not)
                    )
                    ??
                     ''
@@ -207,8 +207,7 @@ method templates {
         },
         #| Toc/Index floats below navbar except for mobile
         page-navigation => -> %prm, $tmpl {
-           ( %prm<source-data><rakudoc-config><toc>:exists
-            && %prm<source-data><rakudoc-config><toc>.not )
+           ( %prm<source-data><rakudoc-config><toc>.not )
             ?? '' !!
             Q:c:to/PAGENAV/;
             <nav class="raku-webs panel is-hidden-mobile" id="page-nav">
@@ -354,11 +353,11 @@ method templates {
         'page-edit' => -> %,$ {''},
         #| the main section of body
         main-content => -> %prm, $tmpl {
-            if %prm<source-data><rakudoc-config><direct-wrap>:exists && %prm<source-data><rakudoc-config><direct-wrap>
+            if %prm<source-data><rakudoc-config><direct-wrap><> =:= True
             { # no extra styling if direct-wrap exists and is true
                %prm<body>
             }
-            elsif ( %prm<source-data><rakudoc-config><toc>:exists && %prm<source-data><rakudoc-config><toc>.not )
+            elsif ( %prm<source-data><rakudoc-config><toc>.not )
             {
                 qq:to/END/
                 { $tmpl<page-navigation> }


### PR DESCRIPTION
Rakuast::RakuDoc::Render was update to ensure that `:toc` and `:index` were always set to True if not explicitly set in a Rakudoc source.

This made some template logic easier.

This PR updates the Rakuast::RakuDoc::Render requirements and simplifies a bit of templates