### PR TITLE
Use a script to build and push.

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,32 +15,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Login to Quay.io
-      uses: docker/login-action@v2
-      with:
-        registry: quay.io
-        username: ${{ secrets.REGISTRY_RW_USERNAME }}
-        password: ${{ secrets.REGISTRY_RW_PASSWORD }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-
-    - name: Generate version tag
-      id: version
-      run: echo "TAG=v1-$(date +%Y%m%d)-${{ github.run_number }}" >> $GITHUB_OUTPUT
-
-    - name: Build Docker image
-      uses: docker/build-push-action@v4
-      with:
-        context: ./New_Website
-        file: ./New_Website/Dockerfile
-        # Only PUSH if it's a commit to main
-        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        tags: |
-          quay.io/chroot.club/raku-doc-website:latest
-          quay.io/chroot.club/raku-doc-website:${{ steps.version.outputs.TAG }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        build-args: |
-          quay_expiration=8w
+    - name: Build and push Docker container
+      env:
+        QUAY_USERNAME: ${{ secrets.REGISTRY_RW_USERNAME }}
+        QUAY_PASSWORD: ${{ secrets.REGISTRY_RW_PASSWORD }}
+      run: ./scripts/cibuild-new-site.sh
 

--- a/scripts/cibuild-new-site.sh
+++ b/scripts/cibuild-new-site.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+set -e
+
+# Exit if not running in GitHub Actions
+if [ -z "$GITHUB_ACTIONS" ]; then
+  echo "Not running in GitHub Actions, exiting"
+  exit 0
+fi
+
+cmd_container () {
+  tag_version="v1-$(date +%Y%m%d)-${GITHUB_RUN_NUMBER}"
+
+  # Only login to quay.io if we're going to push (on main branch)
+  if [ "$GITHUB_REF_NAME" = "main" ]; then
+    echo $QUAY_PASSWORD | docker login quay.io -u $QUAY_USERNAME --password-stdin
+  fi
+
+  full_tag="quay.io/chroot.club/raku-doc-website:${tag_version}"
+  docker build --build-arg quay_expiration="8w" -t $full_tag -f New_Website/Dockerfile New_Website/
+
+  # Also tag as "latest"
+  latest_tag="quay.io/chroot.club/raku-doc-website:latest"
+  docker tag $full_tag $latest_tag
+
+  # Only push if on main branch
+  if [ "$GITHUB_REF_NAME" = "main" ]; then
+    echo "Pushing container images (branch: $GITHUB_REF_NAME)"
+    docker push $full_tag
+    docker push $latest_tag
+  else
+    echo "Skipping push (branch: $GITHUB_REF_NAME, only pushing from main)"
+  fi
+}
+
+if [ -z $1 ]; then
+  cmd_container
+fi
+
+CMD=$1
+shift
+case $CMD in
+  container)
+    cmd_$CMD $@
+    ;;
+  *)
+    echo "unknown command $CMD"
+    exit 1
+    ;;
+esac
+


### PR DESCRIPTION
The GitHub Actions yaml wasn't applying the correct expiry labels. Use a script instead, like raku.org does. It seems more reliable than the action Docker maintains.
