### PR TITLE
Remove trailing for issue 475

### DIFF
--- a/Website/plugins/rainbow/template.raku
+++ b/Website/plugins/rainbow/template.raku
@@ -76,19 +76,19 @@ my %hilight-langs = %(
             $syntax-label = 'Raku highlighting';
         }
         without $code {
-            $code = Rainbow::tokenize(%prm<contents>).map( -> $t {
+            $code = '<pre class="nohighlights">' ~ Rainbow::tokenize(%prm<contents>).map( -> $t {
                 if $t.type.key ne 'TEXT' {
                     qq[<span class="highlite-{$t.type.key}">{%tml<escaped>($t.text)}</span>]
                 }
                 else { %tml<escaped>($t.text) }
-            }).join;
+            }).join ~ '</pre>';
         }
         qq[
             <div class="raku-code raku-lang">
                 <button class="copy-code" title="Copy code"><i class="far fa-clipboard"></i></button>
                 <label>$syntax-label\</label>
                 <div>
-                    <pre class="nohighlights">$code\</pre>
+                    $code
                 </div>
             </div>
         ]

--- a/Website/plugins/rainbow/template.raku
+++ b/Website/plugins/rainbow/template.raku
@@ -57,8 +57,7 @@ my %hilight-langs = %(
                 $syntax-label = %prm<lang>.tc ~  ' highlighting by highlight-js';
                 $code = qq:to/HILIGHT/;
                     <pre class="browser-hl">
-                    <code class="language-{ %hilight-langs{ %prm<lang>.uc } }">{ %tml<escaped>(%prm<contents>) }
-                    </code></pre>
+                    <code class="language-{ %hilight-langs{ %prm<lang>.uc } }">{ %tml<escaped>(%prm<contents>) }</code></pre>
                     HILIGHT
             }
             elsif %prm<lang> ~~ any( <Raku Rakudoc raku rakudoc> ) {


### PR DESCRIPTION
@coke or @dontlaugh a third attempt to deal with #475 
This patch removes the duplicate `<pre` tag for non-Rainbow Raku code.

It is possible that the CSS for the pre used by highlight-js may need tweaking. Lets see how it looks first