### PR TITLE
Fix for #485

### DIFF
--- a/Website/plugins/filtered-toc/filtered-toc-template.raku
+++ b/Website/plugins/filtered-toc/filtered-toc-template.raku
@@ -67,7 +67,8 @@ use v6.d;
                     ~ '<a href="#'
                     ~ (%tml<escaped>.(%el.<target>) )
                     ~ '">'
-                    ~ (%el.<text> // '')
+                    ~
+                    ~ %tml<escaped>.(%el.<text> // '')
                     ~ '</a></li>';
             }
             $rv ~= "\n</ul>\n";


### PR DESCRIPTION
@coke The fix here is to pass the text through an HTML escape routine. It was an error not to HTML escape the text when I developed the Filtering ToC