### PR TITLE
Use new docker image

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "name": "Raku-Official-Documentation",
     "description": "Tool chain for creating the Raku official documentation site",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "authors": [
         "Richard Hainsworth, aka finanalyst"
     ],

--- a/Website/Dockerfile
+++ b/Website/Dockerfile
@@ -1,11 +1,11 @@
-FROM docker.io/finanalyst/raku-cro-rrr-base AS builder
+FROM docker.io/finanalyst/raku-doc-website-base AS builder
 
 WORKDIR /build
 COPY . .
 
 # Install dependencies and build site
-RUN POD_RENDER_NO_HIGHLIGHTER=1 zef install . --deps-only -/test
 RUN ./bin_files/build-site --without-completion --no-status
+RUN ./bin_files/build-site --no-status EBook
 
 FROM docker.io/caddy:latest AS server
 

--- a/Website/structure-sources/index.rakudoc
+++ b/Website/structure-sources/index.rakudoc
@@ -218,7 +218,7 @@
                 <ul>
                   <li><a href="https://raku.guide/">The Raku Guide</a></li>
                   <li><a href="https://perl6book.com/">Books</a></li>
-                  <li><a href="https://www.raku.org/community/rosettacode">Rosetta Code</a></li>
+                  <li><a href="https://raku.org/learn">Rosetta Code</a></li>
                 </ul>
               </div>
               <div class="column">


### PR DESCRIPTION
@dontlaugh all the installation steps are moved to a new docker image `docker.io/finanalyst/raku-doc-website-base`

So the time taken to build should only be for building rakudoc sources. 
- problem: generating svg from dot files happens at build time, and is very long.
- Both Website and EBook generate these files separately

The sources for the Dockerfiles can be found at [docker base](https://github.org/finanalyst/raku-container-base)
