### PR TITLE
Restore ebook

### DIFF
--- a/Website/Dockerfile
+++ b/Website/Dockerfile
@@ -1,4 +1,5 @@
 FROM docker.io/finanalyst/raku-cro-rrr-base AS builder
+RUN apk add --no-cache zip
 
 WORKDIR /build
 COPY . .
@@ -6,6 +7,7 @@ COPY . .
 # Install dependencies and build site
 RUN POD_RENDER_NO_HIGHLIGHTER=1 zef install . --deps-only -/test
 RUN ./bin_files/build-site --without-completion --no-status
+RUN ./bin_files/build-site --no-status EBook
 
 FROM docker.io/caddy:latest AS server
 

--- a/Website/structure-sources/index.rakudoc
+++ b/Website/structure-sources/index.rakudoc
@@ -218,7 +218,7 @@
                 <ul>
                   <li><a href="https://raku.guide/">The Raku Guide</a></li>
                   <li><a href="https://perl6book.com/">Books</a></li>
-                  <li><a href="https://www.raku.org/community/rosettacode">Rosetta Code</a></li>
+                  <li><a href="https://raku.org/learn">Rosetta Code</a></li>
                 </ul>
               </div>
               <div class="column">


### PR DESCRIPTION
This should fix #490 
- zip is added to the Alpine image
- The Ebook is rengenerated, and is moved to the rendered_html directory.
